### PR TITLE
feat: add lazy Pyodide syntax demo contract

### DIFF
--- a/.github/workflows/article-pipeline-ci.yml
+++ b/.github/workflows/article-pipeline-ci.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "articles/**"
       - "artifacts/**"
+      - "demos/**"
       - "README.md"
       - ".github/workflows/article-pipeline.yml"
       - ".github/workflows/article-pipeline-ci.yml"
@@ -20,6 +21,7 @@ on:
       - "docs/**"
       - "articles/**"
       - "artifacts/**"
+      - "demos/**"
       - "README.md"
       - ".github/workflows/article-pipeline.yml"
       - ".github/workflows/article-pipeline-ci.yml"
@@ -36,9 +38,26 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile
-        run: python -m compileall pipeline
+        run: python -m compileall pipeline demos/python-syntax-gate/syntax_gate.py
       - name: Contract tests
         run: python -m unittest discover -s tests -v
+      - name: Demo JavaScript syntax
+        run: |
+          node --check demos/_shared/pyodide-worker.mjs
+          node --check demos/python-syntax-gate/app.mjs
+      - name: Demo static route smoke
+        shell: bash
+        run: |
+          python -m http.server 8000 >/tmp/articles-demo-http.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
+          for path in \
+            demos/python-syntax-gate/ \
+            demos/python-syntax-gate/demo.json \
+            demos/python-syntax-gate/syntax_gate.py \
+            demos/_shared/pyodide-worker.mjs; do
+            curl --fail --silent --show-error "http://127.0.0.1:8000/$path" >/dev/null
+          done
       - name: Repository and privacy audit
         run: python -m pipeline.audit
       - name: Verify clean checkout

--- a/.github/workflows/article-pipeline-ci.yml
+++ b/.github/workflows/article-pipeline-ci.yml
@@ -51,8 +51,17 @@ jobs:
           python -m http.server 8000 >/tmp/articles-demo-http.log 2>&1 &
           server_pid=$!
           trap 'kill "$server_pid"' EXIT
+          for attempt in 1 2 3 4 5; do
+            if curl --fail --silent http://127.0.0.1:8000/demos/python-syntax-gate/ >/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              cat /tmp/articles-demo-http.log
+              exit 1
+            fi
+            sleep 1
+          done
           for path in \
-            demos/python-syntax-gate/ \
             demos/python-syntax-gate/demo.json \
             demos/python-syntax-gate/syntax_gate.py \
             demos/_shared/pyodide-worker.mjs; do

--- a/demos/_shared/pyodide-worker.mjs
+++ b/demos/_shared/pyodide-worker.mjs
@@ -1,0 +1,30 @@
+const PYODIDE_VERSION = "v314.0.2";
+const PYODIDE_BASE = `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`;
+
+let pyodidePromise = null;
+
+async function getPyodide(packages = []) {
+  if (!pyodidePromise) {
+    pyodidePromise = import(`${PYODIDE_BASE}pyodide.mjs`).then(({ loadPyodide }) =>
+      loadPyodide({ indexURL: PYODIDE_BASE }),
+    );
+  }
+  const pyodide = await pyodidePromise;
+  if (packages.length) {
+    await pyodide.loadPackage(packages);
+  }
+  return pyodide;
+}
+
+self.addEventListener("message", async (event) => {
+  const { id, action, source, input, packages = [] } = event.data ?? {};
+  if (action !== "run") return;
+  try {
+    const pyodide = await getPyodide(packages);
+    pyodide.globals.set("DEMO_INPUT", input ?? "");
+    const result = await pyodide.runPythonAsync(source);
+    self.postMessage({ id, ok: true, result: String(result ?? "") });
+  } catch (error) {
+    self.postMessage({ id, ok: false, error: String(error?.message ?? error) });
+  }
+});

--- a/demos/python-syntax-gate/app.mjs
+++ b/demos/python-syntax-gate/app.mjs
@@ -1,0 +1,71 @@
+const runButton = document.querySelector("#run");
+const sourceInput = document.querySelector("#source");
+const resultOutput = document.querySelector("#result");
+const fixtureSelect = document.querySelector("#fixture");
+
+let manifest = null;
+let pythonSource = null;
+let worker = null;
+let requestId = 0;
+const pending = new Map();
+
+async function loadManifest() {
+  manifest = await fetch("./demo.json", { cache: "no-store" }).then((response) => {
+    if (!response.ok) throw new Error(`manifest HTTP ${response.status}`);
+    return response.json();
+  });
+  pythonSource = await fetch(manifest.python, { cache: "no-store" }).then((response) => {
+    if (!response.ok) throw new Error(`python HTTP ${response.status}`);
+    return response.text();
+  });
+  sourceInput.value = manifest.inputs.broken;
+}
+
+function getWorker() {
+  if (worker) return worker;
+  worker = new Worker("../_shared/pyodide-worker.mjs", { type: "module" });
+  worker.addEventListener("message", (event) => {
+    const resolver = pending.get(event.data?.id);
+    if (!resolver) return;
+    pending.delete(event.data.id);
+    resolver(event.data);
+  });
+  return worker;
+}
+
+function runPython(input) {
+  const id = ++requestId;
+  const target = getWorker();
+  return new Promise((resolve) => {
+    pending.set(id, resolve);
+    target.postMessage({
+      id,
+      action: "run",
+      source: pythonSource,
+      input,
+      packages: manifest.packages,
+    });
+  });
+}
+
+fixtureSelect.addEventListener("change", () => {
+  sourceInput.value = manifest.inputs[fixtureSelect.value];
+});
+
+runButton.addEventListener("click", async () => {
+  runButton.disabled = true;
+  resultOutput.textContent = "Pythonを読み込んで実行しています…";
+  try {
+    const response = await runPython(sourceInput.value);
+    resultOutput.textContent = response.ok ? response.result : `ERROR: ${response.error}`;
+  } catch (error) {
+    resultOutput.textContent = `ERROR: ${error.message}`;
+  } finally {
+    runButton.disabled = false;
+  }
+});
+
+loadManifest().catch((error) => {
+  runButton.disabled = true;
+  resultOutput.textContent = `Demo unavailable: ${error.message}`;
+});

