### PR TITLE
記事候補を146公開repoの母集団調査から再構成

### DIFF
--- a/artifacts/candidates/2026-08/2026-08-13-chatgpt-multiproject-autonomy.md
+++ b/artifacts/candidates/2026-08/2026-08-13-chatgpt-multiproject-autonomy.md
@@ -30,7 +30,7 @@ GitHubのプロフィールには、公開リポジトリが146個ある。
 
 Repository Searchでは、通常の公開repo検索で123件、`fork:only` で23件が確認できる。
 
-- non-fork側: https://api.github.com/search/repositories?q=user%3AKAFKA2306+is%3Apublic
+- non-fork側: https://api.github.com/search/repositories?q=user%3AKAFKA2306+is%3Apublic+fork%3Afalse
 - forkのみ: https://api.github.com/search/repositories?q=user%3AKAFKA2306+fork%3Aonly
 
 つまり、最初に少なくとも次を分けないといけない。
@@ -60,6 +60,7 @@ forkは無価値という意味ではない。
 4. 各テーマ群から複数repoを確認する
 5. 詳細な設計を本文で主張するrepoはREADMEまで読む
 6. 作成日と現在READMEの設計を混同しない
+7. どのテーマにも安全に分類できないrepoを捨てず、全件inventoryに残す
 ```
 
 以下の長いrepo名一覧は、**公開repository metadata上に存在するテーマの広がりを示すインベントリ**である。各repoの内部設計を名前だけから断定するためのものではない。
@@ -354,7 +355,144 @@ fork側には `DeepCode`、`claude-code`、`openclaw`、`financial-services-plug
 
 現在の制御ループが機能するのは、金融系のprovenance、VR系のartifact validation、ゲーム系のCI再現性、情報系のcanonical/projection分離、生活系のprivacy boundaryなど、**他系統で先に必要になった契約が持ち込まれているから**である。
 
-## 23 forksは全件、別の集合として扱う
+## 付録A：123 non-fork public repositories 全件
+
+ここまでの系統分類に無理に押し込まなかったrepoも含め、GitHub Search APIの `user:KAFKA2306 is:public fork:false` で得た123件を全て残す。
+
+<details>
+<summary>123件を表示</summary>
+
+```text
+anime
+vrpoker
+2510youtuber
+books
+nlm
+yt4
+mitsuikaggle
+furutsatotax
+investor2
+know
+vrc_cast_event_calender
+BestEthernet
+prompt-vault
+CrewTrade
+DominionDeckDrawSimlator
+vrmine
+image2outfit
+WealthAudit
+hitaiall
+magicaltexture
+alpha
+patent
+salary
+agent-resources
+VRPhotoJourney
+Swiss-Tournament-Manager
+kafin3
+finAnalist
+us-swing-strategy-bi-pages
+expense2
+Year2035
+trahist
+nk225seasonality
+molecularshader
+vrcrelator
+bodogenomikata2
+articles
+readable-github
+vrcviewer
+gennote
+rule-scribe-games
+kafka
+cedar-pollen-bi
+vrcgimmicknetwork
+shaderGPT
+vmatch2
+mastramcp
+fin_age_cfd
+pal-atlas
+dancer
+factory
+jhr
+KAFKA2306
+x
+vrcplat
+irr
+com
+SecureVCC
+hitaiou
+RooBrawser
+chat-code-architect-ai2
+m2
+backend
+vrc-pilot-test
+oil
+semiconductor-earnings-model
+chat-code-architect-ai
+skew
+VeilVoice
+AutoPhotogrammetry
+kakeibo
+photoprism
+fx
+UnityMCPforUbuntu22.04
+NVII
+abestudy
+launcher
+aboutkafka
+furuyoni
+game-library-dashboard
+bpyutils
+auto-invest
+summer
+vlogrs
+PictureChangerTools
+detective
+fit
+adaptive_wear_generator_pro
+investor
+kindle2
+pamiq-poker
+2511youtuber
+nonfarmpayroll
+kafin2
+CantStopExpressLearn
+blendshapedeformer
+vmatching
+option
+cast_event_cal
+boothitemmanager
+kimeraassist
+uranium
+bonus
+dmovie2511
+VRChat-bolt
+boardgamelist
+yt3
+vlog
+finBI
+tradermade_cfd
+mstr
+kindle
+ytmanager
+financeLLM
+vtttv
+econalert
+333
+marvelousdesigner
+mj
+BMAX
+hf-cache-hub
+etf
+travel
+```
+
+</details>
+
+この一覧の存在自体が重要で、たとえば `factory`、`jhr`、`KAFKA2306`、`x`、`com`、`SecureVCC`、`hitaiou`、`m2`、`333`、`BMAX`、`kimeraassist` のように、名前だけでは安全に一つの系統へ押し込めないrepoも落とさず残せる。
+
+## 付録B：23 forks 全件
 
 GitHub Searchで `fork:only` を指定して得た23件は次の通りだった。
 

--- a/artifacts/candidates/2026-08/2026-08-13-chatgpt-multiproject-autonomy.md
+++ b/artifacts/candidates/2026-08/2026-08-13-chatgpt-multiproject-autonomy.md
@@ -1,711 +1,590 @@
 ---
-title: "146リポジトリは突然こうならなかった。2023年からの個人開発が、ChatGPTのマルチプロジェクト制御になるまで"
+title: "146公開リポジトリを母集団にして見直した。個人開発がChatGPTのマルチプロジェクト制御へ収束するまで"
 emoji: "🛰️"
 type: "tech"
 topics: ["chatgpt", "github", "automation", "githubactions"]
 published: false
 ---
 
-GitHubに公開リポジトリが146個ある。
+GitHubのプロフィールには、公開リポジトリが146個ある。
 
-2026年7月13日から8月13日までをGitHub Search APIで再確認すると、`KAFKA2306` アカウントではIssueが385件、PRが805件作成され、680件のPRが同期間内にmergeされていました。
+前稿では、その中から `finBI`、`AutoPhotogrammetry`、`mastramcp`、VRChat Event Calendar、`daily-arXiv-ai-enhanced` などを選び、2023年から2026年までの「自動化の成熟史」として並べた。
 
