### PR TITLE
Ratchet article outcome and image policy contract

### DIFF
--- a/.github/workflows/article-pipeline-ci.yml
+++ b/.github/workflows/article-pipeline-ci.yml
@@ -41,3 +41,12 @@ jobs:
         run: python -m unittest discover -s tests -v
       - name: Repository and privacy audit
         run: python -m pipeline.audit
+      - name: Verify clean checkout
+        shell: bash
+        run: |
+          find . -type d -name __pycache__ -prune -exec rm -rf {} +
+          status="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$status" ]; then
+            printf '%s\n' "$status"
+            exit 1
+          fi

--- a/articles/liltoon-reimport-first-aid-qa.md
+++ b/articles/liltoon-reimport-first-aid-qa.md
@@ -1,3 +1,12 @@
+---
+title: "lilToonで左右の目の見え方が違うとき、最初に何をする？ — Reimportだけで切り分けるQA"
+emoji: "👁️"
+type: "tech"
+topics: ["vrchat", "unity", "liltoon", "shader"]
+published: true
+published_at: 2026-08-12 19:12
+---
+
 # lilToonで左右の目の見え方が違うとき、最初に何をする？ — Reimportだけで切り分けるQA
 
 VRChatで「左目では正常なのに右目ではおかしい」「VRだけ見え方が崩れる」といった症状が出たとき、いきなりアバターやMaterialを作り直す必要はありません。

--- a/articles/unity-vrchat-shader-troubleshooting-qa.md
+++ b/articles/unity-vrchat-shader-troubleshooting-qa.md
@@ -1,3 +1,12 @@
+---
+title: "Unity / VRChatで『VRだけ二重に見える』をどう考えるか"
+emoji: "🥽"
+type: "tech"
+topics: ["vrchat", "unity", "shader", "liltoon", "poiyomi"]
+published: true
+published_at: 2026-08-12 19:46
+---
+
 # Unity / VRChatで「VRだけ二重に見える」をどう考えるか
 
 Unityでは普通に見える。Desktopでも大きな異常は分からない。しかしVRの人から見ると二重に見える、左右の目で違って見える、あるいは直接見ると崩れる。

--- a/pipeline/audit.py
+++ b/pipeline/audit.py
@@ -13,6 +13,11 @@ FORBIDDEN_PUBLIC_MARKERS = (
     "PRIVATE_GRAPHITI_DIARY:",
     "PRIVATE_WEEKLY_CONTEXT:",
 )
+CANONICAL_RATCHET_KPIS = [
+    "publication_pass_rate",
+    "primary_source_rate",
+    "manual_corrections",
+]
 
 
 def fail(message: str) -> None:
@@ -86,6 +91,16 @@ def audit_config() -> None:
     source = (core.ROOT / "pipeline" / "core.py").read_text(encoding="utf-8")
     if "models.github.ai" in source:
         fail("retired GitHub Models endpoint remains in core.py")
+
+    if list(core.CONFIG.get("ratchet_kpis", [])) != CANONICAL_RATCHET_KPIS:
+        fail("ratchet_kpis must be exactly the three canonical outcome KPIs")
+    image_policy = core.CONFIG.get("image_policy", {})
+    if image_policy.get("objective") != "reader_comprehension":
+        fail("image policy must optimize reader comprehension")
+    if image_policy.get("fixed_count") is not None:
+        fail("image policy must not require a fixed image count")
+    if image_policy.get("require_explanatory_value") is not True:
+        fail("every generated diagram must have explanatory value")
 
 
 def audit_editorial_contract() -> None:

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -25,6 +25,16 @@
     "minimum_primary_sources": 3,
     "minimum_own_github_evidence": 2
   },
+  "ratchet_kpis": [
+    "publication_pass_rate",
+    "primary_source_rate",
+    "manual_corrections"
+  ],
+  "image_policy": {
+    "objective": "reader_comprehension",
+    "fixed_count": null,
+    "require_explanatory_value": true
+  },
   "lapras_axes": [
     "論理性",
     "実用性",

--- a/tests/test_ratchet_contract.py
+++ b/tests/test_ratchet_contract.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import copy
+import unittest
+from unittest import mock
+
+from pipeline import audit, core
+
+
+class RatchetContractTests(unittest.TestCase):
+    def test_canonical_kpis_and_image_policy_pass(self) -> None:
+        audit.audit_config()
+
+    def test_fixed_image_count_fails_closed(self) -> None:
+        config = copy.deepcopy(core.CONFIG)
+        config["image_policy"]["fixed_count"] = 10
+        with mock.patch.object(core, "CONFIG", config):
+            with self.assertRaises(SystemExit):
+                audit.audit_config()
+
+    def test_extra_kpi_fails_closed(self) -> None:
+        config = copy.deepcopy(core.CONFIG)
+        config["ratchet_kpis"].append("article_count")
+        with mock.patch.object(core, "CONFIG", config):
+            with self.assertRaises(SystemExit):
+                audit.audit_config()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the remaining mechanically enforceable parts of #11.

- make the three outcome KPIs canonical in `pipeline/config.json`
- make image generation optimize reader comprehension with no fixed image count
- fail closed in `pipeline.audit` if either contract drifts
- add regression tests for extra KPI and fixed-count image regressions

Existing canonical pipeline, privacy boundary, legacy-layout cleanup, source gate, editorial review and branch hygiene remain unchanged.

Validation expected from `article-pipeline-ci.yml`: compileall, unittest discovery, repository audit, clean checkout.