--- a/demos/python-syntax-gate/demo.json
+++ b/demos/python-syntax-gate/demo.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "articles.pyodide-demo.v1",
+  "title": "Python syntax gate",
+  "python": "./syntax_gate.py",
+  "packages": [],
+  "inputs": {
+    "broken": "value = (1 + 2",
+    "fixed": "value = (1 + 2)"
+  },
+  "expected": {
+    "broken_prefix": "SYNTAX_ERROR",
+    "fixed": "COMPILE_OK"
+  }
+}

--- a/demos/python-syntax-gate/index.html
+++ b/demos/python-syntax-gate/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Python Syntax Gate</title></head>
+<body>
+<main>
+<h1>Python Syntax Gate</h1>
+<p>ブラウザ内Pythonで構文確認を試すためのデモです。Pyodideは実行操作まで読み込みません。</p>
+<label>例 <select id="fixture"><option value="broken">壊れた例</option><option value="fixed">修正後</option></select></label>
+<label for="source">入力</label>
+<textarea id="source" rows="10" cols="60"></textarea>
+<button id="run" type="button">実行</button>
+<pre id="result" role="status" aria-live="polite">未実行</pre>
+</main>
+<script type="module" src="./app.mjs"></script>
+</body>
+</html>

--- a/demos/python-syntax-gate/syntax_gate.py
+++ b/demos/python-syntax-gate/syntax_gate.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+def check_source(source: str) -> str:
+    try:
+        compile(source, "<reader-input>", "exec")
+    except SyntaxError as exc:
+        line = exc.lineno or 0
+        message = exc.msg or "SyntaxError"
+        return f"SYNTAX_ERROR line={line}: {message}"
+    return "COMPILE_OK"
+
+
+check_source(DEMO_INPUT)

--- a/tests/test_pyodide_demo_contract.py
+++ b/tests/test_pyodide_demo_contract.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import runpy
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+DEMO = ROOT / "demos" / "python-syntax-gate"
+
+
+class PyodideDemoContractTests(unittest.TestCase):
+    def test_manifest_fixture_matches_python_core(self) -> None:
+        manifest = json.loads((DEMO / "demo.json").read_text(encoding="utf-8"))
+        namespace = runpy.run_path(
+            str(DEMO / "syntax_gate.py"),
+            init_globals={"DEMO_INPUT": manifest["inputs"]["fixed"]},
+        )
+        check_source = namespace["check_source"]
+        self.assertTrue(
+            check_source(manifest["inputs"]["broken"]).startswith(
+                manifest["expected"]["broken_prefix"]
+            )
+        )
+        self.assertEqual(
+            check_source(manifest["inputs"]["fixed"]),
+            manifest["expected"]["fixed"],
+        )
+
+    def test_demo_declares_no_extra_packages(self) -> None:
+        manifest = json.loads((DEMO / "demo.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["packages"], [])
+        self.assertEqual(manifest["python"], "./syntax_gate.py")
+
+    def test_worker_is_lazy_and_controller_has_no_python_formula(self) -> None:
+        worker = (ROOT / "demos" / "_shared" / "pyodide-worker.mjs").read_text(
+            encoding="utf-8"
+        )
+        controller = (DEMO / "app.mjs").read_text(encoding="utf-8")
+        self.assertIn('action !== "run"', worker)
+        self.assertIn("getPyodide(packages)", worker)
+        self.assertNotIn("pyodide.mjs", controller)
+        self.assertIn('new Worker("../_shared/pyodide-worker.mjs", { type: "module" })', controller)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the technical foundation for Issue #31 without modifying any Zenn article or claiming public E2E completion.

- adds one shared module Web Worker for Pyodide
- loads Pyodide only after an explicit run request
- adds a stdlib-only Python syntax-gate fixture with manifest-declared inputs/expected output/packages
- keeps Python logic in Python; JS only handles manifest loading, worker messaging, and display
- adds contract tests, JS syntax checks, static route smoke, and clean-checkout coverage for `demos/**`

Primary references:
- https://zenn.dev/zenn/articles/markdown-guide
- https://pyodide.org/en/stable/usage/webworker.html

Issue #31 remains open until a public static URL is deployed and worker execution is verified E2E; only after that should an article link/card be added.