### PR TITLE
feat: LAPRAS 3.5+を狙う月次自律記事ファクトリ

### DIFF
--- a/.github/workflows/article-factory-ci.yml
+++ b/.github/workflows/article-factory-ci.yml
@@ -1,0 +1,36 @@
+name: Article Factory CI
+
+on:
+  pull_request:
+    paths:
+      - "article_factory/**"
+      - ".github/workflows/monthly-article.yml"
+      - ".github/workflows/article-factory-ci.yml"
+      - "articles/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Compile Python
+        run: python -m py_compile article_factory/run.py
+      - name: Validate config
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          c = json.loads(Path('article_factory/config.json').read_text(encoding='utf-8'))
+          gate = c['quality_gate']
+          assert gate['target_overall'] >= 4.0
+          assert gate['minimum_overall'] >= 3.5
+          assert gate['minimum_axis'] >= 3.5
+          assert gate['minimum_primary_sources'] >= 3
+          assert gate['minimum_own_github_evidence'] >= 2
+          PY

--- a/.github/workflows/monthly-article.yml
+++ b/.github/workflows/monthly-article.yml
@@ -1,0 +1,84 @@
+name: Monthly LAPRAS Article Factory
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: candidate or publish
+        required: true
+        default: candidate
+        type: choice
+        options:
+          - candidate
+          - publish
+  schedule:
+    # Weekly candidate generation: Monday 09:00 JST.
+    - cron: "0 0 * * 1"
+    # Monthly finalization retries: 25th, 27th, 29th at 09:30 JST.
+    - cron: "30 0 25,27,29 * *"
+
+permissions:
+  contents: write
+  models: read
+
+concurrency:
+  group: monthly-lapras-article-factory
+  cancel-in-progress: false
+
+jobs:
+  build-article:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.schedule }}" == "0 0 * * 1" ]]; then
+            echo "mode=candidate" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=publish" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate or publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTICLE_MODE: ${{ steps.mode.outputs.mode }}
+          ARTICLE_MODEL: openai/gpt-4.1
+        run: python article_factory/run.py
+
+      - name: Validate generated Zenn files
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+          for p in Path('articles').glob('*.md') if Path('articles').exists() else []:
+              text = p.read_text(encoding='utf-8')
+              assert text.startswith('---\n'), p
+              if 'published: true' in text:
+                  assert re.search(r'^published_at: \d{4}-\d{2}-\d{2}', text, re.M), p
+          PY
+
+      - name: Commit factory output
+        shell: bash
+        run: |
+          if git diff --quiet && [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes"
+            exit 0
+          fi
+          git config user.name "article-factory[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add candidates articles reports 2>/dev/null || true
+          git commit -m "content: ${{ steps.mode.outputs.mode }} monthly technical article"
+          git push

--- a/ARTICLE_FACTORY.md
+++ b/ARTICLE_FACTORY.md
@@ -1,0 +1,59 @@
+# Autonomous Monthly Article Factory
+
+## Objective
+
+毎月1本以上、LAPRAS AI Reviewで3.5以上を狙える最高品質の技術記事を公開する。
+
+量産ではなく、週次で候補を作り、月次で最良候補だけを公開する。
+
+## Pipeline
+
+1. 毎週月曜 09:00 JST に公開GitHub活動を収集する。
+2. 直近のrepo、commit、設計テーマから5候補を作る。
+3. 既存記事との重複を避け、実装証拠が最も強いテーマを1件選ぶ。
+4. 記事を生成し `candidates/` に保存する。
+5. 毎月25日・27日・29日に候補を比較し、最良1件を選ぶ。
+6. LAPRAS公式の5軸（論理性・実用性・読みやすさ・独自性・明確性）を3回独立査読し、中央値で判定する。
+7. 一次情報URLを実HTTP取得し、KAFKA2306 GitHub一次証拠2件以上、外部公式一次情報1件以上を必須にする。
+8. 目標4.1、最低overall 3.8、各軸3.5以上を満たさなければ最大3回自動改稿する。
+9. 合格した1本だけ `articles/*.md` にZenn front matter付きで書き出し、`published: true` にする。
+10. 査読値と一次情報検証結果を `reports/*.json` に保存する。
+
+## Why the gate is stricter than 3.5
+
+LAPRASの実AI Reviewは公開後のクロールで初めて確定するため、GitHub Actions内では同一値を事前取得できない。そのため内部評価を安全側に寄せ、3.5を直接目標にせず4.1を目標、3.8を最低公開基準とする。
+
+## GitHub Models
+
+GitHub Actionsでは `GITHUB_TOKEN` と `permissions: models: read` を使い、GitHub Modelsの推論APIを利用する。追加APIキーを必須にしない。
+
+既定モデルは `openai/gpt-4.1`。変更する場合はworkflowの `ARTICLE_MODEL` を更新する。
+
+## Zenn connection
+
+Zennへの自動公開には、Zenn側でこのGitHub repositoryをアカウント連携repoとして一度だけ接続し、同期ブランチを `main` に設定する必要がある。
+
+Zenn公式仕様では、連携済みrepoの同期対象branchにpushすると自動デプロイされ、`articles/*.md` の `published: true` が公開対象になる。
+
+この外部OAuth/GitHub App承認だけはGitHub repository内のコードから代行できない。接続後は月次候補生成・選抜・改稿・公開まで自動化される。
+
+## Repository outputs
+
+- `article_factory/config.json` — 品質ゲートとモデル設定
+- `article_factory/prompt.md` — 執筆・査読契約
+- `article_factory/run.py` — 生成・査読・一次情報検証・公開処理
+- `candidates/` — 非公開候補
+- `articles/` — Zenn同期対象の公開記事
+- `reports/` — 月次品質証跡
+- `.github/workflows/monthly-article.yml` — 定期実行
+- `.github/workflows/article-factory-ci.yml` — 構文・設定CI
+
+## Failure policy
+
+- 一次情報URLが不足・404・許可外host → 公開しない
+- KAFKA2306 GitHub一次証拠が2件未満 → 公開しない
+- overall 3.8未満 → 改稿、最終的に失敗なら公開しない
+- いずれかの評価軸が3.5未満 → 改稿、最終的に失敗なら公開しない
+- 同月に既に1本公開済み → 重複公開しない
+
+「月1本」を守るため25日だけでなく27日・29日にも再試行するが、品質ゲートを下げて本数だけ満たすことはしない。

--- a/article_factory/config.json
+++ b/article_factory/config.json
@@ -1,0 +1,40 @@
+{
+  "owner": "KAFKA2306",
+  "model": "openai/gpt-4.1",
+  "candidate_count": 5,
+  "revision_limit": 3,
+  "quality_gate": {
+    "target_overall": 4.1,
+    "minimum_overall": 3.8,
+    "minimum_axis": 3.5,
+    "minimum_primary_sources": 3,
+    "minimum_own_github_evidence": 2
+  },
+  "lapras_axes": [
+    "論理性",
+    "実用性",
+    "読みやすさ",
+    "独自性",
+    "明確性"
+  ],
+  "preferred_topics": [
+    "backend",
+    "infrastructure",
+    "product-engineering",
+    "technical-leadership",
+    "data-engineering",
+    "ai-agents"
+  ],
+  "allowed_primary_source_hosts": [
+    "github.com",
+    "docs.github.com",
+    "docs.python.org",
+    "docs.astral.sh",
+    "docs.docker.com",
+    "kubernetes.io",
+    "developer.mozilla.org",
+    "openai.com",
+    "platform.openai.com",
+    "zenn.dev"
+  ]
+}

--- a/article_factory/prompt.md
+++ b/article_factory/prompt.md
@@ -1,0 +1,61 @@
+# Monthly Article Factory Prompt
+
+## Goal
+
+毎月1本以上、LAPRAS AI Reviewで3.5以上を狙える技術記事を自律生成する。量ではなく、公開可能な最高品質の1本を選ぶ。
+
+## Official LAPRAS rubric
+
+記事を以下の5軸で0.0〜5.0評価する。
+
+- 論理性
+- 実用性
+- 読みやすさ
+- 独自性
+- 明確性
+
+内部ゲートでは平均4.1を目標、3.8未満は公開しない。各軸3.5未満も公開しない。
+
+## Article contract
+
+1. 冒頭で「誰の、どの問題を、この記事でどう解決するか」を3文以内で明示する。
+2. 一般論ではなく、KAFKA2306の実装・設計判断・失敗・改善結果を中心にする。
+3. 少なくとも2件のKAFKA2306 GitHub上の一次証拠（commit / PR / file / workflow等）を含める。
+4. 外部仕様・数値・挙動は一次情報URLで裏付ける。一次情報を確認できない主張は削除する。
+5. 数値には対象、期間、単位、比較基準を付ける。
+6. コードを載せる場合は、なぜその設計にしたか、代替案、失敗条件、検証方法まで書く。
+7. 「やってみた」「便利だった」で終わらず、再現可能な手順・判断基準・検証結果を残す。
+8. 読者がそのまま使えるチェックリスト、最小実装、検証コマンドのいずれかを必ず含める。
+9. 最後に「適用範囲」「限界」「次に検証すべきこと」を明示する。
+10. 誇張表現、根拠のない最上級、未検証の性能主張は禁止する。
+
+## Topic selection priority
+
+優先順位は以下。
+
+1. backend / infrastructure の実装証拠
+2. product engineering の成果とユーザー導線
+3. technical leadership / architecture decision
+4. data engineering / AI agent reliability
+5. その他、直近30〜45日の公開GitHub活動から強い一次証拠があるテーマ
+
+同じ主題の焼き直しは避ける。既存記事より新規性が低い候補は棄却する。
+
+## Evaluation output
+
+評価器はJSONのみを返す。
+
+```json
+{
+  "logic": 0.0,
+  "utility": 0.0,
+  "readability": 0.0,
+  "originality": 0.0,
+  "clarity": 0.0,
+  "overall": 0.0,
+  "blocking_issues": [],
+  "revision_actions": []
+}
+```
+
+overallは5軸の算術平均とする。

--- a/article_factory/run.py
+++ b/article_factory/run.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = json.loads((ROOT / "article_factory" / "config.json").read_text(encoding="utf-8"))
+PROMPT = (ROOT / "article_factory" / "prompt.md").read_text(encoding="utf-8")
+JST = timezone(timedelta(hours=9))
+NOW = datetime.now(JST)
+MODEL_ENDPOINT = "https://models.github.ai/inference/chat/completions"
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+MODEL = os.environ.get("ARTICLE_MODEL", CONFIG["model"])
+MODE = os.environ.get("ARTICLE_MODE", "candidate")
+
+
+def http_json(url: str, *, headers: dict[str, str] | None = None) -> object:
+    req = urllib.request.Request(url, headers=headers or {"User-Agent": "KAFKA2306-article-factory/1.0"})
+    with urllib.request.urlopen(req, timeout=20) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def model_call(system: str, user: str, *, temperature: float = 0.2, json_mode: bool = False) -> str:
+    if not TOKEN:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    payload: dict[str, object] = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "temperature": temperature,
+    }
+    if json_mode:
+        payload["response_format"] = {"type": "json_object"}
+    req = urllib.request.Request(
+        MODEL_ENDPOINT,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {TOKEN}",
+            "Content-Type": "application/json",
+            "User-Agent": "KAFKA2306-article-factory/1.0",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    return data["choices"][0]["message"]["content"].strip()
+
+
+def collect_public_github_signals(owner: str) -> list[dict[str, object]]:
+    repos = http_json(
+        f"https://api.github.com/users/{urllib.parse.quote(owner)}/repos?sort=pushed&direction=desc&per_page=12"
+    )
+    signals: list[dict[str, object]] = []
+    if not isinstance(repos, list):
+        return signals
+    for repo in repos[:8]:
+        if not isinstance(repo, dict) or repo.get("fork"):
+            continue
+        name = str(repo.get("name", ""))
+        default_branch = str(repo.get("default_branch", "main"))
+        signal: dict[str, object] = {
+            "repo": repo.get("html_url"),
+            "name": name,
+            "description": repo.get("description"),
+            "language": repo.get("language"),
+            "pushed_at": repo.get("pushed_at"),
+            "stars": repo.get("stargazers_count"),
+        }
+        try:
+            commits = http_json(
+                f"https://api.github.com/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(name)}/commits?sha={urllib.parse.quote(default_branch)}&per_page=1"
+            )
+            if isinstance(commits, list) and commits:
+                latest = commits[0]
+                commit = latest.get("commit", {}) if isinstance(latest, dict) else {}
+                message = commit.get("message") if isinstance(commit, dict) else None
+                signal["latest_commit"] = latest.get("html_url") if isinstance(latest, dict) else None
+                signal["latest_commit_message"] = message
+        except Exception as exc:
+            signal["commit_fetch_error"] = type(exc).__name__
+        signals.append(signal)
+    return signals
+
+
+def existing_titles() -> list[str]:
+    titles: list[str] = []
+    for base in (ROOT / "articles", ROOT / "candidates"):
+        if not base.exists():
+            continue
+        for path in base.glob("*.md"):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            match = re.search(r"^#\s+(.+)$", text, flags=re.MULTILINE)
+            if match:
+                titles.append(match.group(1).strip())
+            else:
+                fm = re.search(r'^title:\s*["\']?(.+?)["\']?\s*$', text, flags=re.MULTILINE)
+                if fm:
+                    titles.append(fm.group(1).strip())
+    return titles[-40:]
+
+
+def choose_topic(signals: list[dict[str, object]]) -> dict[str, object]:
+    user = f"""
+直近の公開GitHubシグナルから技術記事候補を{CONFIG['candidate_count']}件作り、最も強い1件を選んでください。
+一般論より、実装証拠・設計判断・失敗・定量検証が揃う題材を優先します。
+弱点補強の優先順: backend, infrastructure, product-engineering, technical-leadership, data-engineering, ai-agents。
+既存タイトルとの焼き直しは禁止です。
+
+既存タイトル:
+{json.dumps(existing_titles(), ensure_ascii=False)}
+
+GitHubシグナル:
+{json.dumps(signals, ensure_ascii=False, indent=2)}
+
+JSONのみ返してください。形式:
+{{"selected":{{"title":"...","audience":"...","problem":"...","evidence_urls":["..."],"why_unique":"..."}},"alternatives":[...]}}
+"""
+    return json.loads(model_call("あなたは技術編集長です。証拠の弱いテーマは選びません。", user, json_mode=True))
+
+
+def draft_article(topic: dict[str, object], signals: list[dict[str, object]]) -> str:
+    user = f"""
+以下の契約に従って日本語の完成記事を書いてください。Markdown本文のみ。front matterは不要です。
+
+{PROMPT}
+
+選定テーマ:
+{json.dumps(topic, ensure_ascii=False, indent=2)}
+
+利用可能な一次証拠:
+{json.dumps(signals, ensure_ascii=False, indent=2)}
+
+重要:
+- GitHub上で確認できない実装事実を創作しない。
+- 外部仕様を断定する場合は公式一次情報URLを本文の直後に付ける。
+- URLを確信できない場合、その外部仕様自体を削除する。
+- 最後に「一次情報・再現証拠」節を設け、本文で実際に使ったURLだけを列挙する。
+- 最低でもKAFKA2306 GitHub URLを2件、外部の公式一次情報を1件含める。
+"""
+    return model_call("あなたは一次証拠を最優先するシニア技術ライターです。", user, temperature=0.25)
+
+
+URL_RE = re.compile(r"https://[^\s)\]>\"']+")
+
+
+def verify_url(url: str) -> bool:
+    try:
+        parsed = urllib.parse.urlparse(url)
+        host = parsed.netloc.lower()
+        if host not in set(CONFIG["allowed_primary_source_hosts"]):
+            return False
+        if host == "zenn.dev" and not parsed.path.startswith("/zenn/articles/"):
+            return False
+        req = urllib.request.Request(url, headers={"User-Agent": "KAFKA2306-article-factory/1.0"})
+        with urllib.request.urlopen(req, timeout=15) as response:
+            response.read(512)
+            return 200 <= int(response.status) < 400
+    except Exception:
+        return False
+
+
+def source_gate(article: str) -> tuple[bool, dict[str, object]]:
+    urls = sorted(set(URL_RE.findall(article)))
+    valid = [url for url in urls if verify_url(url)]
+    own = [url for url in valid if url.startswith("https://github.com/KAFKA2306/")]
+    external = [url for url in valid if url not in own]
+    gate = CONFIG["quality_gate"]
+    ok = len(valid) >= gate["minimum_primary_sources"] and len(own) >= gate["minimum_own_github_evidence"] and len(external) >= 1
+    return ok, {"all_urls": urls, "valid_urls": valid, "own_github": own, "external_primary": external}
+
+
+def evaluate(article: str) -> dict[str, object]:
+    user = f"""
+LAPRAS AI Reviewの5軸に合わせてこの記事を厳格に評価してください。
+0.0〜5.0。overallは5軸の算術平均。甘く採点しないでください。
+
+{PROMPT}
+
+ARTICLE:
+{article}
+
+JSONのみ返してください。
+"""
+    result = json.loads(model_call("あなたは独立した技術記事査読者です。", user, temperature=0.0, json_mode=True))
+    axes = ["logic", "utility", "readability", "originality", "clarity"]
+    values = [float(result.get(key, 0.0)) for key in axes]
+    result["overall"] = round(sum(values) / len(values), 3)
+    return result
+
+
+def aggregate_evaluations(article: str, rounds: int = 3) -> dict[str, object]:
+    reviews = [evaluate(article) for _ in range(rounds)]
+    axes = ["logic", "utility", "readability", "originality", "clarity", "overall"]
+    aggregate: dict[str, object] = {"reviews": reviews}
+    for key in axes:
+        values = sorted(float(review.get(key, 0.0)) for review in reviews)
+        aggregate[key] = values[len(values) // 2]
+    aggregate["blocking_issues"] = list(dict.fromkeys(
+        issue for review in reviews for issue in review.get("blocking_issues", []) if isinstance(issue, str)
+    ))
+    aggregate["revision_actions"] = list(dict.fromkeys(
+        action for review in reviews for action in review.get("revision_actions", []) if isinstance(action, str)
+    ))
+    return aggregate
+
+
+def passes_quality(review: dict[str, object], sources_ok: bool) -> bool:
+    gate = CONFIG["quality_gate"]
+    axis_keys = ["logic", "utility", "readability", "originality", "clarity"]
+    return bool(
+        sources_ok
+        and float(review["overall"]) >= gate["minimum_overall"]
+        and all(float(review[key]) >= gate["minimum_axis"] for key in axis_keys)
+    )
+
+
+def revise(article: str, review: dict[str, object], source_report: dict[str, object]) -> str:
+    user = f"""
+以下の記事を全面改稿してください。情報量を水増しせず、弱点を直接修正してください。
+Markdown本文のみ返してください。
+
+品質契約:
+{PROMPT}
+
+査読結果:
+{json.dumps(review, ensure_ascii=False, indent=2)}
+
+一次情報検証:
+{json.dumps(source_report, ensure_ascii=False, indent=2)}
+
+ARTICLE:
+{article}
+
+特に、存在確認できないURL・断定・数値は削除し、GitHub一次証拠と再現手順を厚くしてください。
+"""
+    return model_call("あなたは査読指摘を潰すリビジョン担当です。", user, temperature=0.15)
+
+
+def article_title(article: str) -> str:
+    match = re.search(r"^#\s+(.+)$", article, flags=re.MULTILINE)
+    return match.group(1).strip() if match else f"Monthly Engineering Note {NOW:%Y-%m}"
+
+
+def slug_for(article: str) -> str:
+    digest = hashlib.sha256(article.encode("utf-8")).hexdigest()[:8]
+    return f"engineering-evidence-{NOW:%Y-%m}-{digest}"
+
+
+def save_candidate(article: str, meta: dict[str, object]) -> Path:
+    out = ROOT / "candidates"
+    out.mkdir(parents=True, exist_ok=True)
+    slug = slug_for(article)
+    path = out / f"{NOW:%Y-%m-%d}-{slug}.md"
+    header = f"<!-- factory_meta: {json.dumps(meta, ensure_ascii=False)} -->\n\n"
+    path.write_text(header + article.rstrip() + "\n", encoding="utf-8")
+    return path
+
+
+def published_this_month() -> bool:
+    base = ROOT / "articles"
+    if not base.exists():
+        return False
+    needle = f"published_at: {NOW:%Y-%m}"
+    return any(needle in path.read_text(encoding="utf-8", errors="ignore") for path in base.glob("*.md"))
+
+
+def candidate_files_this_month() -> list[Path]:
+    base = ROOT / "candidates"
+    if not base.exists():
+        return []
+    return sorted(base.glob(f"{NOW:%Y-%m}-*.md"))
+
+
+def choose_best_candidate(paths: list[Path]) -> str:
+    if len(paths) == 1:
+        return paths[0].read_text(encoding="utf-8")
+    corpus = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        corpus.append({"path": path.name, "title": article_title(text), "excerpt": text[:3500]})
+    result = json.loads(model_call(
+        "あなたは月次の技術編集長です。独自性・実用性・一次証拠密度が最も高い1本を選びます。",
+        "次の候補から最高品質の1本を選び、JSONで {\"path\":\"...\"} のみ返してください。\n" + json.dumps(corpus, ensure_ascii=False),
+        temperature=0.0,
+        json_mode=True,
+    ))
+    selected = str(result.get("path", ""))
+    for path in paths:
+        if path.name == selected:
+            return path.read_text(encoding="utf-8")
+    return paths[0].read_text(encoding="utf-8")
+
+
+def publish(article: str, review: dict[str, object], source_report: dict[str, object]) -> Path:
+    out = ROOT / "articles"
+    out.mkdir(parents=True, exist_ok=True)
+    slug = slug_for(article)
+    title = article_title(article).replace('"', "'")
+    body = re.sub(r"^#\s+.+?\n", "", article, count=1, flags=re.MULTILINE).lstrip()
+    frontmatter = (
+        "---\n"
+        f'title: "{title}"\n'
+        'emoji: "🧭"\n'
+        'type: "tech"\n'
+        'topics: ["python", "github", "architecture", "ai"]\n'
+        "published: true\n"
+        f"published_at: {NOW:%Y-%m-%d %H:%M}\n"
+        "---\n\n"
+    )
+    path = out / f"{slug}.md"
+    path.write_text(frontmatter + body.rstrip() + "\n", encoding="utf-8")
+    reports = ROOT / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    (reports / f"{NOW:%Y-%m}-{slug}.json").write_text(
+        json.dumps({"review": review, "sources": source_report, "published_path": str(path.relative_to(ROOT))}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def generate_fresh() -> tuple[str, dict[str, object]]:
+    signals = collect_public_github_signals(CONFIG["owner"])
+    topics = choose_topic(signals)
+    selected = topics.get("selected", topics)
+    article = draft_article(selected if isinstance(selected, dict) else topics, signals)
+    return article, {"topic_selection": topics, "signals": signals}
+
+
+def main() -> int:
+    if MODE == "candidate":
+        article, meta = generate_fresh()
+        sources_ok, source_report = source_gate(article)
+        review = aggregate_evaluations(article, rounds=1)
+        meta["initial_review"] = review
+        meta["initial_sources"] = source_report
+        path = save_candidate(article, meta)
+        print(f"candidate={path.relative_to(ROOT)} sources_ok={sources_ok} score={review['overall']}")
+        return 0
+
+    if MODE != "publish":
+        raise ValueError(f"Unknown ARTICLE_MODE={MODE}")
+    if published_this_month():
+        print("monthly article already published; no-op")
+        return 0
+
+    paths = candidate_files_this_month()
+    if paths:
+        article = choose_best_candidate(paths)
+    else:
+        article, _ = generate_fresh()
+
+    last_review: dict[str, object] = {}
+    last_sources: dict[str, object] = {}
+    for attempt in range(CONFIG["revision_limit"] + 1):
+        sources_ok, last_sources = source_gate(article)
+        last_review = aggregate_evaluations(article, rounds=3)
+        print(f"attempt={attempt} sources_ok={sources_ok} score={last_review['overall']}")
+        if passes_quality(last_review, sources_ok):
+            path = publish(article, last_review, last_sources)
+            print(f"published={path.relative_to(ROOT)}")
+            return 0
+        if attempt < CONFIG["revision_limit"]:
+            article = revise(article, last_review, last_sources)
+
+    print(json.dumps({"error": "quality_gate_failed", "review": last_review, "sources": last_sources}, ensure_ascii=False, indent=2))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 目的

LAPRAS AI Reviewで基本3.5以上を狙い、月次で最低1本の最高品質記事をGit管理・自律生成する。

## 実装

- GitHub Models + `GITHUB_TOKEN` で追加API key不要の生成
- 毎週候補生成、毎月25/27/29日に最良候補を再査読して公開
- LAPRAS公式5軸（論理性・実用性・読みやすさ・独自性・明確性）を3回査読し中央値採用
- 内部目標4.1 / overall最低3.8 / 各軸最低3.5
- 最大3回の自動改稿
- KAFKA2306 GitHub一次証拠2件以上 + 外部公式一次情報1件以上
- URL実取得によるsource gate
- Zenn互換 `articles/*.md` + `published: true`
- `reports/*.json` に査読・source証跡保存
- PR用CIでPython構文とgate設定を検証

## 運用境界

Zennへの最終自動同期には、Zenn側でこのrepoを一度だけGitHub連携し、同期branchをmainに設定する必要がある。連携後は候補生成→選抜→改稿→公開まで自律実行する。

## 関連

Issue #1 の一次情報・検証ゲート方針を新規月次記事パイプラインへ適用する。