### PR TITLE
Adopt date-sequence filenames for new articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ pipeline/
   cli.py                     # candidate / publish entry point
   core.py                    # collection, source verification, persistence
   editorial.py               # story shaping, drafting, dual review, revision
+  filenames.py               # readable publication filename contract
   runtime.py                 # Copilot CLI response normalization / fail-close JSON adapter
   graphiti.py                # private weekly → readable in-memory context → public-safe topic
   selection.py               # candidate maturation + story-first month-end selection
@@ -110,6 +111,30 @@ tests/
 ```
 
 `articles/` だけが公開記事の正準出力です。候補と査読証跡は `artifacts/` に隔離し、実装コードは `pipeline/` に集約します。
+
+### Article filename policy
+
+新規公開記事のrepository内ファイル名は、一覧性を優先して次を正準とします。
+
+```text
+YYYY-MM-DD-NN-title.md
+```
+
+例:
+
+```text
+2026-08-13-01-codex-chatgpt-github-issue-bridge.md
+2026-08-13-02-csv-migration-dry-run-before-write.md
+```
+
+- `YYYY-MM-DD` は公開処理を行ったJST日付
+- `NN` は同日内の `01`, `02`, ... の連番
+- `title` は記事内容を識別する短いASCII kebab-caseで、表示用の日本語 `title:` とは分離する
+- Zennのslug上限50文字に収めるため `title` 部分は最大36文字
+- この規則は**新規公開記事だけ**に適用し、既存公開記事はrenameしない
+- Zennでは `articles/[slug].md` のファイル名が公開URLのslugになるため、公開済みファイルのrenameを管理目的だけで行わない
+
+Zenn一次仕様: https://zenn.dev/zenn/articles/what-is-slug
 
 ## Branch lifecycle
 

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -8,6 +8,15 @@
     "reports": "artifacts/reports",
     "published": "articles"
   },
+  "filename_policy": {
+    "format": "YYYY-MM-DD-NN-title",
+    "sequence_width": 2,
+    "max_slug_length": 50,
+    "title_max_length": 36,
+    "new_articles_only": true,
+    "rename_existing_articles": false,
+    "zenn_slug_reference": "https://zenn.dev/zenn/articles/what-is-slug"
+  },
   "graphiti": {
     "repo": "KAFKA2306/graphiti",
     "weekly_dir": "diary/weekly",

--- a/pipeline/filenames.py
+++ b/pipeline/filenames.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+SAFE_TITLE_RE = re.compile(r"[^a-z0-9]+")
+MANAGED_SLUG_RE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})-(?P<number>\d{2})-(?P<title>[a-z0-9]+(?:-[a-z0-9]+)*)$"
+)
+
+
+def normalize_file_title(value: str, *, max_length: int = 36) -> str:
+    """Normalize a human-readable ASCII file-title stem for a Zenn slug."""
+    normalized = SAFE_TITLE_RE.sub("-", value.lower()).strip("-")
+    normalized = re.sub(r"-+", "-", normalized)
+    normalized = normalized[:max_length].rstrip("-")
+    if not normalized:
+        raise ValueError("file_title must contain at least one ASCII letter or digit")
+    return normalized
+
+
+def next_publication_slug(
+    file_title: str,
+    *,
+    moment: datetime,
+    published_dir: Path,
+    sequence_width: int = 2,
+    max_slug_length: int = 50,
+) -> str:
+    """Return YYYY-MM-DD-NN-title without mutating existing published files."""
+    date_prefix = moment.strftime("%Y-%m-%d")
+    title_budget = max_slug_length - len(date_prefix) - sequence_width - 2
+    if title_budget < 1:
+        raise ValueError("max_slug_length is too short for the filename contract")
+    title = normalize_file_title(file_title, max_length=title_budget)
+
+    used_numbers: list[int] = []
+    if published_dir.exists():
+        for path in published_dir.glob(f"{date_prefix}-*.md"):
+            match = MANAGED_SLUG_RE.fullmatch(path.stem)
+            if match:
+                used_numbers.append(int(match.group("number")))
+
+    number = max(used_numbers, default=0) + 1
+    if number >= 10**sequence_width:
+        raise ValueError("daily article sequence exhausted")
+
+    slug = f"{date_prefix}-{number:0{sequence_width}d}-{title}"
+    if len(slug) > max_slug_length:
+        raise AssertionError("generated slug exceeded configured maximum")
+    return slug
+
+
+def is_managed_slug(slug: str) -> bool:
+    return MANAGED_SLUG_RE.fullmatch(slug) is not None

--- a/pipeline/selection.py
+++ b/pipeline/selection.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from . import core
+from . import core, filenames
 from .editorial import EDITORIAL_AXES, TECHNICAL_AXES
 
 EVALUATION_KIND = str(
@@ -189,6 +190,74 @@ def save_monthly_selection_report(
     return path
 
 
+def publication_file_title(article: str) -> str:
+    """Create the readable ASCII title segment used only for file management."""
+    title = core.article_title(article)
+    policy = core.CONFIG["filename_policy"]
+    max_length = int(policy["title_max_length"])
+    prompt = f"""
+次の記事タイトルを、ファイル管理用の短い英語kebab-caseへ変換してください。
+表示タイトルの翻訳ではなく、内容を識別できる3〜6語程度のASCII識別子です。
+半角英小文字 a-z、数字 0-9、ハイフンだけを使い、{max_length}文字以内にしてください。
+
+記事タイトル:
+{title}
+
+JSONのみ返してください。
+{{"file_title":"example-readable-title"}}
+"""
+    try:
+        result = json.loads(
+            core.model_call(
+                "あなたは技術記事のファイル命名担当です。意味を保ち、短く安定した識別子だけを作ります。",
+                prompt,
+                json_mode=True,
+            )
+        )
+        return filenames.normalize_file_title(
+            str(result.get("file_title", "")),
+            max_length=max_length,
+        )
+    except Exception:
+        try:
+            return filenames.normalize_file_title(title, max_length=max_length)
+        except ValueError:
+            digest = hashlib.sha256(article.encode("utf-8")).hexdigest()[:10]
+            return f"article-{digest}"
+
+
+def finalize_publication_filename(old_path: Path, article: str) -> Path:
+    """Rename only the newly generated artifact; existing publications are untouched."""
+    policy = core.CONFIG["filename_policy"]
+    moment = core.now_jst()
+    file_title = publication_file_title(article)
+    slug = filenames.next_publication_slug(
+        file_title,
+        moment=moment,
+        published_dir=old_path.parent,
+        sequence_width=int(policy["sequence_width"]),
+        max_slug_length=int(policy["max_slug_length"]),
+    )
+    new_path = old_path.with_name(f"{slug}.md")
+    old_path.rename(new_path)
+
+    reports_root = core.output_dir("reports")
+    matches = list(reports_root.rglob(f"{old_path.stem}.json")) if reports_root.exists() else []
+    for old_report in matches:
+        payload = json.loads(old_report.read_text(encoding="utf-8"))
+        payload["published_path"] = str(new_path.relative_to(core.ROOT))
+        payload["filename_policy"] = str(policy["format"])
+        new_report = old_report.with_name(f"{slug}.json")
+        new_report.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        if new_report != old_report:
+            old_report.unlink()
+
+    return new_path
+
+
 def publish_best() -> Path | None:
     if not scheduled_publish_allowed():
         print(
@@ -238,8 +307,9 @@ def publish_best() -> Path | None:
         selected=selected,
         status="selected",
     )
-    return core.publish(
+    old_path = core.publish(
         str(selected["article"]),
         dict(selected["review"]),
         dict(selected["source_report"]),
     )
+    return finalize_publication_filename(old_path, str(selected["article"]))

--- a/tests/test_filenames.py
+++ b/tests/test_filenames.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+from pipeline import core
+from pipeline import filenames
+
+
+class ArticleFilenameTests(unittest.TestCase):
+    def test_filename_policy_is_explicit_and_non_destructive(self) -> None:
+        policy = core.CONFIG["filename_policy"]
+        self.assertEqual(policy["format"], "YYYY-MM-DD-NN-title")
+        self.assertEqual(policy["sequence_width"], 2)
+        self.assertEqual(policy["max_slug_length"], 50)
+        self.assertEqual(policy["title_max_length"], 36)
+        self.assertTrue(policy["new_articles_only"])
+        self.assertFalse(policy["rename_existing_articles"])
+        self.assertEqual(
+            policy["zenn_slug_reference"],
+            "https://zenn.dev/zenn/articles/what-is-slug",
+        )
+
+    def test_normalize_file_title_keeps_readable_ascii_kebab_case(self) -> None:
+        self.assertEqual(
+            filenames.normalize_file_title("Codex + ChatGPT GitHub Issue Bridge"),
+            "codex-chatgpt-github-issue-bridge",
+        )
+
+    def test_next_slug_uses_date_and_daily_sequence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            published = Path(tmp)
+            (published / "2026-08-13-01-first-article.md").write_text("x", encoding="utf-8")
+            (published / "legacy-article.md").write_text("x", encoding="utf-8")
+
+            slug = filenames.next_publication_slug(
+                "second-readable-article",
+                moment=datetime(2026, 8, 13, 16, 30),
+                published_dir=published,
+            )
+
+        self.assertEqual(slug, "2026-08-13-02-second-readable-article")
+        self.assertTrue(filenames.is_managed_slug(slug))
+
+    def test_slug_respects_zenn_fifty_character_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            slug = filenames.next_publication_slug(
+                "this-is-a-deliberately-very-long-readable-article-title-for-testing",
+                moment=datetime(2026, 8, 13, 16, 30),
+                published_dir=Path(tmp),
+            )
+
+        self.assertLessEqual(len(slug), 50)
+        self.assertTrue(slug.startswith("2026-08-13-01-"))
+        self.assertTrue(filenames.is_managed_slug(slug))
+
+    def test_existing_legacy_filename_does_not_need_to_match_new_schema(self) -> None:
+        self.assertFalse(filenames.is_managed_slug("codex-chatgpt-github-issue-bridge"))
+        self.assertFalse(filenames.is_managed_slug("engineering-evidence-2026-08-deadbeef00"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- canonicalize new published article filenames as `YYYY-MM-DD-NN-title.md`
- keep existing published filenames unchanged
- enforce Zenn's 50-character slug ceiling in the generator
- keep display `title:` independent from the repository filename
- rename the corresponding publication report together with the generated article
- add filename-policy unit tests and README documentation

## Primary specification
- https://zenn.dev/zenn/articles/what-is-slug

## Verification
- `python -m compileall pipeline`
- `python -m unittest discover -s tests -v`
- `python -m pipeline.audit`
