### PR TITLE
feat: Graphiti記録をprivacy-safeな記事アイデア源へ接続

### DIFF
--- a/.github/workflows/article-factory-ci.yml
+++ b/.github/workflows/article-factory-ci.yml
@@ -20,8 +20,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile Python
-        run: python -m py_compile article_factory/run.py
-      - name: Validate config
+        run: |
+          python -m py_compile article_factory/run.py
+          python -m py_compile article_factory/graphiti_seed.py
+      - name: Validate config and privacy boundary
         run: |
           python - <<'PY'
           import json
@@ -33,4 +35,10 @@ jobs:
           assert gate['minimum_axis'] >= 3.5
           assert gate['minimum_primary_sources'] >= 3
           assert gate['minimum_own_github_evidence'] >= 2
+          seed = Path('article_factory/graphiti_seed.py').read_text(encoding='utf-8')
+          assert 'raw_private_content_persisted": False' in seed
+          assert 'privacy_check' in seed
+          assert 'GRAPHITI_READ_TOKEN' in seed
+          workflow = Path('.github/workflows/monthly-article.yml').read_text(encoding='utf-8')
+          assert 'secrets.GRAPHITI_READ_TOKEN' in workflow
           PY

--- a/.github/workflows/monthly-article.yml
+++ b/.github/workflows/monthly-article.yml
@@ -50,6 +50,15 @@ jobs:
             echo "mode=publish" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate Graphiti-seeded candidate
+        if: steps.mode.outputs.mode == 'candidate'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRAPHITI_READ_TOKEN: ${{ secrets.GRAPHITI_READ_TOKEN }}
+          GRAPHITI_REPO: KAFKA2306/graphiti
+          ARTICLE_MODEL: openai/gpt-4.1
+        run: python article_factory/graphiti_seed.py
+
       - name: Generate or publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ARTICLE_FACTORY.md
+++ b/ARTICLE_FACTORY.md
@@ -9,15 +9,39 @@
 ## Pipeline
 
 1. 毎週月曜 09:00 JST に公開GitHub活動を収集する。
-2. 直近のrepo、commit、設計テーマから5候補を作る。
-3. 既存記事との重複を避け、実装証拠が最も強いテーマを1件選ぶ。
-4. 記事を生成し `candidates/` に保存する。
-5. 毎月25日・27日・29日に候補を比較し、最良1件を選ぶ。
-6. LAPRAS公式の5軸（論理性・実用性・読みやすさ・独自性・明確性）を3回独立査読し、中央値で判定する。
-7. 一次情報URLを実HTTP取得し、KAFKA2306 GitHub一次証拠2件以上、外部公式一次情報1件以上を必須にする。
-8. 目標4.1、最低overall 3.8、各軸3.5以上を満たさなければ最大3回自動改稿する。
-9. 合格した1本だけ `articles/*.md` にZenn front matter付きで書き出し、`published: true` にする。
-10. 査読値と一次情報検証結果を `reports/*.json` に保存する。
+2. `GRAPHITI_READ_TOKEN` が設定済みなら、private `KAFKA2306/graphiti` の直近weekly diaryも実行時だけ読み、技術テーマ発見の補助入力にする。
+3. Graphiti由来テーマはprivate記録を根拠にせず、公開GitHub上で2件以上の実装証拠へ再接地できる場合だけ候補化する。
+4. 直近のrepo、commit、設計テーマから候補を作る。
+5. 既存記事との重複を避け、実装証拠が最も強いテーマを選び、`candidates/` に保存する。
+6. 毎月25日・27日・29日に候補を比較し、最良1件を選ぶ。
+7. LAPRAS公式の5軸（論理性・実用性・読みやすさ・独自性・明確性）を3回独立査読し、中央値で判定する。
+8. 一次情報URLを実HTTP取得し、KAFKA2306 GitHub一次証拠2件以上、外部公式一次情報1件以上を必須にする。
+9. 目標4.1、最低overall 3.8、各軸3.5以上を満たさなければ最大3回自動改稿する。
+10. 合格した1本だけ `articles/*.md` にZenn front matter付きで書き出し、`published: true` にする。
+11. 査読値と一次情報検証結果を `reports/*.json` に保存する。
+
+## Autonomous-loop boundary
+
+内側のループは自律化する。
+
+`Graphiti / public GitHub → topic discovery → public evidence grounding → draft → source gate → multi-review → revision → best-of-month selection → publish`
+
+LAPRASの実AI Review値は公開後にLAPRAS側で計算される外部評価であり、公式の取得APIが利用できることを前提にしない。このため、現行実装ではLAPRAS実測値そのものをGitHub Actionsへ自動帰還させるループは持たない。内部ゲートを4.1目標 / 3.8最低にして外部3.5割れを抑える。
+
+将来、LAPRASが公式APIまたは安全な機械取得経路を提供した場合のみ、実測値をcalibration feedbackとして接続する。非公式スクレイピングや認証cookie保存は採用しない。
+
+## Graphiti privacy boundary
+
+Graphiti記録は**アイデア源だけ**に使う。
+
+- private diary本文を記事へ引用しない。
+- private diary本文を `candidates/`、`articles/`、`reports/` へ保存しない。
+- 個人情報、税務、資産、健康、旅行、私生活、勤務先内部情報、未公開情報はテーマ化しない。
+- 技術テーマは必ずpublic GitHub evidenceへ再接地する。
+- Graphitiから取得した生テキストはworkflowプロセス内だけで使用し、Gitへstageしない。
+- public repoに残すmetadataは抽象化済みテーマ、record count、内容を復元できないdigest、公開証拠だけとする。
+
+`KAFKA2306/graphiti` は別repositoryなので、Actions標準の `GITHUB_TOKEN` ではなく、read-onlyのfine-grained credentialを `GRAPHITI_READ_TOKEN` secretとして一度だけ設定する。未設定時はGraphiti入力だけskipし、公開GitHub由来の通常候補生成は継続する。
 
 ## Why the gate is stricter than 3.5
 