-- GitHub profile: https://api.github.com/users/KAFKA2306
+しかし、この見方には大きな問題があった。
+
+**146個を先に母集団として調べたのではなく、説明しやすいrepoを先に選び、その後で歴史を作っていた。**
+
+実際にrepository一覧を広く取り直すと、金融、VR/3D、ゲーム、情報収集、動画生成、個人データ、Web UI、MCP/agent基盤など、かなり違う系統が並行して存在していた。
+
+したがって、この記事では一本道の「進化史」をやめる。
+
+**複数の開発系統が別々に自動化・検証・公開・権限分離を獲得し、2026年に一部がGitHubを共通状態として読む制御ループへ収束した**、という形で整理し直す。
+
+## まず146 repoを分解する
+
+2026年8月13日時点のGitHub profile APIは `public_repos: 146` を返す。
+
+- Profile: https://api.github.com/users/KAFKA2306
+- 公開repo一覧 1ページ目: https://api.github.com/users/KAFKA2306/repos?per_page=100&page=1&sort=created&direction=asc
+- 公開repo一覧 2ページ目: https://api.github.com/users/KAFKA2306/repos?per_page=100&page=2&sort=created&direction=asc
+
+Repository Searchでは、通常の公開repo検索で123件、`fork:only` で23件が確認できる。
+
+- non-fork側: https://api.github.com/search/repositories?q=user%3AKAFKA2306+is%3Apublic
+- forkのみ: https://api.github.com/search/repositories?q=user%3AKAFKA2306+fork%3Aonly
+
+つまり、最初に少なくとも次を分けないといけない。
+
+```text
+146 public repositories
+├─ 123 non-fork repositories
+└─ 23 forks
+```
+
+forkは無価値という意味ではない。
+
+既存OSSを評価・改造・実験するための重要なrepoもある。
+
+ただし、**forkを「自分がゼロから構築したシステムの歴史」と同じ証拠として数えるのは不適切**なので、以降の自作系統とは分離して扱う。
+
+また、古いrepoのREADMEは2026年の横断監査で更新されたものがある。repoの作成日は「そのテーマがGitHub上に現れた時点」の証拠として使い、現在READMEの高度な設計が作成当初から存在したとは主張しない。
+
+### 今回の採用ルール
+
+前稿の失敗を繰り返さないため、今回は次の順序で見る。
+
+```text
+1. 146公開repoを母集団として取得する
+2. 23 forks と 123 non-forks を先に分離する
+3. repo名・metadataから広いテーマ群を作る
+4. 各テーマ群から複数repoを確認する
+5. 詳細な設計を本文で主張するrepoはREADMEまで読む
+6. 作成日と現在READMEの設計を混同しない
+```
+
+以下の長いrepo名一覧は、**公開repository metadata上に存在するテーマの広がりを示すインベントリ**である。各repoの内部設計を名前だけから断定するためのものではない。
+
+一方、「このrepoでは何を検証している」「このpipelineは何段階である」といった具体的な設計上の主張は、READMEや実装を実際に確認したものに限定する。
+
+## 一番古い時期から、すでにテーマは一つではなかった
+
+最初期の公開repoには、ゲーム学習の `CantStopExpressLearn`、VR/Unity系のfork `BoneRenamer`、金融系の `finBI` がある。
+
+ここだけでも、
+
+```text
+ゲーム
+VR / Unity
+金融
+```
+
+という別々の方向が同時に現れている。
+
+だから、
+
+```text
+2023 = app
+2024 = pipeline
+2025 = agent
+2026 = orchestration
+```
+
+のように年ごとに一つの成熟段階を割り当てるのは、実際のrepository群を圧縮しすぎていた。
+
+より正確なのは、**複数の系統がそれぞれの問題に応じて別の能力を獲得した**と見ることだ。
+
+## 系統1：金融・市場・投資研究
+
+金融系は `finBI` だけではない。
+
+公開non-fork repoには、少なくとも次のような系統がある。
+
+```text
+finBI
+etf
+finAnalist
+kafin2
+kafin3
+fx
+econalert
+mstr
+oil
+uranium
+auto-invest
+financeLLM
+option
+fin_age_cfd
+tradermade_cfd
+nk225seasonality
+nonfarmpayroll
+investor
+investor2
+semiconductor-earnings-model
+WealthAudit
+CrewTrade
+us-swing-strategy-bi-pages
+skew
+irr
+```
+
+これらは同じ「投資アプリ」のコピーではない。
+
+- `auto-invest` は市場価格からKelly基準、ボラティリティ、Expected Shortfallなどを計算し、入力不足や品質不良時には確信的な数値を出さない。
+- `semiconductor-earnings-model` は企業開示、規制開示、業界KPI、市場観測を別の値種別として保持し、JSON / SQLite / Webまで生成する。
+- `finBI` は古いUI試作を縮約し、計算とpoint-in-time provenanceを検証する方向へ再構成された。
+
+- https://github.com/KAFKA2306/auto-invest
+- https://github.com/KAFKA2306/semiconductor-earnings-model
+- https://github.com/KAFKA2306/finBI
+
+この系統で発達したのは、主に次の能力だった。
+
+```text
+データ取得
+→ 単位・期間・観測時点の固定
+→ 派生計算
+→ 出典と計算系譜
+→ fail-closedな品質判定
+→ API / DB / Pagesへの投影
+```
+
+つまり金融系から得た重要な要素は「AI」より、**観測値・推定値・シナリオ・判断を混ぜないこと**だった。
+
+## 系統2：VRChat・Unity・3D制作
+
+別の巨大な系統がVR/3Dである。
+
+```text
+VRPhotoJourney
+AutoPhotogrammetry
+vrcviewer
+vrcgimmicknetwork
+VRChat-bolt
+adaptive_wear_generator_pro
+blendshapedeformer
+marvelousdesigner
+bpyutils
+vmatching
+vmatch2
+UnityMCPforUbuntu22.04
+boothitemmanager
+fit
+image2outfit
+vrmine
+vrcplat
+magicaltexture
+molecularshader
+vrcrelator
+dancer
+vrc-pilot-test
+shaderGPT
+PictureChangerTools
+```
+
+この系統では、単なるWeb APIとは違う問題が起きる。
+
+FBX、BlendShape、bone、material、Unity asset、Prefab、Modular Avatar、外部3Dツールなど、**状態を持つ制作環境とファイルの整合性**が問題になる。
+
+`AutoPhotogrammetry` の現在READMEでは、実写画像の収集元とSHA-256を保存し、特徴抽出・クラスタリング・選別・外部photogrammetry実行を分離している。
+
+`boothitemmanager` は、BOOTHの商品情報について販売者が明示した事実とシステムの派生タグを分け、根拠不足を `UNKNOWN` / `quarantine` に落とす。
+
+- https://github.com/KAFKA2306/AutoPhotogrammetry
+- https://github.com/KAFKA2306/boothitemmanager
+
+この系統で育ったのは、
+
+```text
+sourceを壊さない
+identityを曖昧にしない
+生成物を保存する
+実環境の状態を再取得する
+見た目と内部参照の両方を検証する
+```
+
+という考え方だった。
+
+後の `source immutable`、artifact manifest、visual evidence、build / upload gateは、この問題群と相性がよい。
+
+## 系統3：ゲーム・ルール・シミュレーション
+
+ゲーム系も古くから独立して存在する。
+
+```text
+CantStopExpressLearn
+DominionDeckDrawSimlator
+Swiss-Tournament-Manager
+boardgamelist
+rule-scribe-games
+pamiq-poker
+vrpoker
+furuyoni
+game-library-dashboard
+mj
+bodogenomikata2
+```
+
+`Swiss-Tournament-Manager` はReact frontendとExpress/Mongoose backendを分け、clean checkoutから `npm ci`、test、build、DB不要のstartup smokeまでCI契約にしている。
+
+`rule-scribe-games` はボードゲーム情報を検索・構造化するWebサービスで、AIによるルール生成だけでなく、cache、deploy、data fix、search verificationなどの運用workflowsも持つ。
+
+- https://github.com/KAFKA2306/Swiss-Tournament-Manager
+- https://github.com/KAFKA2306/rule-scribe-games
+
+ここから見えるのは、**AIを使うかどうかに関係なく、clean install・再現可能build・外部依存を切ったsmoke testが自動化の土台になる**ということだ。
+
+## 系統4：情報収集・知識・検索・出版
+
+情報を集めて、人間が読める形へ変える系統もある。
+
+```text
+articles
+kindle
+kindle2
+gennote
+readable-github
+know
+nlm
+books
+cast_event_cal
+vrc_cast_event_calender
+RooBrawser
+detective
+```
+
+`daily-arXiv-ai-enhanced` と `notebooklm-py` はforkを起点にした実験なので、自作repoとは別枠で扱う。
+
+`know` は開発・AI・金融・生活で再利用する知識を集め、観測、推定、主張、test、evidence、decisionを共通語彙へ整理する。
+
+VRChat Event Calendarでは `cast_event_cal` を正本、`vrc_cast_event_calender` を配信projectionとして分け、source commit、snapshot、hash、production確認を別段階にしている。
+
+- https://github.com/KAFKA2306/know
+- https://github.com/KAFKA2306/cast_event_cal
+- https://github.com/KAFKA2306/vrc_cast_event_calender
+
+この系統の中心は、**生成することより、原情報・派生情報・公開物の境界を保つこと**だった。
+
+## 系統5：動画・音声・生成コンテンツ
+
+前稿ではほぼ抜けていたが、生成・公開系にも複数repoがある。
+
+```text
+dmovie2511
+vlog
+vlogrs
+ytmanager
+yt3
+yt4
+2510youtuber
+2511youtuber
+anime
+VeilVoice
+vtttv
+```
+
+`kling` と `ComfyUI-KLingAI-API` は既存OSSからのforkなので、自作側の系統には数えない。
+
+`2511youtuber` は、ニュース候補取得から台本、VOICEVOX音声、字幕、動画、metadata、YouTube公開までを一つのpipelineにしている。
+
+一方 `vlog` は、VRChatの音声・写真・会話を単純にAI日記へ変換するのではなく、Evidence → Human Memory → Narrative Artifact → Public Projectionという層へ分けている。
+
+- https://github.com/KAFKA2306/2511youtuber
+- https://github.com/KAFKA2306/vlog
+
+同じ「生成AI」でも、前者は**media production pipeline**、後者は**memory / privacy / publication boundary**が中心で、設計課題はかなり違う。
+
+## 系統6：生活・個人データ・日常ツール
+
+生活系も、金融投資とは分けた方がよい。
+
+```text
+salary
+kakeibo
+furutsatotax
+bonus
+aboutkafka
+BestEthernet
+travel
+expense2
+cedar-pollen-bi
+Year2035
+```
+
+`kakeibo` は銀行・カード明細を扱うため、実データ、ログ、認証情報をGit外へ隔離し、privacy guard、local-only review、入力SHA-256、決定論的monthly snapshotまで持つ。
+
+- https://github.com/KAFKA2306/kakeibo
+
+ここでは「自動化を増やす」より先に、
+
+```text
+何をGitへ出さないか
+何を外部へ送らないか
+何を匿名化するか
+何を再現できる形で残すか
+```
+
+が重要になる。
+
+この系統を落とすと、マルチプロジェクト自律化を単なる開発速度の話に誤読してしまう。
+
+## 系統7：MCP・agent・開発基盤
+
+AIそのものを扱うnon-fork repoも複数ある。
+
+```text
+mastramcp
+chat-code-architect-ai
+chat-code-architect-ai2
+backend
+hf-cache-hub
+agent-resources
+prompt-vault
+launcher
+```
+
+fork側には `DeepCode`、`claude-code`、`openclaw`、`financial-services-plugins` など、既存agentic / domain基盤を評価するために取り込んだrepoもある。
+
+`mastramcp` ではWeb検索、filesystem、package管理、GitHub操作を役割別に分け、読み取りと書き込み、最小権限、人間承認の境界を検討していた。
+
+- https://github.com/KAFKA2306/mastramcp
+
+この系統だけを見ると「AI agentが進化して今の運用になった」と言いたくなる。
+
+しかし全repoを横断すると、それは一部にすぎない。
+
+現在の制御ループが機能するのは、金融系のprovenance、VR系のartifact validation、ゲーム系のCI再現性、情報系のcanonical/projection分離、生活系のprivacy boundaryなど、**他系統で先に必要になった契約が持ち込まれているから**である。
+
+## 23 forksは全件、別の集合として扱う
+
+GitHub Searchで `fork:only` を指定して得た23件は次の通りだった。
+
+```text
+AntennaPod
+BoneRenamer
+Basis
+unity-mcp
+unity-agent
+rakuten_rss
+claude-code
+DeepCode
+UnityMCP-VRC
+Unique3D
+TexasSolver
+openclaw
+KillFrenzyAvatarText
+daily-arXiv-ai-enhanced
+jquants-api-quick-start
+ComfyUI-KLingAI-API
+koodo-reader
+open-fitter
+expense
+notebooklm-py
+TradingView-Screener
+kling
+financial-services-plugins
+```
+
+この23件は、自作repoの数に混ぜて成熟度の証拠にしない。
+
+一方で、forkには別の意味がある。
+
+```text
+既存OSSを読む
+→ 手元で変更する
+→ 自分の用途へ適合するか検証する
+→ 必要なら別の自作repoへ考え方を持ち帰る
+```
+
+この経路は「ゼロから作った歴史」ではなく、**外部OSSを実験台として採用・評価した歴史**として別枠に置く方が正確だ。
+
+この分離をしたことで、前稿で自作側へ誤って入れていた `Unique3D`、`jquants-api-quick-start`、`kling`、`financial-services-plugins`、`notebooklm-py`、`ComfyUI-KLingAI-API`、`open-fitter` なども除外できた。
+
+## ここまで見て初めて、2026年の横断制御を説明できる
+
+2026年7月13日から8月13日までをGitHub Search APIで確認すると、`KAFKA2306` アカウントではIssueが385件、PRが805件作成され、680件のPRが同期間内にmergeされている。
+
 - Issues: https://api.github.com/search/issues?q=author%3AKAFKA2306+is%3Aissue+created%3A2026-07-13..2026-08-13
 - Pull Requests: https://api.github.com/search/issues?q=author%3AKAFKA2306+is%3Apr+created%3A2026-07-13..2026-08-13
 - Merged Pull Requests: https://api.github.com/search/issues?q=author%3AKAFKA2306+is%3Apr+is%3Amerged+merged%3A2026-07-13..2026-08-13
 
