### PR TITLE
記事タイトルを「次に何をするか」までChatGPTに任せた、へ簡潔化

### DIFF
--- a/artifacts/candidates/2026-08/2026-08-13-chatgpt-multiproject-autonomy.md
+++ b/artifacts/candidates/2026-08/2026-08-13-chatgpt-multiproject-autonomy.md
@@ -1,5 +1,5 @@
 ---
-title: "146リポジトリは突然こうならなかった。バラバラな個人開発が、ChatGPTのマルチプロジェクト制御になるまで"
+title: "個人開発が146個に増えたので、「次に何をするか」までChatGPTに任せた"
 emoji: "🛰️"
 type: "tech"
 topics: ["chatgpt", "github", "automation", "githubactions"]


### PR DESCRIPTION
## 変更

記事候補のタイトルだけを、初見で内容が分かる表現へ変更します。

- 旧: `146リポジトリは突然こうならなかった。バラバラな個人開発が、ChatGPTのマルチプロジェクト制御になるまで`
- 新: `個人開発が146個に増えたので、「次に何をするか」までChatGPTに任せた`

本文、146 repoの全件監査、`published: false` は変更しません。