@@ -42,11 +66,12 @@ Zenn公式仕様では、連携済みrepoの同期対象branchにpushすると�
 - `article_factory/config.json` — 品質ゲートとモデル設定
 - `article_factory/prompt.md` — 執筆・査読契約
 - `article_factory/run.py` — 生成・査読・一次情報検証・公開処理
-- `candidates/` — 非公開候補
+- `article_factory/graphiti_seed.py` — private Graphiti記録を公開可能な技術テーマへ変換するideation adapter
+- `candidates/` — Zenn未公開候補。repository自体はpublicなのでprivate情報を置かない
 - `articles/` — Zenn同期対象の公開記事
 - `reports/` — 月次品質証跡
 - `.github/workflows/monthly-article.yml` — 定期実行
-- `.github/workflows/article-factory-ci.yml` — 構文・設定CI
+- `.github/workflows/article-factory-ci.yml` — 構文・設定・privacy境界CI
 
 ## Failure policy
 
@@ -54,6 +79,8 @@ Zenn公式仕様では、連携済みrepoの同期対象branchにpushすると�
 - KAFKA2306 GitHub一次証拠が2件未満 → 公開しない
 - overall 3.8未満 → 改稿、最終的に失敗なら公開しない
 - いずれかの評価軸が3.5未満 → 改稿、最終的に失敗なら公開しない
+- Graphiti seedのprivacy check失敗 → Graphiti由来候補を作らない
+- `GRAPHITI_READ_TOKEN` 未設定 → Graphiti入力のみskipし通常候補生成を継続
 - 同月に既に1本公開済み → 重複公開しない
 
 「月1本」を守るため25日だけでなく27日・29日にも再試行するが、品質ゲートを下げて本数だけ満たすことはしない。