-数字だけを見ると、この1か月で突然、大量の開発をChatGPTへ渡し始めたように見えます。
+この数字は大きいが、重要なのは件数そのものではない。
 
-でも、GitHubの履歴を古い順に見直すと、実態は違いました。
-
-2023年には金融分析のrepoがあり、2024年には画像収集・選別から外部3D処理までをつなぐ試作があり、2025年にはMCPで役割を分けたエージェント構成、イベント収集・配信、arXivの定期取得とAI要約がありました。
-
-2026年夏に起きたのは、まったく新しいことではありません。
-
-**それまでrepoごとに作ってきた自動化が、GitHubを共通状態として読み、ChatGPTが「次に何を進めるか」まで選ぶ制御ループへ合流した。**
-
-この記事では、直近1か月の派手な件数だけではなく、そこへ至る古い試行も含めて整理します。
-
-> 注記: 古いrepoのREADMEは2026年の監査で更新されているものがあります。したがって、repoの`created_at`は「そのテーマに取り組み始めた時期」の証拠として、現在のREADMEは「現在どのような設計へ整理されているか」の証拠として扱います。現在のREADMEに書かれた設計が、作成当初から同じ形だったとは主張しません。
-
-## まず全体像：3年で変わった「自動化の単位」
-
-私のGitHub上の変化を一番短く書くと、こうなります。
-
-| 時期 | 代表例 | 自動化の単位 | 人間に残っていた仕事 |
-|---|---|---|---|
-| 2023 | `finBI` | 1つのアプリ | 実行、修正、次の作業選択 |
-| 2024 | `AutoPhotogrammetry` | 1本の処理パイプライン | 入力選択、失敗判断、外部実行管理 |
-| 2025春 | `mastramcp` | 役割別エージェント / tool | 権限境界、書込承認、役割間の調整 |
-| 2025春〜 | VRChat Event Calendar | 収集→検証→配信 | 情報源監査、分類判断、公開判断 |
-| 2025秋〜 | `daily-arXiv-ai-enhanced` | 定期取得→AI生成→公開 | テーマ設定、品質基準、例外判断 |
-| 2026夏 | `agent-resources` ほか | 複数repoの状態遷移 | 目的、不可逆判断、公開承認 |
-
-重要なのは、使うAIモデルの名前より、**人間が毎回やっていた調整仕事がどの順番でコードや状態へ移ったか**です。
-
-## 2023：まずは「1つのrepoで価値を出す」段階だった
-
-`finBI` は2023年10月25日に作成されています。
-
-- repository: https://github.com/KAFKA2306/finBI
-- GitHub API: https://api.github.com/repos/KAFKA2306/finBI
-
-2026年の現在は、Pythonの金融計算を正本にして静的Webから呼び出し、provenanceまで検証する小さなBIへ作り直しています。
-
-しかし、このrepoが古くから存在すること自体が重要です。
-
-当時の自動化の単位は、基本的に**1つのアプリ**でした。
+以前は、各repoの中で
 
 ```text
-データを取る
-→ 計算する
-→ 画面に出す
+取得する
+計算する
+生成する
+検証する
+公開する
 ```
 
