### PR TITLE
fix: bootstrap候補の内部metadataを公開前に正規化

### DIFF
--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -6,6 +6,28 @@ from . import core
 from .graphiti import generate_graphiti_candidate
 
 
+def normalize_legacy_candidate_metadata() -> int:
+    """Migrate one-off bootstrap metadata before any pipeline action.
+
+    The bootstrap candidate used ``factory_meta`` before ``pipeline_meta`` became
+    canonical. Normalize it in-place so monthly evaluation and publication use
+    the same metadata-stripping contract and never publish the internal comment.
+    """
+    normalized = 0
+    for path in core.candidate_files_this_month():
+        text = path.read_text(encoding="utf-8")
+        if not text.startswith("<!-- factory_meta: "):
+            continue
+        path.write_text(
+            text.replace("<!-- factory_meta: ", "<!-- pipeline_meta: ", 1),
+            encoding="utf-8",
+        )
+        normalized += 1
+    if normalized:
+        print(f"legacy_candidate_metadata_normalized={normalized}")
+    return normalized
+
+
 def candidate() -> int:
     generated = []
     graphiti_path = generate_graphiti_candidate()
@@ -33,6 +55,7 @@ def main() -> int:
     )
     parser.add_argument("mode", choices=("candidate", "publish"))
     args = parser.parse_args()
+    normalize_legacy_candidate_metadata()
     return candidate() if args.mode == "candidate" else publish()
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
 from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
 
 from pipeline import core
+from pipeline.cli import normalize_legacy_candidate_metadata
 from pipeline.graphiti import compact_weekly_record
 
 
@@ -53,6 +57,23 @@ class PipelineContractTests(unittest.TestCase):
             core.strip_pipeline_meta(sample),
             "# Public article\n",
         )
+
+    def test_legacy_factory_metadata_is_normalized_before_pipeline_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            candidate = Path(tmp) / "candidate.md"
+            candidate.write_text(
+                '<!-- factory_meta: {"idea_only": true} -->\n\n# Public article\n',
+                encoding="utf-8",
+            )
+            with patch.object(
+                core,
+                "candidate_files_this_month",
+                return_value=[candidate],
+            ):
+                self.assertEqual(normalize_legacy_candidate_metadata(), 1)
+            migrated = candidate.read_text(encoding="utf-8")
+            self.assertTrue(migrated.startswith("<!-- pipeline_meta: "))
+            self.assertEqual(core.strip_pipeline_meta(migrated), "# Public article\n")
 
     def test_month_end_detection_handles_leap_years(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## 背景
初回bootstrap候補だけ `<!-- factory_meta: ... -->` を使用していますが、正準の公開処理は `pipeline_meta` のみを本文から除去します。このまま月次候補に残ると、内部metadataコメントが公開本文へ残り得ます。

## 変更
- pipeline action開始前に当月候補の legacy `factory_meta` を `pipeline_meta` へidempotentに正規化
- 正規化後に `strip_pipeline_meta()` で本文だけになることを契約テスト化
- private diary本文は扱わず、metadata markerだけを変更

## Acceptance
- legacy候補が1回だけ正規化される
- canonical `pipeline_meta` は従来どおり本文から除去される
- Article Pipeline CIのcompile / contract tests / privacy auditが通る

GitHub Models有効化・`GRAPHITI_READ_TOKEN`設定とは独立した安全修正です。