### PR TITLE
chore: article factoryを初回実運転できるpush trigger追加

### DIFF
--- a/.github/workflows/monthly-article.yml
+++ b/.github/workflows/monthly-article.yml
@@ -1,6 +1,11 @@
 name: Monthly LAPRAS Article Factory
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/monthly-article.yml"
   workflow_dispatch:
     inputs:
       mode:
@@ -44,6 +49,8 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "mode=candidate" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event.schedule }}" == "0 0 * * 1" ]]; then
             echo "mode=candidate" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## 目的

Monthly LAPRAS Article Factoryをこの場で一度実運転し、Graphiti seed / GitHub Models / candidate保存 / bot commitまで通るか確認する。

## 変更

- `main` の `.github/workflows/monthly-article.yml` 自体が更新された場合のみ `push` で起動
- `push` イベントは常に `candidate` modeとして扱う
- 通常運用のweekly/monthly scheduleとmanual workflow_dispatchは維持

このPRをmergeしたpush自体が初回candidate runを起動する。