-それぞれのrepoは独立した道具です。
+を自動化していた。
 
-この段階では「この処理をコードにする」はできても、
-
-```text
-どのrepoを直す？
-どこまで終わった？
-次に何をする？
-```
-
-は人間が決めます。
-
-今のマルチプロジェクト制御から見ると原始的ですが、ここが出発点でした。
-
-## 2024：アプリから「処理の鎖」へ広がった
-
-`AutoPhotogrammetry` は2024年4月11日に作成されています。
-
-- repository: https://github.com/KAFKA2306/AutoPhotogrammetry
-- GitHub API: https://api.github.com/repos/KAFKA2306/AutoPhotogrammetry
-- current README: https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/README.md
-
-現在のREADMEでは、明示されたWebページから実写画像を収集し、出典とSHA-256を保存し、特徴量を計算し、クラスタリング・選別を行い、必要ならMeshroom / VisualSFM / COLMAPの外部実行へ渡す構成になっています。
-
-ここで単位が、1画面のアプリから**複数stageを持つpipeline**へ変わりました。
+現在はそこに、
 
 ```text
-collect
-→ validate
-→ deduplicate
-→ feature extraction
-→ cluster
-→ select
-→ external photogrammetry
-→ manifest / logs
-```
-
-この形になると、「最後のファイルができた」だけでは成功とは言えません。
-
-入力は正しかったか。途中で落ちていないか。どの画像を使ったか。外部プロセスは本当に成功したか。元データを壊していないか。
-
-後に何度も出てくる**manifest、hash、非破壊処理、stageごとの検証**の発想は、マルチrepo管理より前から必要になっていました。
-
-## 2025春：MCPで「AIに何を触らせるか」を分け始めた
-
-`mastramcp` は2025年3月26日に作成されています。
-
-- repository: https://github.com/KAFKA2306/mastramcp
-- GitHub API: https://api.github.com/repos/KAFKA2306/mastramcp
-- current README: https://github.com/KAFKA2306/mastramcp/blob/main/README.md
-
-現在のREADMEには、MastraとModel Context Protocol（MCP）を使い、Web検索、ファイル操作、パッケージ管理、GitHub操作を役割別エージェントへ分ける設計意図が残っています。
-
-```text
-webSearchAssistant
-fileSystemNavigator
-packageInstallationManager
-githubRepositoryManager
-```
-
-さらに、読み取りと書き込みを分け、破壊的操作を自動実行しない、という境界も明示されています。
-
-ここで問題は「AIがコードを書けるか」から、
-
-**どのAIに、どのtoolを、どの権限で渡すか**
-
-へ移りました。
-
-これは現在の運用にもそのまま残っています。
-
-自律化を強くするには、権限を広げるのではなく、むしろ
-
-```text
-読める範囲
-書ける範囲
-実行できる操作
-人間承認が必要な操作
-```
-
-を狭く定義する必要があります。
-
-## 2025春：収集系では「作る場所」と「配る場所」を分ける必要が出た
-
-`vrc_cast_event_calender` は2025年4月15日に作成されています。
-
-- repository: https://github.com/KAFKA2306/vrc_cast_event_calender
-- GitHub API: https://api.github.com/repos/KAFKA2306/vrc_cast_event_calender
-- current README: https://github.com/KAFKA2306/vrc_cast_event_calender/blob/main/README.md
-
-現在は `cast_event_cal` を正本として、`vrc_cast_event_calender` は検証済みsnapshotを受け取って配信するprojection側に整理されています。
-
-現在の契約では、source commit、snapshot digest、artifactごとのSHA-256、production HTTP確認まで追跡します。
-
-ここで学んだ問題は、データ系では特に重要でした。
-
-```text
-収集できた
-!=
-分類できた
-!=
-正しいsnapshotができた
-!=
-deployできた
-!=
-利用者が正しい内容を見られた
-```
-
-「成功」を一語で扱わない。
-
-この考え方は後に、CI successとproduction successを分ける設計、tool successとproduct successを分ける設計へつながります。
-
-## 2025秋：人が実行しなくても回る定期AIパイプラインになった
-
-`daily-arXiv-ai-enhanced` は2025年11月18日にforkとして作成されています。
-
-- repository: https://github.com/KAFKA2306/daily-arXiv-ai-enhanced
-- GitHub API: https://api.github.com/repos/KAFKA2306/daily-arXiv-ai-enhanced
-- current README: https://github.com/KAFKA2306/daily-arXiv-ai-enhanced/blob/main/README.md
-
-現在のREADMEでは、arXiv公開レコードを定期取得し、LLMで日本語要約を生成し、JSONL / Markdown / 静的Webを作り、GitHub Pagesへ公開する流れが定義されています。
-
-```text
-arXivを取得
-→ ID / version / author / dateを検証
-→ 重複検査
-→ LLM要約
-→ 原文と生成文を分離保存
-→ 静的ページ生成
-→ link / content検証
-→ Pages公開
-```
-
-必要なprovenanceが欠ける成果物は公開しない、というfail-closedの考え方も現在の設計に入っています。
-
-この段階で初めて、かなり明確に
-
-**「人がボタンを押す」のではなく、時間が来れば収集・生成・検証・公開まで進む**
-
-という運用になります。
-
-ただし、まだ自律化の対象は1つのpipelineです。
-
-「今日はどのrepoを改善すべきか」までは決めません。
-
-## 2026夏：自動化の対象が「repoの中」から「repo間」へ出た
-
-2026年7月13日から8月13日までの約1か月で、変化が一段進みました。
-
-ChatGPTとの会話を、個々のrepoに指示を出す場所ではなく、**複数プロジェクトの状態遷移を制御する場所**として使うようになりました。
-
-ここで初めて、過去の各系統が一つに合流します。
-
-```text
-2023: appを作る
-2024: pipelineを作る
-2025: tool / agentを分ける
-2025: 定期実行する
-2025: provenanceを残す
-2026: 複数repoの状態を読む
-2026: 次の1件を選ぶ
-2026: 完了証拠まで確認して次へ進む
-```
-
-最近の件数は、この最後の段階が高速で回った結果です。
-
-## 最初の失敗：repoごとにAIへお願いすると、管理仕事が増える
-
-対象が少ないうちは、次で十分です。
-
-```text
-repo Aを直す
-repo Bを調べる
-repo CにIssueを作る
-repo Dをdeployする
-```
-
-しかし対象が増えると、人間側に別の仕事が発生します。
-
-```text
-次はどのrepoを見る？
+どのrepoが止まっているかを見る
 ↓
-前回どこまで終わった？
+次に進められる候補を選ぶ
 ↓
-PRは残っていない？
+Issueの完了条件を読む
 ↓
-CI成功はdeploy成功まで含む？
+実装・検証する
 ↓
-Issueをcloseしてよい？
+PR / mergeする
 ↓
-似た作業を別repoでまたやっていない？
+productionを確認する
+↓
+残骸を片付ける
+↓
+もう一度全体を見る
 ```
 
