### PR TITLE
Harden .gitignore and keep canonical article assets explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,62 @@
+# Python bytecode / virtual environments
 __pycache__/
 *.py[cod]
+*$py.class
 .venv/
+venv/
+
+# Python test / analysis caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# Local environment / credentials
 .env
+.env.*
+!.env.example
+
+# Node / Zenn local tooling
+node_modules/
+.npm/
+.pnpm-store/
+.yarn/
+
+# Editor / OS residue
 .DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*~
+
+# Build / cache / temporary output
+.cache/
+build/
+dist/
+tmp/
+.temp/
+*.tmp
+*.log
+*.bak
+*.orig
+*.rej
+
+# Root-level image dumps are local residue.
+# Canonical article images belong under images/<article-slug>/ and stay tracked.
+/*.png
+/*.jpg
+/*.jpeg
+/*.webp
+
+# Local archive / export residue at repository root
+/*.zip
+/*.tar
+/*.tar.gz
+
+# Intentionally tracked canonical outputs:
+# - articles/  : published Zenn articles
+# - images/    : article publication assets
+# - artifacts/ : public-safe candidates and review evidence


### PR DESCRIPTION
## Summary

`.gitignore` が Python 最小5行だけだったため、article factory のローカル実行・Zenn CLI・画像生成作業で混入しやすい残骸を明示的に除外します。

- Python bytecode / venv / test caches
- `.env.*`（`.env.example` は許可）
- Node/Zenn local dependencies
- IDE / OS residue
- build / cache / temp / logs
- repository root に落ちた一時画像・archive

## Canonical boundary

次は **ignoreしません**。

- `articles/` — Zenn公開記事
- `images/` — 記事に埋め込む正準画像
- `artifacts/` — public-safe candidate / review evidence

特に `images/<article-slug>/` のPNGは公開成果物なので追跡対象のままです。root直下に誤って落ちたPNG/JPEG/WebPだけを residue として無視します。

## Cleanup

既にmerge済みだった `article/books-local-dry-run-migration` は main と同じSHAへ正規化し、divergentな残骸を解消しました。