### PR TITLE
fix: GitHub Models API 410を現行REST versionで修復

### DIFF
--- a/.github/workflows/article-pipeline.yml
+++ b/.github/workflows/article-pipeline.yml
@@ -11,6 +11,10 @@ on:
         options:
           - candidate
           - publish
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/article-pipeline.yml"
   schedule:
     # Monday 09:00 JST.
     - cron: "0 0 * * 1"
@@ -44,11 +48,42 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "mode=candidate" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event.schedule }}" == "0 0 * * 1" ]]; then
             echo "mode=candidate" >> "$GITHUB_OUTPUT"
           else
             echo "mode=publish" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Pin current GitHub REST API version
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          current = "2026-03-10"
+
+          core = Path("pipeline/core.py")
+          text = core.read_text(encoding="utf-8")
+          needle = '            "Accept": "application/vnd.github+json",\n            "Authorization":'
+          replacement = (
+              '            "Accept": "application/vnd.github+json",\n'
+              f'            "X-GitHub-Api-Version": "{current}",\n'
+              '            "Authorization":'
+          )
+          if needle not in text and f'"X-GitHub-Api-Version": "{current}"' not in text:
+              raise SystemExit("GitHub Models request header insertion point not found")
+          core.write_text(text.replace(needle, replacement, 1), encoding="utf-8")
+
+          graphiti = Path("pipeline/graphiti.py")
+          text = graphiti.read_text(encoding="utf-8")
+          text = text.replace(
+              '"X-GitHub-Api-Version": "2022-11-28"',
+              f'"X-GitHub-Api-Version": "{current}"',
+          )
+          graphiti.write_text(text, encoding="utf-8")
+          PY
 
       - name: Preflight audit
         run: |
@@ -70,12 +105,12 @@ jobs:
       - name: Commit canonical outputs
         shell: bash
         run: |
-          if git diff --quiet && [[ -z "$(git status --porcelain)" ]]; then
-            echo "No changes"
+          git add -A artifacts articles
+          if git diff --cached --quiet; then
+            echo "No canonical output changes"
             exit 0
           fi
           git config user.name "article-pipeline[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A artifacts articles
           git commit -m "content: ${{ steps.mode.outputs.mode }} canonical article pipeline"
           git push


### PR DESCRIPTION
## 目的

Canonical Article Pipeline の初回実運転で確認した GitHub Models `HTTP 410 Gone` を、現行 GitHub REST API version `2026-03-10` へ固定して修復する。

## 変更

- workflow実行時に GitHub Models requestへ `X-GitHub-Api-Version: 2026-03-10` を注入
- Graphiti private repo transportの旧 `2022-11-28` も同じversionへ補正
- このworkflow自身がmainへ更新されたpushでは candidate modeとして初回実運転
- canonical outputが無い場合の空commit失敗を防止

## 根拠

GitHub公式REST docsでは現行モデル推論例が `2026-03-10` を使用し、サポート終了version指定時は `410 Gone` と明記されている。

## Graphiti

`GRAPHITI_READ_TOKEN` が未設定でもGraphiti入力だけfail-softでskipし、公開GitHub由来candidateは継続する。secretが設定されれば同じrunでGraphiti候補も生成する。