-つまりAIに実装を渡しても、**仕事の選択と完了判定が人間に残る**。
+という**repo間の制御**が加わった。
 
-ここを消さない限り、プロジェクト数が増えるほど人間がオーケストレーターになります。
+## GitHubを共通状態にした
 
-## GitHubを「記憶」ではなく状態機械にした
-
-そこで会話の内容をGitHub上の明示的な状態へ落とすようにしました。
+複数repoで共通して使える単位は、最終的にGitHub上へ寄っていった。
 
 ```text
 Issue
-  = 何を変えるか + Acceptance Criteria
+  = 変更要求 + Acceptance Criteria
 
 Pull Request
   = 実装候補 + 差分
 
 GitHub Actions
-  = 機械検証の証拠
+  = 機械検証
 
-main / production
-  = 正準状態
+main
+  = repositoryの正準状態
+
+Pages / production
+  = 利用者が観測する成果物
 ```
 
-重要なのは、ChatGPTが「終わったと思う」ことを完了条件にしないことです。
+中央管理用の `agent-resources` では、repository、Issue / PR、Actionsを集め、状態を機械可読なJSONへ落とす方向へ進めている。
 
-中央管理用の `agent-resources` では、ダッシュボードを一気に作らず、Schema、公開対象設定、collector、lane判定、canonical JSON、UI、QAへ小さく分解しました。
+- https://github.com/KAFKA2306/agent-resources
 
-- Schema: https://github.com/KAFKA2306/agent-resources/issues/3
-- public repo config: https://github.com/KAFKA2306/agent-resources/issues/4
-- repository collector: https://github.com/KAFKA2306/agent-resources/issues/5
-- Issue / PR collector: https://github.com/KAFKA2306/agent-resources/issues/6
-- Actions collector: https://github.com/KAFKA2306/agent-resources/issues/7
-- lane logic: https://github.com/KAFKA2306/agent-resources/issues/8
-- canonical dashboard JSON: https://github.com/KAFKA2306/agent-resources/issues/9
-- QA: https://github.com/KAFKA2306/agent-resources/issues/19
+ここで大事なのは、ChatGPTが146個のrepoを全部「覚える」ことではない。
 
-見た目より先にデータ構造を固定した理由は単純です。
+**各repoが自分の状態・完了条件・証拠をGitHubへ出し、横断側はそれを読むだけにすること**だ。
 
-**AIが次の行動を選ぶには、プロジェクトの状態が機械可読でなければならない。**
+## 4状態へ圧縮する理由
 
-## 状態を4つまで減らした
+生のGitHub状態は多い。
 
-複数repoを横断すると、GitHubの生の状態は多すぎます。
+Issueのopen / closed、PRのdraft / open / merged、workflowのqueued / in_progress / completed、conclusionのsuccess / failure / cancelledなどを、そのまま横断制御へ使うと複雑になる。
 
