### PR TITLE
fix: GitHub Models 410を外部blockerとしてfail-close

### DIFF
--- a/.github/workflows/article-pipeline.yml
+++ b/.github/workflows/article-pipeline.yml
@@ -57,42 +57,80 @@ jobs:
             echo "mode=publish" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Pin current GitHub REST API version
-        shell: bash
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-
-          current = "2026-03-10"
-
-          core = Path("pipeline/core.py")
-          text = core.read_text(encoding="utf-8")
-          needle = '            "Accept": "application/vnd.github+json",\n            "Authorization":'
-          replacement = (
-              '            "Accept": "application/vnd.github+json",\n'
-              f'            "X-GitHub-Api-Version": "{current}",\n'
-              '            "Authorization":'
-          )
-          if needle not in text and f'"X-GitHub-Api-Version": "{current}"' not in text:
-              raise SystemExit("GitHub Models request header insertion point not found")
-          core.write_text(text.replace(needle, replacement, 1), encoding="utf-8")
-
-          graphiti = Path("pipeline/graphiti.py")
-          text = graphiti.read_text(encoding="utf-8")
-          text = text.replace(
-              '"X-GitHub-Api-Version": "2022-11-28"',
-              f'"X-GitHub-Api-Version": "{current}"',
-          )
-          graphiti.write_text(text, encoding="utf-8")
-          PY
-
       - name: Preflight audit
         run: |
           python -m compileall pipeline
           python -m unittest discover -s tests -v
           python -m pipeline.audit
 
+      - name: Check GitHub Models availability
+        id: models
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/article-pipeline
+          set +e
+          code=$(curl -sS -L \
+            -o /tmp/article-pipeline/models-response.json \
+            -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            https://models.github.ai/inference/chat/completions \
+            -d '{"model":"openai/gpt-4.1","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":8,"temperature":0}')
+          curl_status=$?
+          set -e
+
+          if [[ "$curl_status" -ne 0 ]]; then
+            echo "GitHub Models preflight transport failure" >&2
+            exit "$curl_status"
+          fi
+
+          if [[ "$code" == "200" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            month=$(TZ=Asia/Tokyo date +%Y-%m)
+            rm -f "artifacts/reports/$month/runtime-status.json"
+            exit 0
+          fi
+
+          if [[ "$code" == "410" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            export MODELS_HTTP_STATUS="$code"
+            python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timedelta, timezone
+          from pathlib import Path
+
+          jst = timezone(timedelta(hours=9))
+          now = datetime.now(jst)
+          out = Path("artifacts/reports") / now.strftime("%Y-%m")
+          out.mkdir(parents=True, exist_ok=True)
+          payload = {
+              "status": "blocked",
+              "reason_code": "github_models_http_410",
+              "http_status": int(os.environ["MODELS_HTTP_STATUS"]),
+              "checked_at": now.isoformat(),
+              "official_prerequisite": "Enable GitHub Models for this repository before inference is used.",
+              "official_docs": "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-github-models-in-your-repository",
+          }
+          (out / "runtime-status.json").write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+            echo "GitHub Models inference unavailable (HTTP 410); candidate/publish generation is fail-closed." >&2
+            exit 0
+          fi
+
+          echo "Unexpected GitHub Models HTTP status: $code" >&2
+          cat /tmp/article-pipeline/models-response.json >&2 || true
+          exit 1
+
       - name: Generate or publish
+        if: steps.models.outputs.available == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GRAPHITI_READ_TOKEN: ${{ secrets.GRAPHITI_READ_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docs/
 
 artifacts/
   candidates/YYYY-MM/        # unpublished, public-safe candidates only
-  reports/YYYY-MM/           # review/source/selection evidence
+  reports/YYYY-MM/           # review/source/selection/runtime evidence
 
 articles/                    # Zenn-compatible published articles only
 tests/
@@ -63,6 +63,8 @@ tests/
 ## Automation
 
 毎週月曜 09:00 JST:
+- GitHub Models inferenceをpreflightする
+- inferenceがHTTP 410なら生成をfail-closeし、`artifacts/reports/YYYY-MM/runtime-status.json` にblockerを保存する
 - Graphiti weeklyをread-onlyで読む（`GRAPHITI_READ_TOKEN` がある場合のみ）
 - weeklyを読みやすい作業用contextへ圧縮
 - private内容を根拠にせず、公開GitHub evidence 2件以上へ再接地
@@ -99,6 +101,17 @@ tests/
 - gate失敗時は公開しない
 - monthly publication limit: 1
 
+## GitHub-side prerequisites
+
+GitHub ActionsからGitHub Modelsを使うには、workflowの `models: read` だけでなく、repository自体でGitHub Modelsが有効になっている必要があります。
+
+- GitHub公式: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-github-models-in-your-repository
+- `KAFKA2306/articles` では **Settings → Models → Models in this repository → Enabled** が必要
+- inferenceが利用不可の間は、記事を捏造・代替公開せずruntime blockerを記録して正常終了する
+- 利用可能になった次回runではblocker reportを削除して通常生成へ復帰する
+
+Graphiti入力には別途、private `KAFKA2306/graphiti` だけをread-onlyで読める `GRAPHITI_READ_TOKEN` が必要です。未設定時はGraphiti入力のみskipし、GitHub Modelsが利用可能ならpublic GitHub由来候補は継続します。
+
 ## Local verification
 
 ```bash
@@ -120,7 +133,5 @@ python -m pipeline.cli candidate
 ```bash
 python -m pipeline.cli publish
 ```
-
-GitHub ActionsではGitHub Modelsを利用します。private Graphiti readは別のread-only credential `GRAPHITI_READ_TOKEN` を使い、未設定時はGraphiti入力のみskipします。
 
 詳細は [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) と [`docs/GRAPHITI_WEEKLY.md`](docs/GRAPHITI_WEEKLY.md) を参照してください。


### PR DESCRIPTION
## 目的

PR #5で現行REST versionへ補正しても実運転のGitHub Models inferenceがHTTP 410を継続したため、API versionを原因と断定する実装を撤回し、repository側のModels利用可否をpreflightして外部依存blockerとして扱う。

## GitHub公式根拠

- Actionsでは `models: read` + `GITHUB_TOKEN` でGitHub Modelsを利用できる
- 個人所有repositoryでも Settings → Models でGitHub ModelsをEnabledにすることが利用前提
- current Actions quickstartは `https://models.github.ai/inference/chat/completions` を直接利用

## 変更

- runtimeでsource fileを書き換えるAPI-version pin stepを削除
- 生成前に公式Actions例と同じinference endpointを最小requestでpreflight
- HTTP 200なら通常のGraphiti/public GitHub候補生成へ進む
- HTTP 410なら記事を生成・公開せず、`artifacts/reports/YYYY-MM/runtime-status.json` にblocked状態と公式設定URLを保存して正常終了
- その他のHTTP status / transport failureは引き続きworkflow failureとして露出
- Modelsが利用可能になった次回runではruntime blocker reportを削除
- READMEへGitHub Models有効化をruntime prerequisiteとして明記

## Safety

410時に代替記事を捏造したり品質gateを迂回したりしない。Modelsが利用できない限りgeneration/publishはfail-closeする。