--- a/article_factory/graphiti_seed.py
+++ b/article_factory/graphiti_seed.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import urllib.parse
+import urllib.request
+
+import run as factory
+
+GRAPHITI_REPO = os.environ.get("GRAPHITI_REPO", "KAFKA2306/graphiti")
+GRAPHITI_TOKEN = os.environ.get("GRAPHITI_READ_TOKEN", "")
+MAX_RECORDS = int(os.environ.get("GRAPHITI_IDEA_RECORDS", "4"))
+MAX_CHARS_PER_RECORD = int(os.environ.get("GRAPHITI_IDEA_MAX_CHARS", "18000"))
+
+
+def github_json(path: str) -> object:
+    if not GRAPHITI_TOKEN:
+        raise RuntimeError("GRAPHITI_READ_TOKEN is not configured")
+    url = f"https://api.github.com/repos/{GRAPHITI_REPO}/{path.lstrip('/')}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {GRAPHITI_TOKEN}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "KAFKA2306-article-factory/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def recent_weekly_records() -> list[dict[str, str]]:
+    listing = github_json("contents/diary/weekly?ref=main")
+    if not isinstance(listing, list):
+        return []
+    files = sorted(
+        (
+            item
+            for item in listing
+            if isinstance(item, dict)
+            and item.get("type") == "file"
+            and str(item.get("name", "")).endswith(".md")
+        ),
+        key=lambda item: str(item.get("name", "")),
+        reverse=True,
+    )[:MAX_RECORDS]
+
+    records: list[dict[str, str]] = []
+    for item in files:
+        path = str(item["path"])
+        payload = github_json(f"contents/{urllib.parse.quote(path, safe='/')}?ref=main")
+        if not isinstance(payload, dict) or payload.get("encoding") != "base64":
+            continue
+        raw = base64.b64decode(str(payload.get("content", ""))).decode("utf-8", errors="replace")
+        records.append({
+            "name": str(item.get("name", "")),
+            "content": raw[:MAX_CHARS_PER_RECORD],
+        })
+    return records
+
+
+def extract_public_safe_topic(records: list[dict[str, str]], public_signals: list[dict[str, object]]) -> dict[str, object]:
+    digest = hashlib.sha256(
+        "\n".join(record["content"] for record in records).encode("utf-8")
+    ).hexdigest()[:16]
+    private_corpus = "\n\n--- RECORD ---\n\n".join(record["content"] for record in records)
+
+    prompt = f"""
+以下はprivateなGraphiti diaryです。記事本文の根拠ではなく、テーマ発見だけに使ってください。
+
+厳守:
+- 個人情報、税務、資産、健康、旅行、私生活、勤務先内部情報、未公開情報をテーマにしない。
+- private diaryの文章を引用・要約して公開しない。
+- 記事化候補は、下記PUBLIC_GITHUB_SIGNALSだけで再現・検証できる技術テーマに限定する。
+- 設計判断、失敗、境界条件、fail-close、provenance、API/MCP、CI、データ契約など、他のエンジニアに再利用可能な知見を優先する。
+- PUBLIC_GITHUB_SIGNALSに公開証拠が2件以上ないテーマは選ばない。
+- Graphiti自体を記事の出典として扱わない。
+
+PRIVATE_GRAPHITI_DIARY:
+{private_corpus}
+
+PUBLIC_GITHUB_SIGNALS:
+{json.dumps(public_signals, ensure_ascii=False, indent=2)}
+
+JSONのみ返してください:
+{{
+  "title": "...",
+  "audience": "...",
+  "problem": "...",
+  "why_unique": "...",
+  "evidence_urls": ["https://github.com/KAFKA2306/...", "https://github.com/KAFKA2306/..."],
+  "design_lessons": ["..."],
+  "privacy_check": "PASS"
+}}
+"""
+    result = json.loads(factory.model_call(
+        "あなたはprivacy-firstの技術編集長です。private memoryは発想にだけ使い、公開証拠へ必ず再接地します。",
+        prompt,
+        temperature=0.0,
+        json_mode=True,
+    ))
+    urls = result.get("evidence_urls", [])
+    if result.get("privacy_check") != "PASS":
+        raise RuntimeError("Graphiti seed privacy gate failed")
+    if not isinstance(urls, list) or len(urls) < 2:
+        raise RuntimeError("Graphiti seed lacks two public evidence URLs")
+    if any(not str(url).startswith("https://github.com/KAFKA2306/") for url in urls):
+        raise RuntimeError("Graphiti seed contains non-public-evidence URL")
+    result["record_digest"] = digest
+    return result
+
+
+def main() -> int:
+    if not GRAPHITI_TOKEN:
+        print("graphiti_seed=skipped reason=GRAPHITI_READ_TOKEN_missing")
+        return 0
+
+    records = recent_weekly_records()
+    if not records:
+        print("graphiti_seed=skipped reason=no_records")
+        return 0
+
+    public_signals = factory.collect_public_github_signals(factory.CONFIG["owner"])
+    topic = extract_public_safe_topic(records, public_signals)
+    article = factory.draft_article(topic, public_signals)
+    sources_ok, source_report = factory.source_gate(article)
+    review = factory.aggregate_evaluations(article, rounds=1)
+
+    meta = {
+        "idea_source": "private-graphiti-diary",
+        "idea_only": True,
+        "raw_private_content_persisted": False,
+        "record_count": len(records),
+        "record_digest": topic.pop("record_digest", None),
+        "topic": topic,
+        "initial_review": review,
+        "initial_sources": source_report,
+    }
+    path = factory.save_candidate(article, meta)
+    print(
+        f"graphiti_candidate={path.relative_to(factory.ROOT)} "
+        f"sources_ok={sources_ok} score={review['overall']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 目的

月次記事ファクトリのテーマ探索にprivate `KAFKA2306/graphiti` のweekly diaryを追加し、公開GitHub実装へ再接地できる技術テーマだけを候補化する。

## 変更

- `article_factory/graphiti_seed.py` を追加
- private diaryは実行時のみ読み、raw本文をpublic repoへ保存しない
- 個人情報・税務・資産・健康・旅行・私生活・勤務先内部情報・未公開情報をテーマ化しないprivacy gate
- public KAFKA2306 GitHub evidence 2件以上へ再接地できるテーマだけ記事候補化
- `GRAPHITI_READ_TOKEN` 未設定時はGraphiti入力だけskipし、通常候補生成は継続
- weekly candidate runでGraphiti候補 + 通常公開GitHub候補を生成し、月末のbest-of-month選抜へ投入
- CIで新scriptの構文とprivacy boundaryを検査
- docsで「内部自律ループ」と「LAPRAS実測feedbackは公式取得経路がないため未接続」を明記

## セキュリティ境界

`articles` はpublic repoなのでGraphiti raw contentはcommitしない。残すのは抽象化済みテーマ、復元不能digest、公開一次証拠のみ。

Cross-repo private readにはActions標準 `GITHUB_TOKEN` を使わず、read-only fine-grained credentialをrepository secret `GRAPHITI_READ_TOKEN` として一度だけ設定する。