-Issueのopen/closed、PRのdraft/open/merged、workflowのqueued/in_progress/completed、conclusionのsuccess/failure/cancelledなどを、そのまま人間へ見せても次の行動は決まりません。
-
-そこで中央ダッシュボードでは、最終的に4つへ圧縮しました。
+そこで中央側では、最終的な行動へつながる状態へ圧縮する。
 
 ```text
-working  = AIやworkflowが進められる
-waiting  = 人間判断・外部依存待ち
-done     = 完了条件まで証拠がある
-failed   = 失敗または要確認
+working  = 機械が次へ進められる
+waiting  = 人間判断または外部依存待ち
+done     = 完了証拠がある
+failed   = 失敗または再確認が必要
 ```
 
-さらに `laneReason` を持たせ、なぜ止まっているかを機械が説明できるようにします。
-
-すると次の巡回で、ChatGPTはチャット履歴を全部思い出す必要がありません。
-
-現在のGitHub状態を読み、`working` の中から次の候補を選び、`waiting` は人間へ返せます。
-
-## 自律化したのは「作業」より「次を決めるループ」だった
-
-現在の制御ループは、だいたい次の形です。
+ただし、この4状態が成立するのは、各repo側ですでに
 
 ```text
-全体状態を監査
-↓
-候補を比較
-↓
-今もっとも価値の高い1件を選ぶ
-↓
-Issueの完了条件を読む
-↓
-実装
-↓
-テスト / CI
-↓
-PR / merge
-↓
-公開物・本番を確認
-↓
-branch / PR / 一時ファイルをcleanup
-↓
-次の状態を再取得
+何を成功とするか
+何を公開してよいか
+何を証拠として残すか
+何がUNKNOWNか
+どこで停止するか
 ```
 
-ポイントは「AIに好きに作らせる」ことではありません。
+を持っているからである。
 
-**選択肢を広く持たせる一方、Doneの条件を狭くする**ことです。
+## 一本の成熟史ではなく、「契約の合流」だった
 
-## 最近の例は「新しい思想」ではなく、古い思想の横展開だった
-
-直近の `Prompt Vault`、`finBI`、`investor2` は重要ですが、記事全体の主役ではありません。
-
-それぞれ、過去から続くパターンの現在形として見る方が分かりやすいです。
-
-### Prompt Vault：manifestとhashをrepo間へ拡張
-
-共有Asset Registryでは、source SHA-256、source commit、destination SHA-256を固定し、consumer側のbuildと公開URLまで確認します。
-
-- Asset Registry: https://github.com/KAFKA2306/prompt-vault/issues/55
-- consumer inventory / migration: https://github.com/KAFKA2306/prompt-vault/issues/57
-- first consumer `travel`: https://github.com/KAFKA2306/travel/issues/20
-
-これは2024年のpipelineでも使っていた「入力・出力・manifestを分ける」考え方を、repo間へ広げたものです。
-
-### finBI：古いrepoを自動化しやすい状態数へ縮約
-
-2023年からある `finBI` は、2026年に古いStreamlit試作を延命せず、公開Web runtimeを4ファイルまで縮約しました。
-
-- redesign: https://github.com/KAFKA2306/finBI/issues/8
-- legacy reduction: https://github.com/KAFKA2306/finBI/issues/6
-
-ここでの原則は、複雑なものをそのままAIへ渡さないことです。
-
-**状態数を減らしてから自動化する。**
-
-### investor2：人間が残る境界を固定
-
-投資研究の `investor2` では、分析から自動売買へ進ませず、判断直前の状態をimmutableなDecision Snapshotとして固定します。
-
-- Decision Snapshot: https://github.com/KAFKA2306/investor2/issues/34
-- Hypothesis Lab: https://github.com/KAFKA2306/investor2/issues/35
-
-自律化とは、人間を消すことではありません。
-
-**機械的に判定できる作業を機械へ寄せ、価値判断と不可逆判断を人間へ残すこと**です。
-
-## 「取得できた」と「正しい」を最後まで分ける
-
-AI運用で危険なのは、tool callやCIが成功すると、それを成果物の正しさまで拡大解釈しやすいことです。
-
-`finBI` では、snapshotの `retrieved_at` と、その時点ではまだ利用できなかったFRED観測値が共存するpoint-in-time不整合が実際に見つかりました。
-
-- issue: https://github.com/KAFKA2306/finBI/issues/10
-- fix PR: https://github.com/KAFKA2306/finBI/pull/13
-
-このとき必要だったのは、単純な日付比較ではなく、その観測値がsource側でいつ利用可能になったかというavailability / vintageの検証でした。
-
-自律化するほど、次を別物として扱う必要があります。
+146 repoを広く見ると、最終的な見方はこう変わった。
 
 ```text
-tool success != product success
-CI success != production success
-file exists != verified artifact
-HTTP 200 != correct content
-```
+金融
+  provenance / PIT / unit / evidence
 
-これはVRChatカレンダーのprojection、arXiv pipeline、画像pipeline、現在のPages deployまで一貫して使える原則です。
+VR・3D
+  identity / source immutability / artifact validation
 
-## データ基盤の実態：GitHubをcontrol plane、private bucketをdata planeに分けた
+ゲーム
+  clean install / deterministic build / smoke test
 
-ここまでGitHubを状態機械として書きましたが、データ本体までGitへ詰め込んでいるわけではありません。
+情報収集
+  canonical source / derived data / projection
 
-2026年8月13日時点の実装では、**GitHub側のrepo・Issue・PR・Actionsをcontrol plane、private Hugging Face Storage Bucket `k4fka/kafka-data-lake` をmaterialized data plane**として分離しています。
+動画・生成
+  storyboard / provider boundary / publish gate
 
-Hugging Face公式もStorage Bucketsを、Git履歴を持つrepositoryとは別の、mutableなS3-like object storageとして説明しています。
+生活・個人データ
+  privacy / local-only / redaction / reproducible snapshot
 
-- current publish contract: https://github.com/KAFKA2306/semiconductor-earnings-model/blob/main/config/data_lake_publish.json
-- publisher workflow: https://github.com/KAFKA2306/semiconductor-earnings-model/blob/main/.github/workflows/hf-bucket-smoke.yml
-- architecture note: https://github.com/KAFKA2306/semiconductor-earnings-model/blob/main/docs/central-data-lake.md
-- Hugging Face Storage Buckets: https://huggingface.co/docs/hub/storage-buckets
+agent・MCP
+  tool boundary / least privilege / orchestration
 
-全体像はこうです。
-
-```text
-source repositories / local artifacts
-  ├─ factory
-  ├─ books
-  ├─ cast_event_cal
-  ├─ investor2-derived market snapshots
-  ├─ EDINET DB projections
-  ├─ financial analysis
-  ├─ earnings ledger
-  └─ finance artifacts
-          ↓
-KAFKA2306/semiconductor-earnings-model
-HF Bucket - Smoke Test and Central Publisher
-  ├─ stage
-  ├─ validate
-  ├─ authenticate by GitHub OIDC
-  ├─ exact-mirror allowlisted prefixes
-  ├─ publish manifest
-  └─ download again and verify SHA-256
-          ↓
-private Storage Bucket
-k4fka/kafka-data-lake
-          ↓
-central/manifests/latest.json
-```
-
-### データレイクへ何でも入れるのではなく、8つのpublish rootをallow-listする
-
-現在の `config/data_lake_publish.json` には、次の8系統だけが明示されています。
-
-| source | destination prefix |
-|---|---|
-| `artifacts/edinetdb/projections` | `edinetdb/projections` |
-| `data/financial_analysis` | `financial_analysis` |
-| `artifacts/earnings_ledger` | `earnings_ledger` |
-| `artifacts/finance` | `finance` |
-| `KAFKA2306/factory:data` | `factory/data` |
-| `KAFKA2306/books:data` | `books/data` |
-| `KAFKA2306/cast_event_cal:data` | `events` |
-| `data/market_snapshots` | `market_snapshots` |
-
-最後の `market_snapshots` はpublisher側へstageされますが、contractにはprovenanceとして `source_repository: KAFKA2306/investor2` と `source_ref: main` も保持されています。
-
-つまり「146 repoを全部中央へコピーする」のではありません。
-
-**中央data planeへ出してよいものを、機械可読なallow-listとして絞る。**
-
-ここでも、自律化を強くする方法は権限を広げることではなく、境界を狭くすることでした。
-
-### writerも1本に絞り、長期HF tokenをrepoへ置かない
-
-architecture noteでは、このbucketへのauthenticated writerを `KAFKA2306/semiconductor-earnings-model` の `.github/workflows/hf-bucket-smoke.yml` に限定しています。
-
-workflow自身も、
-
-```yaml
-permissions:
-  contents: read
-  id-token: write
-```
-
-を持ち、`huggingface/login@v1` でGitHub Actions OIDCからHugging Faceへ認証します。
-
-GitHub公式でも、OIDC token取得には `id-token: write` が必要で、長期credentialをworkflowへ保存せず外部providerへ認証するための仕組みとして説明されています。Hugging Faceの公式login actionもOIDC認証用です。
-
-- GitHub OIDC: https://docs.github.com/en/actions/reference/security/oidc
-- Hugging Face login action: https://github.com/huggingface/login
-
-ここで重要なのは、bucketがあることより、**誰が書けるかを1本へ絞り、credential lifecycleまでworkflow contractへ入れたこと**です。
-
-### publishは単純コピーではなく、検証可能な順序にした
-
-現在のpublisherは、いきなりremoteへ書きません。
-
-```text
-sourceをstage
-↓
-manifestを生成
-↓
-staged treeとmanifestをvalidate
-↓
-allow-listされたdestination prefixだけexact mirror
-↓
-central manifestをpublish
-↓
-remoteからmanifestとobjectsを再download
-↓
-SHA-256を再計算して一致確認
-```
-
-manifest `central/manifests/latest.json` には、source repository / ref / path、destination、byte size、SHA-256などを残す設計です。
-
-exact mirrorでもbucket全体を消すのではなく、allow-listされたprefixだけを置き換え、無関係なpathには触れません。
-
-これはデータベースのtransactionそのものではありませんが、**「途中までコピーできた」を「publish完了」と誤認しないためのtransaction-likeなpublish protocol**にはなっています。
-
-### 設計文書より、実行されるconfigとworkflowを運用上の正本として読む
-
-ここは実運用らしいズレもあります。
-
-`docs/central-data-lake.md` の `first release` の説明には、factory / books / cast_event_cal とEDINET DB / earnings ledger / financeが書かれています。一方、現在の実行contract `config/data_lake_publish.json` には、それに加えて `financial_analysis` と `market_snapshots` も入っています。
-
-したがって現状を監査するときは、
-
-```text
-architecture note
-  = 設計意図
-
-config/data_lake_publish.json
-  = 現在のpublish contract
-
-hf-bucket-smoke.yml
-  = 実行手順
-
-Actions run
-  = 実際にその手順が通った証拠
-```
-
-と分けて扱うのが安全です。
-
-これは記事を書くときにも重要でした。READMEや設計文書だけを読んで「今こう動いている」とは断定しません。
-
-### 2026年8月13日のscheduled runで、publishとremote再検証まで実際に成功している
-
-最後に、構成ファイルが存在するだけでは「動いている」とは言えません。
-
-2026年8月13日17:03 JSTに開始されたscheduled run `31680400569` は `success` で完了しています。
-
-- run: https://github.com/KAFKA2306/semiconductor-earnings-model/actions/runs/31680400569
-
-このrunでは、少なくともworkflow上で次の主要stepがすべて `success` になっています。
-
-```text
-Build and validate publish bundle
-Hugging Face login (OIDC)
-Upload / verify / delete bucket marker
-Publish fresh J-Quants inputs from investor2
-Exact mirror allowlisted data-lake prefixes
-Publish central manifest
-Verify published manifest and all objects
-```
-
-さらに、このrunのhead SHA `f2bcb5235ce6d4f5e435b8994b6760cd65b7ac4f` で `config/data_lake_publish.json` を取得すると、上で示した現在の8つのpublish rootと一致します。
-
-つまり現在のデータ基盤は、概念図だけではありません。
-
-**複数repoの状態をGitHubで制御し、中央publisherだけがOIDCでprivate data planeへ書き、manifestとhashを使ってremote側まで再検証するところまで実装されている。**
-
-ここまで来ると、GitHubは単なるソースコード置き場でも、data lakeそのものでもありません。
-
-```text
-GitHub
-= control plane + versioned contract + evidence
-
-private Storage Bucket
-= mutable materialized data plane
-
-manifest / SHA-256
-= 両者をつなぐprovenance contract
-```
-
-この分離のおかげで、コード・状態・レビュー履歴はGitHubへ残しながら、頻繁に更新されるdata objectまでGit履歴へ抱え込まずに済みます。
-
-## ChatGPTのScheduled Tasksも「repoごと」ではなく制御ループに使う
-
-OpenAIの公式ヘルプでは、ChatGPTのScheduled Tasksは定期タスクやmonitoringを扱え、1時間に1回より高い頻度では実行できません。アクティブなタスク数にもプラン別上限があります。
-
-- https://help.openai.com/ja-jp/articles/10291617-scheduled-tasks-in-chatgpt
-
-GitHub連携についても、OpenAI公式は、接続したrepositoryからコード、README、その他のドキュメントを取得し、検索・分析・引用できると説明しています。
-
-- https://help.openai.com/ja-jp/articles/11145903-connecting-github-to-chatgpt
-
-146 repoに対して146個の監視タスクを作る発想ではなく、中央状態を見て次の1件を選ぶ方が、ここまでの歴史とも整合します。
-
-```text
-146 repositories
-      ↓
-GitHub facts
-      ↓
-normalized state
-      ↓
-4 lanes
-      ↓
-priority selection
-      ↓
-one next outcome
-```
-
-## 失敗も高速化するので、細かな事故は「再利用できる契約」へ変える
-
-大量に動かすと、成功だけでなく失敗も高速になります。
-
-実際、誤操作で作られた一時Issueや重複Issueもありました。
-
-- https://github.com/KAFKA2306/rule-scribe-games/issues/83
-- https://github.com/KAFKA2306/furutsatotax/issues/13
-
-Pythonのquote破損、環境変数名の誤り、Uploader停止のような局所事故は、それぞれを独立記事にするより、再利用できる契約へ変換する方が価値があります。
-
-```text
-quote破損
-→ compile gate
-
-環境変数名ミス
-→ deploy前contract validation
-
-Uploader事故
-→ tool successと実環境completionの分離
-```
-
-そのため、細かな候補記事はarchiveへ回し、複数プロジェクトへ再利用できる仕組みが取り出せたものを残します。
-
-- archive policy: https://github.com/KAFKA2306/articles/blob/main/artifacts/archive/README.md
-
-## 3年分を並べると、変わったのはAIの賢さだけではなかった
-
-ここまでを一つの図にすると、こうなります。
-
-```text
-2023
-single application
-    ↓
-2024
-multi-stage pipeline
-    ↓
-2025
-agent / tool boundary
-    ↓
-2025
-recurring execution + provenance
-    ↓
-2026
-GitHub as shared state
-    ↓
-2026
-portfolio audit + next-action selection
-```
-
-最終的な構造は次です。
-
-```text
-Human
-  └─ goal / irreversible decisions / publication
-
-ChatGPT
-  └─ portfolio audit
-     → choose next outcome
-     → inspect evidence
-     → design bounded task
-     → verify completion
-
-GitHub = control plane
-  ├─ Issue = contract
-  ├─ PR = candidate change
-  ├─ Actions = machine evidence / publisher
-  ├─ main = canonical state
-  └─ source repositories + publish contract
               ↓
-       single-writer Actions
-              ↓ OIDC
-private Hugging Face Storage Bucket = data plane
-  └─ k4fka/kafka-data-lake
+        GitHub上の共通契約
               ↓
-       manifest + SHA-256 verification
-              ↓
-Pages / production / downstream artifacts
-
-Automation
-  └─ repetitive collection / validation / build / publish / deploy / cleanup
+  cross-repository control loop
 ```
 
-直近1か月の805 PRは目立ちます。
+つまり、2026年に突然「ChatGPTが自律化した」のではない。
 
-でも、それをこの記事の起点にすると重要なものを見失います。
+**多数の別プロジェクトで必要になった契約が、GitHubという共通状態へ合流した。**
 
-その前に、1つのアプリを作る時期があり、pipelineを作る時期があり、MCPで役割と権限を分ける時期があり、人が触らなくても定期実行する仕組みがあり、manifestやhashで証拠を残す試行がありました。
+この方が、実際のrepository群に近い。
 
-2026年夏に新しかったのは、それらを**repoの中だけで使わず、repo間の次の行動を選ぶために使い始めたこと**です。
+## 人間に残す仕事も、系統ごとに違う
 
-その裏では、GitHubに全データを抱え込むのではなく、**GitHubをcontrol plane、private Storage Bucketをdata plane、manifestとhashをその間の契約**として分離するところまで進んでいました。
+人間境界も一種類ではない。
 
-コード生成は、そのループの一工程にすぎません。
+金融なら、売買判断そのもの。
 
-マルチプロジェクト開発を自律化するときに本当に効いたのは、
+VR/3Dなら、見た目やcreative choice。
 
-**状態を減らすこと。契約を書くこと。データの置き場と制御の置き場を分けること。証拠を残すこと。停止条件を決めること。そして、人間が判断すべき場所を最後まで消さないこと。**
+動画なら、公開してよい内容か。
 
-でした。
+個人データなら、何を記憶として採用し、何を公開するか。
+
+OSS forkなら、上流をそのまま使うか、自分の設計へ持ち帰るか。
+
+そのため、マルチプロジェクト自律化の共通原則は「人間を消す」ではない。
+
+```text
+機械的に証明できるもの
+→ 機械へ
+
+意味・価値・不可逆性を含むもの
+→ 人間へ
+```
+
+という境界を、repoごとに明示することになる。
+
+## 結論
+
+最初の原稿では、説明しやすい少数repoを採用しすぎた。
+
+146公開repoという数字をタイトルへ置くなら、先に146を母集団として見なければならなかった。
+
+広く調べ直すと、実態は一本の自動化史ではない。
+
+金融、VR/3D、ゲーム、知識、イベント収集、動画、個人データ、Web UI、MCP/agentという**複数の独立した問題群**があり、それぞれが別の理由で検証、provenance、privacy、CI、artifact、権限境界を必要としていた。
+
+その後、それらの契約がGitHub上へ集まり、ChatGPTが
+
+```text
+全体を見る
+→ 次を選ぶ
+→ 実行する
+→ 証拠を確認する
+→ 状態を更新する
+```
+
+というrepo横断ループを回せるようになった。
+
+コード生成は、その中の一工程にすぎない。
+
+本質は、**異なる種類のプロジェクトを同じAIへ無理に揃えることではなく、各プロジェクトが自分の真実を機械可読な状態・契約・証拠として外へ出せるようにすること**だった。


### PR DESCRIPTION
## 問題
前稿は146公開repoを母集団として調べる前に、説明しやすい少数repoを選んで歴史を構成していました。選択バイアスが大きく、portfolio全体を代表していませんでした。

## 今回の修正
- GitHub profile / repository APIから146公開repoを母集団として確認
- 123 non-fork / 23 fork を先に分離
- 23 forkを全件列挙し、自作repoの成熟史から除外
- non-fork側を一つの年代順物語ではなく、金融、VR/3D、ゲーム、情報/知識、動画/音声、生活/個人データ、MCP/agent基盤の並行系統として広く棚卸し
- `jquants-api-quick-start`, `Unique3D`, `kling`, `financial-services-plugins`, `notebooklm-py`, `ComfyUI-KLingAI-API`, `open-fitter` など、前稿で自作側へ誤分類していたforkを修正
- `auto-invest`, `Swiss-Tournament-Manager`, `boothitemmanager`, `vlog`, `kakeibo`, `2511youtuber`, `semiconductor-earnings-model` など、従来ほぼ採用していなかった系統のREADMEも確認
- 「repo名一覧はテーマのinventory」「具体的な設計主張はREADME/実装を確認したrepoだけ」という採用ルールを本文に明記
- 一本道の `2023 app → 2024 pipeline → 2025 agent → 2026 orchestration` を撤回し、「異なる系統で育った契約がGitHub上へ合流した」という構造へ変更

`published: false` は維持しています。
