### PR TITLE
Refresh trust-boundary articles around reader outcomes

### DIFF
--- a/articles/2026-08-13-03-dont-infer-domain-from-language.md
+++ b/articles/2026-08-13-03-dont-infer-domain-from-language.md
@@ -1,5 +1,5 @@
 ---
-title: "PythonだからAI、TypeScriptだからWeb、をやめる。分類不能をunclassifiedで残す"
+title: "分類できないなら、無理に埋めない。unclassifiedを残した方がUIは信頼できた"
 emoji: "🗂️"
 type: "tech"
 topics: ["github", "metadata", "python", "architecture"]
@@ -7,48 +7,46 @@ published: false
 published_at: 2026-08-13 20:01
 ---
 
-GitHub上のリポジトリを自動分類するとき、情報不足を「PythonだからAI系」「TypeScriptだからWeb系」のような推測で埋めると、UIは整っても分類へ根拠のない意味が混ざる。
+GitHubのrepository一覧を分類するとき、空欄は気になる。
 
-`KAFKA2306/agent-resources` の現在の `main` では、project zone は明示的な `agent-zone-*` topic がある場合だけ採用し、それ以外は `unclassified` に送る。GitHub公式でもtopicsはprojectの目的やsubject areaなどを表すmetadataとして説明され、repository languagesはfiles/directoriesからGitHub Linguistが算出する言語統計として説明されている。
+PythonならAI。
 
-一次情報:
+TypeScriptならWeb。
 
-- https://github.com/KAFKA2306/agent-resources/blob/main/dashboard/collectors/repositories.py
-- https://github.com/KAFKA2306/agent-resources/blob/main/dashboard/tests/test_repository_collector.py
-- https://github.com/KAFKA2306/agent-resources/pull/60
-- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics
-- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-repository-languages
+そう埋めれば、一覧はすぐ整う。
 
-## 1. 問題
+しかし、その瞬間からUIは**分かっていないことまで分かった顔をする**。
 
-実際の入力を2件考える。
+`KAFKA2306/agent-resources` では、project zoneを明示的な `agent-zone-*` topicがある場合だけ採用し、それ以外は `unclassified` にするよう変更した。
+
+- collector: https://github.com/KAFKA2306/agent-resources/blob/main/dashboard/collectors/repositories.py
+- tests: https://github.com/KAFKA2306/agent-resources/blob/main/dashboard/tests/test_repository_collector.py
+- PR #60: https://github.com/KAFKA2306/agent-resources/pull/60
+
+この記事で扱うのはtaxonomyの作り方ではない。
+
+**情報不足をそれらしい推測で埋めず、「まだ分からない」を利用者へ正しく見せる設計**について書く。
+
+## languageは分かっても、domainは分からない
+
+例えば次の2repoがある。
 
 ```json
 {"name":"market-research","topics":["agent-zone-investing","python"],"language":"Python"}
 {"name":"photo-indexer","topics":[],"language":"Python"}
 ```
 
-前者には `agent-zone-investing` という明示的な意味metadataがある。後者から確定できるのは主言語がPythonであることだけで、投資、画像、科学計算、CLIなどのdomainは確定しない。
+1件目には `agent-zone-investing` という明示的な意味metadataがある。
 
-壊れた例は、明示topicがないとき `language-python` のようなgroupを作るfallbackである。欠損は消えるが、domain taxonomyとimplementation taxonomyが混ざる。
+2件目から分かるのは、主言語がPythonであることまでだ。
 
-## 2. 原因
+AI、画像、投資、科学計算、CLIのどれかは確定しない。
 
-原因は「欠損値を埋めること」と「意味を推論すること」を同一視したことにある。
+それでも `language-python → AI` のようなfallbackを置けば、UI上の空欄は消える。
 
-GitHub topicsとlanguagesは同じrepository metadataに見えるが役割が違う。topicsは目的・subject areaなどを明示できる。一方languagesはrepositoryのコード構成から算出される。Pythonで書かれたprojectが何を目的にしているかは、languageだけでは決まらない。
+代わりに、**根拠のない意味が増える。**
 
-## 3. 設計判断と代替案
-
-代替案は3つある。
-
-1. primary languageをfallbackにする。ほぼ全repoへラベルを付けられるが、domainとしての意味は弱い。
-2. READMEやrepo名からLLMで推論する。自然な分類を作れる可能性はあるが、model・prompt・文章変更で結果が揺れ、GitHub metadataだけでは説明できなくなる。
-3. explicit semantic metadataだけを採用し、不明は `unclassified` にする。
-
-`agent-resources` は3を採用している。PR #60でもlanguage fallbackを外し、LLM/domain inferenceをnon-goalとしている。現在の `main` の `infer_group()` も `agent-zone-*` topicがなければ `UNCLASSIFIED_GROUP` を返す。
-
-## 4. 実装
+## `unclassified` は失敗ではなく、情報の状態にする
 
 改善後の核は小さい。
 
@@ -61,19 +59,76 @@ def classify(repo):
     zones = sorted(
         t[len(ZONE_PREFIX):]
         for t in topics
-        if isinstance(t, str) and t.startswith(ZONE_PREFIX)
+        if isinstance(t, str)
+        and t.startswith(ZONE_PREFIX)
         and t[len(ZONE_PREFIX):]
     )
     return zones[0] if zones else UNCLASSIFIED
 ```
 
-`language` を削除する必要はない。別軸のmetadataとして保存してよい。ただしdomain分類関数のfallbackには使わない。
+ここで `language` を捨てる必要はない。
 
-改善後の例では、`agent-zone-investing` があれば `investing`、topicsが空でlanguageだけPythonなら `unclassified` になる。
+言語は言語として表示する。
 
-## 5. 検証
+ただしdomainの根拠には使わない。
 
-守りたいcontractは「正しいzoneが付く」だけではなく「根拠なしにzoneを作らない」ことなので、negative testを置く。
+```text
+Domain: unclassified
+Language: Python
+```
+
+この表示なら、利用者は何が分かっていて何が分かっていないかを区別できる。
+
+## 見栄えの100%より、意味のcoverageを測る
+
+unknownを許さない設計では、推測ruleを足すほど「分類済み率」を100%へ近づけられる。
+
+しかし、それでは本当に足りないmetadataが見えなくなる。
+
+例えば100repo中40repoに意味topicがなければ、
+
+```text
+semantic metadata coverage = 60%
+```
+
+と観測できる。
+
+この40件をlanguage fallbackで埋めると、UI上は100%にできても、意味metadataが不足している事実は消える。
+
+**unknownを残すと、改善対象が見える。**
+
+これは欠点ではなく、運用上の価値である。
+
+## classifierを賢くするより、昇格条件を明確にする
+
+`unclassified` から正式なzoneへ移す条件を決める。
+
+例えば、
+
+```text
+明示topicが付いた
+→ canonical zoneへ昇格
+```
+
+とする。
+
+READMEやrepo名からLLMで推論する案もあるが、それをcanonicalにするなら、少なくとも推論結果と明示metadataを同じstateにしない方がよい。
+
+```text
+explicit
+inferred
+unclassified
+```
+
+のようにprovenanceを分ける。
+
+今回の `agent-resources` は、より単純にexplicitだけを採用した。
+
+## negative testで「勝手に分類しない」を守る
+
+守りたいのは正しい分類だけではない。
+
+**根拠がないときに分類しないこと**もcontractである。
 
 ```python
 assert classify({"topics":["agent-zone-investing"],"language":"Python"}) == "investing"
@@ -81,32 +136,85 @@ assert classify({"topics":[],"language":"Python"}) == "unclassified"
 assert classify({"topics":[],"language":"JavaScript"}) == "unclassified"
 ```
 
-`agent-resources/main` の回帰testにも、PythonとJavaScriptのどちらでも明示zoneがなければ `unclassified` になる検証がある。
+このtestがあると、後から誰かが便利なfallbackを追加しても、意味境界を壊した時点で気づける。
 
-## 6. 失敗と学び
+## UIではunknownを隠さず、次のactionにつなげる
 
-`unclassified` が増えるとdashboardが未完成に見える。しかし推測で埋めると、本当に不足しているsemantic metadataの量が見えなくなる。
+`unclassified` をただ灰色で並べるだけでは使いにくい。
 
-例えば100 repo中40 repoが `unclassified` なら、「semantic metadata coverageが60%」という改善対象を観測できる。これをlanguage由来のgroupで埋めると、見かけ上は100%にできてもdomain metadataが不足している事実は消える。
+そこでUI上は、
 
-学びは、unknown stateを有効な状態として残すこと、そしてdomain・language・runtimeなど別taxonomyを1つのgroupへ押し込まないことである。
+- unclassified件数
+- explicit metadata coverage
+- metadata追加が必要なrepo
 
-## 7. 再現方法
+を見えるようにする方がよい。
 
-読者は上の `classify()` と3つのassertだけで再現できる。
+つまりunknownを、
 
-まずassertが通ることを確認する。次に、topicsが空の場合に `language-python` を返すfallbackを追加する。するとPython/JavaScriptの2つのassertが失敗する。
+```text
+見せたくない欠損
+```
 
-これで「分類できること」ではなく、**根拠なしに分類しないこと**をtestで固定できる。
+ではなく、
 
-さらに実務では `unclassified` の比率をcoverageとして別に計測する。coverageが低ければtopicなど正準metadataを改善し、classifierへ推測規則を足して数字だけ改善しない。
+```text
+次に整備すべきqueue
+```
 
-## まとめ
+として扱う。
 
-自動分類では、空欄を埋めることより、出力した意味を説明できることの方が重要である。
+これなら「未分類がある」ことが運用を前へ進める。
 
-GitHub topicsは目的やsubject areaを表す明示metadataとして使える。repository languageはコードから算出された別軸の情報で、それだけではproject domainを確定できない。
+## この考え方はrepository分類以外でも使える
 
-だから意味カテゴリの根拠がなければ `unclassified` にする。unknownを残すことで誤分類を避け、metadata不足そのものを観測できる。
+同じ問題は、
 
-**分からないときに、賢そうな分類を作らない。** これが再利用しやすいtaxonomyの最小契約になる。
+- 顧客segment
+- 文書category
+- 製品taxonomy
+- 工場domain
+- AI-generated label
+- データ品質status
+
+でも起きる。
+
+根拠が弱いのに一番近そうなcategoryへ押し込むと、見た目は整う。
+
+しかし利用者は、そのlabelを事実として使い始める。
+
+だから、
+
+```text
+known
+inferred
+unknown
+```
+
+を必要に応じて分ける。
+
+**分類精度だけでなく、分類根拠の透明性をUXにする。**
+
+## まず1つ見直すなら
+
+既存のclassifierでfallback ruleを探す。
+
+例えば、
+
+```text
+値がなければA
+languageがPythonならB
+名前にdataがあればC
+```
+
+のようなruleが、意味を本当に保証しているか確認する。
+
+保証できないなら、いったん `unclassified` へ戻す。
+
+そしてcoverageを測る。
+
+それだけで、**綺麗だが嘘を含む一覧**から、**不足も含めて信頼できる一覧**へ近づける。
+
+分からないときに、賢そうな答えを作らない。
+
+それがこの分類UIで一番守りたかったことだった。

--- a/articles/2026-08-13-04-effect-size-is-not-a-conclusion.md
+++ b/articles/2026-08-13-04-effect-size-is-not-a-conclusion.md
@@ -1,5 +1,5 @@
 ---
-title: "差が大きく見えても結論にしない。効果量を記述で止める"
+title: "Cohen's dが0.76でも「判定できる」とは言わない。数字と利用許可を分ける"
 emoji: "📏"
 type: "tech"
 topics: ["python", "statistics", "dataengineering", "testing"]
@@ -7,138 +7,245 @@ published: false
 published_at: 2026-08-13 21:00
 ---
 
-2群の平均値を比較して大きな差が出ると、すぐに「年代を判定できる」「原因はAIだ」と言いたくなる。しかし、小規模な探索データから計算した効果量は、まず**記述統計として保存し、推論・因果・分類へ自動昇格させない**方が安全である。
+探索分析で **Cohen's d ≈ -0.760** が出た。
 
-この記事では、公開リポジトリ `KAFKA2306/detective` の実装を具体例に、計算結果と解釈権限を別フィールドで管理する方法を扱う。
+数字だけを見ると、かなり差がありそうに見える。
 
-一次情報:
-
-- https://github.com/KAFKA2306/detective/blob/main/scripts/summarize_2026_oss_distribution_shift.py
-- https://github.com/KAFKA2306/detective/blob/main/reports/zenn_2026_oss_distribution_shift.json
-- https://github.com/KAFKA2306/detective/commit/64bf09e86ddf76601a4378ac95d7d4d7cb7ffc4e
-
-## 1. 問題
-
-実際の入力は、2022年と2026年から各12件、先頭1000文字を解析したpilotである。公開artifactでは `title_case_count` の平均が2022年12.0、2026年6.5833、pooled SDが約7.125、Cohen's d（2026−2022）が約-0.760と記録されている。
-
-数字だけを見ると差は目立つ。しかし、この1値から「2026年の記事を判定できる」とは言えない。
-
-壊れた例は次のような実装である。
+ここで次のコードを書きたくなる。
 
 ```python
 if abs(cohen_d) > 0.7:
     result["year_signal"] = True
 ```
 
-これは効果量という**記述値**へ、未検証の分類能力を勝手に付与している。
+しかし今回、それはしなかった。
 
-## 2. 原因
+`KAFKA2306/detective` のpilotは、2022年と2026年から各12件、先頭1000文字を解析した小規模な探索だった。
 
-原因は、計算可能性と解釈可能性を同じものとして扱うことにある。
+- 2022 mean: 12.0
+- 2026 mean: 6.5833
+- pooled SD: 約7.125
+- Cohen's d: 約-0.760
 
-`detective` の公開scriptは2群の平均とpooled standard deviationからCohen's dを計算できる。一方、同じ実装は入力が各年12件のdescriptive pilotであること、上流featureが日本語で妥当性確認されていないことを理由に、年推論・multiple testing claim・AI因果claimを明示的に禁止している。
+観測された差は残す。
 
-つまり、**数値を正しく計算できることは、その数値を意思決定へ使ってよい証拠ではない**。
+一方で、
 
-## 3. 設計判断と代替案
+```text
+年代を判定できる
+AI生成が原因である
+未知記事へ一般化できる
+```
 
-代替案は3つある。
+とは言わない。
 
-1. 効果量が閾値を超えたら自動で意味ラベルを付ける。単純だが、閾値自体が用途妥当性を保証しない。
-2. 効果量を計算せず、生データだけ保存する。過剰解釈は減るが、探索時の比較可能性まで失う。
-3. 効果量は計算・保存するが、解釈権限を別のgateとして保存する。
+この記事で扱うのは効果量の計算方法ではない。
 
-ここでは3を採る。`detective` のartifactは `status: descriptive_pilot_only` とし、さらに `interpretation_gate` に `use_for_year_inference: false`、`multiple_testing_claims: false`、`causal_ai_claim: false` を保存している。
+**派手な数字が出ても、証拠の強さを超えて意思決定へ昇格させない分析UX**について書く。
 
-重要なのは「弱いデータだから捨てる」ことではない。**観測結果は残し、許可されていない用途だけを閉じる**。
+- script: https://github.com/KAFKA2306/detective/blob/main/scripts/summarize_2026_oss_distribution_shift.py
+- artifact: https://github.com/KAFKA2306/detective/blob/main/reports/zenn_2026_oss_distribution_shift.json
+- commit: https://github.com/KAFKA2306/detective/commit/64bf09e86ddf76601a4378ac95d7d4d7cb7ffc4e
 
-## 4. 実装
+## 数字を消すのではなく、権限を狭くする
 
-最小構成は、数値と権限を分離するだけでよい。
+探索結果を過大解釈したくないなら、数字を出さない方法もある。
 
-```python
-result = {
-    "status": "descriptive_pilot_only",
-    "effect": {
-        "cohen_d": d,
-        "absolute_cohen_d": abs(d),
-    },
-    "interpretation_gate": {
-        "use_for_year_inference": False,
-        "multiple_testing_claims": False,
-        "causal_ai_claim": False,
-    },
+しかし、それでは比較や次の仮説づくりに使える情報まで失う。
+
+そこで、
+
+```text
+measurement
+```
+
+と、
+
+```text
+allowed interpretation
+```
+
+を別々に保存する。
+
+```json
+{
+  "status": "descriptive_pilot_only",
+  "effect": {
+    "cohen_d": -0.760
+  },
+  "interpretation_gate": {
+    "use_for_year_inference": false,
+    "multiple_testing_claims": false,
+    "causal_ai_claim": false
+  }
 }
 ```
 
-`detective` の実装ではさらに、入力長を1000文字へ固定しているため常に同じになる `char_count` を `eligible_for_interpretation: false` としてranking対象から除外している。
+この形なら「差が観測された」は残る。
 
-改善後の例では、`title_case_count` の `absolute_cohen_d` 約0.760という観測値は残る。一方で、それを年代分類やAI原因説へ使う経路は閉じたままになる。
+その一方で、「年代判定に使える」へ勝手に昇格しない。
 
-## 5. 検証
+**弱い証拠を捨てるのではなく、使える範囲だけ開ける。**
 
-守るべきcontractは「効果量が計算できる」だけではない。**禁止した解釈が出力上でも禁止されたままか**をtestする。
+## 計算できることと、判断に使えることは別
+
+効果量の式が正しいことは重要である。
+
+しかし、用途妥当性には別の問題がある。
+
+今回のpilotには、少なくとも次の制約がある。
+
+- 各年12件
+- 1000文字の固定window
+- feature自体が日本語用途で十分にvalidationされていない
+- topicやformatting差を拾っている可能性がある
+- multiple testingやcausal inferenceを目的に設計していない
+
+だから、`d = -0.760` の正確な計算から、直接 `year_signal = true` とは言えない。
+
+**metric correctnessとdecision validityは別contract**である。
+
+## 「何に使えるか」をmachine-readableにする
+
+READMEへ「参考値です」と書くだけでも警告にはなる。
+
+ただし後段の自動処理は、その文章を無視できる。
+
+そこで用途をfieldとして持たせる。
+
+```yaml
+allowed_use:
+  exploratory_comparison: true
+  feature_ranking: limited
+  year_classification: false
+  causal_ai_claim: false
+```
+
+これならreport generatorやLLM prompt側でも、禁止用途を確認できる。
+
+例えば、
+
+```python
+if not result["allowed_use"]["year_classification"]:
+    raise ValueError("This pilot cannot be used for year classification")
+```
+
+と後段で止められる。
+
+**注意書きをデータ契約へ昇格させる。**
+
+## 大きな値ほど、用途gateが必要になる
+
+小さな差なら慎重になりやすい。
+
+逆に大きな差が出ると、「これは使えそうだ」という心理が強くなる。
+
+そこが危ない。
+
+```text
+大きなeffect size
+→ 興味深い観測
+```
+
+まではよい。
+
+しかし、
+
+```text
+大きなeffect size
+→ 予測できる
+→ 原因が分かった
+```
+
+には追加証拠が必要である。
+
+この昇格をコード上で別stageへすると、分析者の気分に左右されにくい。
+
+## feature自身が意味を持つかも確認する
+
+今回の実装では、入力長を1000文字へ固定したため常に同じになる `char_count` を `eligible_for_interpretation: false` として扱っている。
+
+これは小さいが重要な例である。
+
+数値として計算できても、実験設計上意味がないfeatureならrankingへ入れない。
+
+```text
+calculated
+≠
+meaningful
+≠
+decision-ready
+```
+
+この3段階を混ぜない。
+
+## testすべきなのは、禁止用途が開いていないこと
+
+分析pipelineでは「計算が成功した」testだけを書きがちである。
+
+しかし今回守りたいのは、解釈境界も含む。
 
 ```python
 assert output["status"] == "descriptive_pilot_only"
 assert output["interpretation_gate"]["use_for_year_inference"] is False
 assert output["interpretation_gate"]["multiple_testing_claims"] is False
 assert output["interpretation_gate"]["causal_ai_claim"] is False
-assert output["features"]["char_count"]["eligible_for_interpretation"] is False
 ```
 
-公開workflowも、固定pilotの測定後にsummary scriptを実行し、measurement JSONとdistribution-shift JSONの両方をevidenceとしてcommitする構成になっている。
+このnegative contractがあると、将来reportを便利にする変更で禁止用途が勝手に開くのを防げる。
 
-## 6. 失敗と学び
+## 企業分析やA/B testでも同じ
 
-失敗は「大きそうな効果量」を「強い結論」と読み替えることである。
+この考え方は文章特徴量だけではない。
 
-今回の公開artifact自身が、各年12件、1000文字window、descriptive pilotという制約を持つ。またinterpretation gateのreasonには、日本語で未検証のfeatureがtopic・formatting・English-tokenization artifactを拾う可能性が明記されている。
+例えば、
 
-したがって、観測された差を消す必要はないが、そこから年代推論やAI因果へ飛ぶべきでもない。
+- 企業AとBのmargin差
+- 製造条件別の不良率差
+- UI A/B testのconversion差
+- ML model間のscore差
 
-学びは、analysis pipelineの出力に**「何が分かったか」だけでなく「何には使ってはいけないか」もmachine-readableに保存する**ことである。READMEの注意書きだけより、後段コードが誤用を検出しやすい。
+でも、観測値と意思決定権限を分けられる。
 
-## 7. 再現方法
+最小schemaなら次でよい。
 
-読者は次の最小例で、計算と解釈gateの分離を試せる。
+```yaml
+metric:
+  name: cohen_d
+  value: -0.760
 
-```python
-import math
+evidence_strength:
+  status: exploratory
+  sample_size: 24
 
-A = {"n": 12, "mean": 12.0, "std": 7.0}
-B = {"n": 12, "mean": 6.6, "std": 7.2}
-
-variance = (
-    (A["n"] - 1) * A["std"] ** 2
-    + (B["n"] - 1) * B["std"] ** 2
-) / (A["n"] + B["n"] - 2)
-pooled_sd = math.sqrt(variance)
-d = (B["mean"] - A["mean"]) / pooled_sd
-
-output = {
-    "cohen_d": d,
-    "use_for_classification": False,
-    "causal_claim": False,
-}
-
-assert isinstance(output["cohen_d"], float)
-assert output["use_for_classification"] is False
-assert output["causal_claim"] is False
-print(output)
+allowed_use:
+  exploration: true
+  production_decision: false
 ```
 
-ここで確認するのはdの大小ではない。**計算結果が存在しても、未検証の用途が自動的にtrueにならない**ことである。
+読者や下流systemは、数字だけでなく「どこまで使える数字か」を同時に見られる。
 
-実務ではこのgateをJSON Schemaや型へ昇格させ、後段のclassifier・report generator・LLM promptが `descriptive_pilot_only` を無視できないようにするとよい。
+## この設計で欲しいのは、慎重さより分析速度
 
-## まとめ
+用途gateを入れると保守的に見える。
 
-探索分析では、数値を出さないことより、数値の権限を狭く保つことが重要になる。
+しかし実際には、探索を速くできる。
 
-- 効果量は観測値として保存する
-- 入力設計上意味のないfeatureはrankingから外す
-- 推論・multiple testing・因果claimの可否を別gateにする
-- 未検証用途をmachine-readableなfalseとして残す
+弱いpilotでも、
 
-この分離を入れると、探索結果を捨てずに残しながら、後段の自動化が「差がある」から「判定できる」「原因が分かった」へ勝手に飛躍するのを防げる。
+```text
+探索用途なら保存してよい
+```
+
+と明示できるからだ。
+
+すべてをproduction-grade validationまで待つ必要はない。
+
+- 観測は残す
+- 仮説を作る
+- 次の実験を決める
+- 判断用途だけは閉じる
+
+この分離により、**探索の速度を落とさず、過剰解釈だけを止める**ことができる。
+
+Cohen's dが0.76だったことより重要なのは、その数字にどの権限を与えたかだった。

--- a/articles/2026-08-13-04-legacy-limit-complete-archive.md
+++ b/articles/2026-08-13-04-legacy-limit-complete-archive.md
@@ -1,5 +1,5 @@
 ---
-title: "60件引数を残しても、公開一覧は60件で切らない"
+title: "APIは壊れていないのに、61件目が消える。互換性を守りながら「全部見える」を取り戻す"
 emoji: "📚"
 type: "tech"
 topics: ["api", "pagination", "typescript", "architecture"]
@@ -7,135 +7,122 @@ published: false
 published_at: 2026-08-13 23:03
 ---
 
-APIの互換性を守るために古い `limit=60` 引数を残したまま、公開アーカイブ全件取得へ移行したい。ここで素直に `slice(0, 60)` を残すと、呼び出し元は壊れなくてもデータ契約だけが古いまま残る。
+公開一覧が60件までは正常に見える。
 
-`KAFKA2306/vlog` のReader実装では、この問題を「引数の互換性」と「productionで保証する取得範囲」を分離して解いている。PR #54で全件paginationと欠落検知を共通化し、PR #55で既存の `60` 引数を互換面として残しながら、production/default pathでは公開アーカイブを切り詰めない実装へ変更した。
+61件目が増えた瞬間、何もエラーを出さずに消える。
 
-一次情報:
+APIも落ちない。既存callerも壊れない。テストも60件以下ならgreenのまま。
 
-- https://github.com/KAFKA2306/vlog/pull/54
-- https://github.com/KAFKA2306/vlog/pull/55
-- https://github.com/KAFKA2306/vlog/blob/4bec2f9d04fa12b0b469cc0a3dc68ec6593d58b8/apps/reader/lib/public-archive.ts
-- https://github.com/KAFKA2306/vlog/blob/4bec2f9d04fa12b0b469cc0a3dc68ec6593d58b8/apps/reader/lib/novels-complete.ts
-- https://github.com/KAFKA2306/vlog/blob/5897543bc432c59e440d09c1a3f8712663419422/apps/reader/tests/public-archive.test.ts
-- https://github.com/PostgREST/postgrest/blob/main/docs/references/api/pagination_count.rst
+利用者から見ると、**「全部見える」と思っていた一覧が静かに欠ける。**
 
-## 1. 問題
+`KAFKA2306/vlog` では、以前から残っていた `limit=60` という互換引数と、新しい「公開対象をすべて列挙する」というproduct contractを分離した。
 
-実際の状況は次のようなものだった。
+- PR #54: https://github.com/KAFKA2306/vlog/pull/54
+- PR #55: https://github.com/KAFKA2306/vlog/pull/55
+- archive reader: https://github.com/KAFKA2306/vlog/blob/4bec2f9d04fa12b0b469cc0a3dc68ec6593d58b8/apps/reader/lib/public-archive.ts
+- complete reader: https://github.com/KAFKA2306/vlog/blob/4bec2f9d04fa12b0b469cc0a3dc68ec6593d58b8/apps/reader/lib/novels-complete.ts
+
+この記事で扱うのはpaginationの実装方法ではない。
+
+**古い呼び出し元を壊さず、利用者へは現在のproduct promiseどおりの完全な結果を返す移行方法**について書く。
+
+## 古い引数が、新しいUXを縛っていた
+
+既存コードには、次のような呼び出しがあった。
 
 ```ts
 const items = await getPublicNovels(60)
 ```
 
-この呼び出しは既存コードやテストから見れば安定している。しかし、公開Readerの要件が「最新60件」から「公開対象をすべて列挙する」に変わったあとも `60` をそのまま取得上限として使うと、61件目以降は静かに消える。
+以前の要件が「最新60件」なら正しい。
 
-壊れた例は、互換性のために残した引数をそのまま新しい意味契約にも適用する実装である。
+しかし要件が、
 
-```ts
-export async function getPublicNovels(limit = 60) {
-  const rows = await fetchRows({ limit })
-  return rows
-}
+```text
+公開対象をすべて一覧する
 ```
 
-このコードは例外を出さない。60件以下の環境ではテストも通りやすい。そのため、データ件数が閾値を超えた瞬間に初めて欠落が見える。
+へ変わったあとも、`60` をそのまま取得上限として使えば61件目以降は消える。
 
-## 2. 原因
+ここで厄介なのは、**後方互換を守った結果としてproduct semanticsだけが古いまま残る**ことだ。
 
-原因は、**呼び出しシグネチャの互換性**と**取得結果の意味契約**を同じものとして扱ったことにある。
+## signature compatibilityとproduct semanticsを分ける
 
-`limit` 引数には少なくとも2つの役割があり得る。
+`limit` には2つの意味が混ざっていた。
 
-1. 呼び出し元を壊さないための互換面
-2. 実際に返すデータ量を決める業務仕様
+1. 既存callerを壊さないためのAPI surface
+2. 実際に返す件数を制限する業務仕様
 
-仕様変更後もこの2つを結び付けたままだと、古い既定値が新しいproduction semanticsへ侵入する。
+要件変更後は、この2つを切り離した。
 
-`vlog` PR #54では先に共通の全件取得contractを作り、`Prefer: count=exact` と `Content-Range` の総件数を使ってpagination完了条件を検証するようにした。さらにprivate row、公開開始日前、重複ID、総件数drift、missing pageを失敗扱いにしている。PostgREST公式ドキュメントも、paginationとcountを組み合わせて全rowを辿れること、`Prefer: count=exact` でtotal countを `Content-Range` に含められることを明記している。
+```text
+legacy argument
+  └─ caller compatibilityのため残す
 
-## 3. 設計判断と代替案
-
-代替案は3つある。
-
-### 案A: `limit=60` を削除する
-
-最もきれいだが、既存呼び出し元とテストを一斉に直す必要がある。変更範囲が大きく、機能変更とAPI破壊が同時に起こる。
-
-### 案B: `limit=60` を残し、そのまま切り詰める
-
-互換性は高いが、新しい「完全な公開アーカイブ」という要件を満たさない。最も危険なのは、失敗ではなく部分成功になる点である。
-
-### 案C: 引数は残すがproduction pathでは意味を切り離す
-
-`vlog` PR #55はこの形を採用している。Diary側は `_legacyLimit?: number` として受け取るが、remote public archiveが取れた場合は全件を返す。Novel側も、既存のinjected fetchテストではlegacy limitを維持しつつ、default production fetchでは共通のcomplete archive readerへ流す。
-
-この設計の利点は、**互換性移行と意味契約移行を別々に進められること**である。
-
-## 4. 実装
-
-最小形にすると、境界は次のようになる。
-
-```ts
-type FetchLike = typeof fetch
-
-async function fetchAllPublicRows(): Promise<Row[]> {
-  const out: Row[] = []
-  let expectedTotal: number | null = null
-  let offset = 0
-  const pageSize = 250
-
-  while (expectedTotal === null || out.length < expectedTotal) {
-    const response = await fetch(
-      `/rest/v1/items?order=date.desc,id.asc&limit=${pageSize}&offset=${offset}`,
-      { headers: { Prefer: 'count=exact' } },
-    )
-    if (!response.ok) throw new Error(`request failed: ${response.status}`)
-
-    const total = parseExactCount(response.headers.get('content-range'))
-    if (expectedTotal === null) expectedTotal = total
-    else if (total !== expectedTotal) throw new Error('count drift')
-
-    const rows = await response.json() as Row[]
-    if (rows.length === 0) break
-    out.push(...rows)
-    offset += rows.length
-  }
-
-  if (expectedTotal === null || out.length !== expectedTotal) {
-    throw new Error(`incomplete archive: expected ${expectedTotal}, got ${out.length}`)
-  }
-  return out
-}
-
-export async function getItems(
-  legacyLimit = 60,
-  fetchImpl: FetchLike = fetch,
-) {
-  if (fetchImpl !== fetch) return fetchLegacyRows(legacyLimit, fetchImpl)
-  return fetchAllPublicRows()
-}
+production semantics
+  └─ complete public archiveを返す
 ```
 
-重要なのは `_legacyLimit` という名前そのものではない。**production pathがその値を取得上限として解釈しない**ことがcontractである。
+PR #55では、legacy引数を受け取る面を残しつつ、default production pathではその値を最終truncateへ使わない形へ移行している。
 
-### 改善後の例
+**引数を残すことと、その古い意味を残すことは同じではない。**
 
-公開対象が83件あり、既存callerが `getItems(60)` を呼んでいても、production/default pathでは83件を返す。一方、既存unit testがinjected fetchで60件上限を前提としているなら、そのテスト用互換経路だけは段階的に維持できる。
+## complete fetchは「複数page取れた」だけでは足りない
 
-## 5. 検証
+PR #54では、まず下位層へcomplete archive contractを作った。
 
-「60件を超えても返る」だけでは不十分である。完全取得contractなら、欠落を成功として返さないことまで検証する。
+`Prefer: count=exact` と `Content-Range` のtotalを使い、期待件数までpageを辿る。
 
-`vlog` PR #54のtestではDiary/Novelの両方について、件数0〜17、page size 1〜5を組み合わせて全IDが1回ずつ返ることを確認している。さらに次のnegative caseを独立fixtureにしている。
+しかし本当に守りたいのは、loopが回ったことではない。
 
-- private rowが混じったらreject
-- 公開開始日前のrowが混じったらreject
-- page間でduplicate IDが出たらreject
-- missing pageならpartial resultを返さずreject
-- countがpagination途中で変わったらreject
+```text
+期待total = 83
+取得total = 83
+duplicate = 0
+missing page = 0
+invalid/private row = 0
+```
 
-読者向けの最小テストなら、少なくとも境界値を3つ置く。
+まで確認して初めてcompleteと扱う。
+
+途中pageが空なら、取れた分だけを返さない。
+
+countが途中で変われば止める。
+
+duplicate IDがあれば止める。
+
+**部分成功を「全件取得成功」にしない。**
+
+## 下位paginationが正しくても、最後のsliceで全部壊れる
+
+ここが実装上の重要な学びだった。
+
+下位のarchive readerが83件を正しく返しても、上位callerが最後に、
+
+```ts
+return rows.slice(0, 60)
+```
+
+としていれば、利用者には60件しか見えない。
+
+PR #54でcomplete paginationを作ったあとも、上位のlegacy truncate pointが残っていたため、PR #55でproduction pathから外した。
+
+つまり完全取得は、
+
+```text
+fetch layer
+adapter layer
+reader layer
+UI loader
+```
+
+のどこか1つだけ見ても証明できない。
+
+**最終的に利用者へ返る配列までcontractを追う必要がある。**
+
+## 59 / 60 / 61をtestするだけで、静かな欠落を捕まえやすい
+
+境界値testは単純だ。
 
 ```ts
 for (const count of [59, 60, 61]) {
@@ -145,41 +132,90 @@ for (const count of [59, 60, 61]) {
 }
 ```
 
-61件で初めて失敗する実装を、この1行追加で捕まえられる。
+60までしかtestしなければ、旧仕様の上限とtest datasetが偶然一致してしまう。
 
-## 6. 失敗と学び
+61を1件足すだけで、古いtruncateが見える。
 
-最初にpaginationを正しく作っても、上位callerが最後に `slice(0, 60)` していれば完全取得にはならない。
+この種のcontractでは、通常ケースを増やすより**境界の外へ1歩出るfixture**が効く。
 
-実際、PR #54では共通archive readerが全件取得を実装した一方、Diary callerには引数によるsliceが残り、Novelには独立した `limit=60` pathが残っていた。PR #55の目的は、その残存truncate pointをproduction/default pathから外すことだった。
+## 利用者が欲しいのは「API互換」ではなく「欠けていない」こと
 
-ここから得られる学びは、**下位層のpagination correctnessだけをテストしても、product contractは保証できない**ということだ。取得層、adapter層、UI loader層のどこか1か所に固定上限が残れば、ユーザーから見える結果は欠ける。
+開発者には、
 
-また `count=exact` 自体にもコストがある。PostgREST公式ドキュメントは大きなtableではexact countが遅くなり得ると説明している。そのため、これは常に最適なpagination方式という主張ではない。今回の設計判断は「公開アーカイブを完全列挙し、欠落をfail-closeしたい」という要件に対するものだ。
+```text
+breaking changeを避けた
+```
 
-## 7. 再現方法
+ことが重要に見える。
 
-手元で再現するなら、DBやSupabaseは不要である。fake fetchだけで確認できる。
+利用者には、
 
-1. 61件の配列を用意する。
-2. `limit=20&offset=N` を解釈して20件ずつ返すfake fetchを作る。
-3. response headerへ `Content-Range: start-end/61` を付ける。
-4. 旧実装として `getItems(60)` の最後に `slice(0, 60)` を置き、60件になることを確認する。
-5. 改善実装ではlegacy引数をproduction pathの取得上限に使わず、61件になることを確認する。
-6. 2page目を空配列へ差し替え、61件未満のpartial resultではなく例外になることを確認する。
+```text
+公開されているものが全部見える
+```
 
-確認したいのは「pagination関数が動く」ことではなく、**古い互換引数が新しい完全取得contractを再び狭めていないこと**である。
+ことの方が重要である。
 
-## まとめ
+だからmigrationの成功条件を、
 
-後方互換のために古い引数を残すことと、その引数の古い意味をproductionに残すことは別問題である。
+```text
+古いcallerがまだ動く
+```
 
-完全取得へ移行するときは、次の順序が安全だった。
+だけにしない。
 
-1. 下位層にcomplete pagination contractを作る
-2. count drift・duplicate・missing pageをfail-closeする
-3. 上位callerに残るtruncate pointを洗い出す
-4. legacy引数は互換面として残しても、production semanticsから切り離す
-5. 59/60/61のような境界値で回帰を固定する
+```text
+古いcallerも動く
+AND
+新しいproduct promiseも満たす
+```
 
-「APIは壊していないのにデータだけ欠ける」という不具合は、型や例外では見つけにくい。互換性と意味契約を別々に設計すると、この種の静かな欠落をかなり早い段階で止められる。
+へする。
+
+この2軸で見れば、互換性維持がUX退行を隠すことを防ぎやすい。
+
+## 既存APIを見直すときのチェックリスト
+
+古いdefaultやlimitが残るAPIでは、次を確認する。
+
+1. この引数は今も業務仕様なのか、単なる互換面なのか
+2. 下位層はcompleteでも上位でtruncateしていないか
+3. 0件と取得失敗を分けているか
+4. pagination途中のcount driftを検出しているか
+5. duplicate/missing pageをpartial successにしていないか
+6. 旧上限の直前・同値・直後をtestしているか
+
+特に6は安い。
+
+`59 / 60 / 61` のような3点だけでも、古い制約がproductionへ漏れているか見つけやすい。
+
+## exact countにもコストがある
+
+今回の方式が常に最適という話ではない。
+
+PostgRESTの公式documentationでも、exact countは大きなtableでコストが上がり得る。
+
+https://github.com/PostgREST/postgrest/blob/main/docs/references/api/pagination_count.rst
+
+今回それを使ったのは、**公開アーカイブを完全列挙し、欠落をfail-closeしたい**という要件があったからだ。
+
+性能が主目的なら、別のpagination contractを選ぶこともある。
+
+設計手段よりproduct promiseを先に置く。
+
+## この変更で守ったのはコードではなく、一覧への信頼だった
+
+古い `limit=60` を削除してbreaking changeにする必要はなかった。
+
+同時に、60件という古い意味まで残す必要もなかった。
+
+- caller compatibilityは残す
+- complete archive semanticsへ移す
+- partial resultは返さない
+- boundary testで61件目を守る
+
+この分離で、**APIを壊さずに「全部見える」体験を更新できた。**
+
+後方互換を守るとき、本当に守るべきなのは古いコードの形だけではない。
+
+現在の利用者に何を約束しているかも、同じくらい重要だった。

--- a/articles/2026-08-13-05-pin-assets-commit-sha256.md
+++ b/articles/2026-08-13-05-pin-assets-commit-sha256.md
@@ -1,5 +1,5 @@
 ---
-title: "同じ画像URLなのに中身が変わる。共有アセットを固定する"
+title: "中央の画像を更新しても、公開サイトが勝手に変わらない。共有assetをcommitとhashで固定する"
 emoji: "📌"
 type: "tech"
 topics: ["github", "ci", "frontend", "architecture"]
@@ -7,39 +7,102 @@ published: false
 published_at: 2026-08-13 23:40
 ---
 
-複数のGitHub Pagesで同じ画像やアイコンを使いたいとき、いちばん簡単なのは中央repoの `main` を直接参照することだ。しかし、`main` は更新される。URLが同じでも、その先のファイルは将来変わり得る。
+複数のサイトで同じ画像やアイコンを使いたい。
 
-GitHub公式ドキュメントも、branch名を含む通常のファイルURLはbranch headの更新に合わせて内容が変わり得るため、特定versionを共有したい場合はcommit IDを使ったpermalinkにするよう説明している。
-
-この問題に対して `KAFKA2306/prompt-vault` と `KAFKA2306/travel` では、共有アセットを **asset IDで選ぶ → Prompt Vaultのcommitを固定する → SHA-256を照合する → consumer repoへvendorする → build後とdeploy後にも同じhashを再確認する** という境界を実装した。
-
-一次情報:
-
-- https://github.com/KAFKA2306/prompt-vault/commit/f96a2d6b5bb257080f235f04cdfb5745e8700ed3
-- https://github.com/KAFKA2306/prompt-vault/commit/a6ef582f7112b0f504bea3d535b9c45437c107f9
-- https://github.com/KAFKA2306/travel/commit/cbc7aeae37398a0f50b76c6de6e85319653dfbfe
-- https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files?apiVersion=2022-11-28
-- https://docs.github.com/en/rest/git/blobs
-
-## 1. 問題
-
-たとえば、複数siteから次のようなURLを参照するとする。
+一番簡単なのは、中央repositoryの `main` を直接参照することだ。
 
 ```text
 https://raw.githubusercontent.com/example/assets/main/hero.webp
 ```
 
-初日は正しい画像が出る。だが中央repoの `main` で `hero.webp` が差し替えられると、consumer側のcommitを1行も変更していないのに、表示結果だけが変わる。
+しかし、このURLは同じままでも中身は変わる。
 
-ここで壊れているのはHTTPではない。404にもならず、buildも通り得る。**consumerが「どのbytesを採用したのか」を後から再現できない**ことが問題になる。
+中央repoで `hero.webp` を差し替えれば、consumer側は1行も変更していないのに公開サイトの見た目が変わる。
 
-GitHub公式のpermalink説明では、branch head上のファイルは新しいcommitによって変わり得る一方、URL中のbranch名を特定commit IDへ置き換えると、そのcommit内の正確なversionへ固定できる。
+404にもならない。buildも通る。
 
-### 実際の状況
+**reviewしていない変更が、正常な配信として利用者へ届く。**
 
-`prompt-vault` の2026年8月13日の実装では、Pages共有アセットを `assets/registry.json` とcollection manifestで管理し、consumerはasset IDと配置先だけを宣言する構造を追加した。さらに `vendor_assets.py` はPrompt Vaultのcommitを引数で受け取り、canonical sourceのSHA-256を確認してからconsumerへコピーする。
+`KAFKA2306/prompt-vault` と `KAFKA2306/travel` では、ここを次の境界へ変えた。
 
-同日の `travel` では `travel-basic` を実consumerとして導入し、lock fileへ次の4点を固定した。
+```text
+asset IDを選ぶ
+  ↓
+canonical commitを固定
+  ↓
+SHA-256を照合
+  ↓
+consumerへvendor
+  ↓
+build後も同じhashか確認
+  ↓
+deploy後も同じhashか確認
+```
+
+この記事で扱うのはhashの計算方法ではない。
+
+**中央管理の便利さを残しながら、consumerの公開物が知らない間に変わらない運用UX**について書く。
+
+一次情報:
+
+- Prompt Vault: https://github.com/KAFKA2306/prompt-vault/commit/f96a2d6b5bb257080f235f04cdfb5745e8700ed3
+- Prompt Vault: https://github.com/KAFKA2306/prompt-vault/commit/a6ef582f7112b0f504bea3d535b9c45437c107f9
+- travel consumer: https://github.com/KAFKA2306/travel/commit/cbc7aeae37398a0f50b76c6de6e85319653dfbfe
+- GitHub permalink: https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files?apiVersion=2022-11-28
+
+## `main` URLは場所を示すが、採用versionは示さない
+
+branch URLは便利である。
+
+常に最新のassetへ追従できる。
+
+しかしconsumerに必要なのは、
+
+> 今どこにassetがあるか
+
+だけではない。
+
+> **このサイトは、どのversionのどのbytesを採用したのか**
+
+も必要である。
+
+そこで識別を2段階に分ける。
+
+1. commit ID — どのrepository snapshotを採用したか
+2. SHA-256 — そのsnapshotから取り出したbytesが期待値と同じか
+
+commitはsource versionを固定する。
+
+hashはconsumerへ入った実体まで照合する。
+
+## consumerはasset pathではなくIDを選ぶ
+
+中央manifestでは、共有assetをIDで管理する。
+
+```json
+{
+  "id": "travel-basic",
+  "file": "travel-basic-illustration.webp",
+  "sha256": "8c45dfb3c32aa5d2991b9d3b9d710b66722f0ef10fb62a0b5dea2582f36ea383"
+}
+```
+
+consumer側はsource pathを自由記述せず、
+
+```json
+{
+  "id": "travel-basic",
+  "destination": "public/assets/kafka-signal/travel-basic-illustration.webp"
+}
+```
+
+のように採用対象と配置先を宣言する。
+
+これにより、source側のdirectory構造より**assetの意味的なID**をcontractにできる。
+
+## vendorした時点でlockを残す
+
+`travel` では、採用したsourceをlockへ残した。
 
 ```json
 {
@@ -50,215 +113,146 @@ GitHub公式のpermalink説明では、branch head上のファイルは新しい
 }
 ```
 
-commitだけでなく、採用したbytesのdigestまでconsumer側に残している。
-
-## 2. 原因
-
-原因は、**「どこにあるか」と「何を採用したか」を同じURLで表現しようとしたこと**にある。
-
-branch URLは場所を示すには便利だが、branch headは動く。対してconsumerが必要なのは、レビュー時に確認したものとdeploy時に配信するものが同じだと検証できる識別子である。
-
-ここでは識別子を2層に分ける。
-
-1. **commit ID**: どのrepository snapshotを参照したか
-2. **SHA-256**: そのsnapshotから取り出したasset bytesが期待値と一致するか
-
-GitHubのGit blob APIも、repository内のファイル内容をGit blobとして扱い、blobにhash識別子を持つことを公式に説明している。今回のconsumer contractではそれとは別にSHA-256をmanifestへ記録し、vendored file・build artifact・deploy後のfileを同じdigestで照合している。
-
-## 3. 設計判断と代替案
-
-### 案A: `main` をruntime hotlinkする
-
-実装は最小になる。しかしconsumer repoのcommitと実際に表示されるasset versionが分離する。
-
-`prompt-vault` のAgent World asset manifestでも、default policyとして mutable `main` URLをruntime hotlinkしないことを明記している。
-
-### 案B: commit permalinkだけを使う
-
-GitHub上の参照先versionは固定できる。単一fileを読むだけなら有効である。
-
-一方、consumer側にコピーしたfileやbuild後のfileまで同一bytesか確認したい場合、commit IDだけではconsumer filesystem上の実体を直接検査できない。そこで今回の実装ではSHA-256もlockへ残す。
-
-### 案C: tagだけを固定する
-
-release単位で扱いやすい。しかしconsumerが最終的にどのcommitを採ったかまでlockに残す設計のほうが、再現時の参照点が明示的になる。
-
-### 案D: commit＋SHA-256＋vendor
-
-今回の採用案である。
-
-consumerは中央repoをruntime dependencyにせず、自分のbuild対象へassetを保持する。その代わり、コピー元commitとdigestをlockへ記録し、CIで一致を検証する。
-
-重要なのは「中央管理だからconsumerはassetを持たない」ではない。**中央repoは正準sourceとdistribution metadataを持ち、consumerは採用versionを自分のrepositoryに固定する**という責務分離である。
-
-## 4. 実装
-
-最小構成は3ファイルで作れる。
-
-### 4.1 中央manifest
-
-```json
-{
-  "id": "travel-basic",
-  "file": "travel-basic-illustration.webp",
-  "sha256": "8c45dfb3c32aa5d2991b9d3b9d710b66722f0ef10fb62a0b5dea2582f36ea383"
-}
-```
-
-`prompt-vault` のcollection manifestは実際にasset ID、file、size、SHA-256、生成由来、用途制約を記録している。
-
-### 4.2 consumer manifest
-
-```json
-{
-  "schema_version": "1.0.0",
-  "repository": "KAFKA2306/travel",
-  "assets": [
-    {
-      "collection": "site-basics",
-      "id": "travel-basic",
-      "destination": "public/assets/kafka-signal/travel-basic-illustration.webp"
-    }
-  ]
-}
-```
-
-consumerはsource pathを自由記述せず、asset IDを選択する。配置先だけをconsumer責務として宣言する。
-
-### 4.3 lock file
-
-vendor後に、commitとsource/destination digestを保存する。
-
-```json
-{
-  "canonical_commit": "90111f8953dd2a45aca2da7053bfdeef57459b41",
-  "assets": [
-    {
-      "id": "travel-basic",
-      "destination": "public/assets/kafka-signal/travel-basic-illustration.webp",
-      "source_sha256": "8c45dfb3c32aa5d2991b9d3b9d710b66722f0ef10fb62a0b5dea2582f36ea383",
-      "destination_sha256": "8c45dfb3c32aa5d2991b9d3b9d710b66722f0ef10fb62a0b5dea2582f36ea383"
-    }
-  ]
-}
-```
-
-### 最小verification
-
-Python標準libraryだけでも確認できる。
-
-```python
-from hashlib import sha256
-from pathlib import Path
-
-EXPECTED = "8c45dfb3c32aa5d2991b9d3b9d710b66722f0ef10fb62a0b5dea2582f36ea383"
-path = Path("public/assets/kafka-signal/travel-basic-illustration.webp")
-
-actual = sha256(path.read_bytes()).hexdigest()
-if actual != EXPECTED:
-    raise SystemExit(f"asset drift: {actual}")
-```
-
-`travel` のCIでは、source/destination digestのlock値だけでなく、vendored fileと `dist/` のbuild後fileを実際に読み直して同じSHA-256になることを確認している。
-
-## 5. 検証
-
-この設計で見るべき境界は4つある。
-
-### 1. 正準source
-
-registryに記録されたSHA-256と中央repoの実fileが一致するか。
-
-`prompt-vault` のvendoring実装はcanonical source SHA-256を確認してからcopyする。さらに、既存destinationがlocalで変更済み、または未管理fileを別内容で上書きしようとする場合はsilent overwriteせず失敗する。
-
-### 2. consumer checkout
-
-lock fileの `canonical_commit` とasset digestが期待値どおりか。
-
-### 3. build artifact
-
-source treeで合っていてもbuild工程で別fileに置換される可能性があるので、`dist/` 側もhashを再計算する。
-
-`travel` のworkflowは `public/assets/...` と `dist/assets/...` の両方を検証している。
-
-### 4. deploy後
-
-最後に公開URLからfileを再取得してSHA-256を確認する。
-
-`travel` のworkflowはGitHub Pages deploy成功後、公開された `travel-basic-illustration.webp` を `curl` で取得し、同じ `8c45...ea383` と一致することを検証する。
-
-つまり検証chainは次のようになる。
+これでasset更新は、
 
 ```text
-canonical asset
-  -> vendor後のconsumer file
-  -> build artifact
-  -> deployed file
+中央repoで差し替えた
 ```
 
-各段階で同じdigestを要求する。
+だけではconsumerへ届かない。
 
-## 6. 失敗と学び
+consumer側でも、新commitと新hashを採用する変更としてreviewされる。
 
-### 壊れた例: URLだけを信じる
+**共有assetの更新を、review可能なversion changeへ変える。**
 
-```html
-<img src="https://raw.githubusercontent.com/example/assets/main/hero.webp">
-```
+## commit pinだけではconsumer内の実fileまでは確認できない
 
-この方式では、consumerのPRで確認したあとに中央repoの `main` が進めば、consumerのcode review外で表示内容が変わる。
+commit permalinkでsource versionは固定できる。
 
-### 改善後: 採用versionをconsumerで固定する
+しかしcopy後のfileが本当に同じbytesかは別である。
+
+例えば、
+
+- vendor scriptのbug
+- local edit
+- build processでの置換
+- deploy時の別asset混入
+
+があれば、source commitは正しくても公開物は違う。
+
+そこで各段階でhashを取り直す。
 
 ```text
-asset ID       = travel-basic
-source repo    = KAFKA2306/prompt-vault
-source commit  = 90111f8...
-SHA-256        = 8c45dfb3...ea383
-destination    = public/assets/kafka-signal/travel-basic-illustration.webp
+canonical source
+  ↓ SHA-256
+consumer checkout
+  ↓ SHA-256
+build artifact
+  ↓ SHA-256
+deployed file
 ```
 
-これならasset更新は「中央repoの変更」だけでは完了しない。consumer側で新commit・新hashをlockへ反映する変更としてreviewできる。
+すべて同じdigestを要求する。
 
-もう1つ重要なのは、**hashをmanifestへ書くだけでは検証にならない**ことである。`travel` の実装が強いのは、PR buildとdeploy後の両方で実fileからdigestを再計算している点にある。
+## `travel` ではdeploy後までread-backする
 
-## 7. 再現方法
+consumer側では、source treeだけでなく `dist/` のbuild後fileもhash確認する。
 
-GitHub Pagesや画像生成環境がなくても、2つのdirectoryだけで再現できる。
+さらにPages deploy後、公開URLからassetを取得し、同じSHA-256になることを検証する。
 
-1. `source/hero.txt` に `version-1` と書く。
-2. SHA-256を計算して `manifest.json` に保存する。
-3. `source/hero.txt` を `consumer/public/hero.txt` へcopyする。
-4. `lock.json` へsource commit相当の識別子とSHA-256を書く。
-5. consumer側でfileを読み直し、lockのSHA-256と一致することを確認する。
-6. sourceだけ `version-2` に変更し、manifestのhashを更新せずvendorを試す。
-7. source hash mismatchで停止することを確認する。
-8. 次にconsumer側だけ手編集し、destination hash mismatchで停止することを確認する。
+つまり、
 
-最小scriptは次の形でよい。
-
-```python
-from hashlib import sha256
-from pathlib import Path
-
-expected = Path("manifest.sha256").read_text().strip()
-actual = sha256(Path("source/hero.txt").read_bytes()).hexdigest()
-assert actual == expected, (expected, actual)
+```text
+正しいsourceを選んだ
 ```
 
-ここで確かめたいのはcopy処理そのものではない。**更新がreview可能なversion changeとして現れ、期待していないbytesが黙ってconsumerへ入らないこと**である。
+だけで終わらず、
 
-## まとめ
+```text
+利用者へ配られたbytesも同じだった
+```
 
-共有アセットを中央管理するとき、`main` URLを共通化するだけではversion管理にならない。
+まで確認する。
 
-今回の実装から再利用できる最小contractは次の4点だった。
+ここまで追うと、asset更新の責任範囲が明確になる。
 
-1. consumerはpathではなくcanonical asset IDを選ぶ
-2. source repositoryのcommit IDを固定する
-3. sourceとdestinationのSHA-256をlockへ残す
-4. PR buildとdeploy後に実bytesからdigestを再計算する
+## 中央管理と自動追従は同じではない
 
-GitHubのcommit permalinkは「どのversionを指したか」を固定する。consumer lockのSHA-256は「実際に配ったbytesがそのversionの期待値と一致したか」を検証する。
+共有asset基盤を作ると、全consumerを常に最新版へ自動追従させたくなる。
 
-この2つを分けると、共有assetを増やしても「中央repoの更新だけで全siteの見た目が暗黙に変わる」状態を避けながら、各consumerの変更を小さなreview可能単位にできる。
+しかし、ブランド画像やhero imageのように公開UXへ直接効くassetでは、それが望ましいとは限らない。
+
+```text
+central source = 1か所で管理
+```
+
+と、
+
+```text
+automatic adoption = 全consumerへ即反映
+```
+
+は別の設計判断である。
+
+今回の構成は、中央sourceを持ちながらconsumer adoptionを明示的な更新にした。
+
+速度より、**consumerがいつ何を採用したかを説明できること**を優先した。
+
+## silent overwriteも止める
+
+vendor先に既存fileがあり、期待hashと違う場合に、そのまま上書きするとlocal changeを消す可能性がある。
+
+そのため、
+
+```text
+managed file + expected old hash
+→ update可能
+
+unknown file / locally modified bytes
+→ fail
+```
+
+のように扱う。
+
+共有基盤だから強制的に上書きするのではなく、consumer側の状態も尊重する。
+
+## このpatternが向く場面
+
+特に効くのは、
+
+- 複数GitHub Pagesで共通画像を使う
+- design system assetを複数repoへ配る
+- ロゴやiconのversionを固定したい
+- build/releaseの再現性が必要
+- 中央更新をconsumer reviewなしで反映したくない
+
+といった場合である。
+
+逆に、常に最新を表示すること自体が要件ならruntime hotlinkも合理的である。
+
+大事なのは、**変更追従を意図しているのか、偶然そうなっているのか**を区別することだ。
+
+## 最小導入はcommit + hashだけでもよい
+
+大きなregistryを最初から作る必要はない。
+
+1つの共有fileについて、
+
+```yaml
+source_repo: KAFKA2306/prompt-vault
+source_commit: 90111f8...
+source_sha256: 8c45dfb3...
+destination: public/assets/hero.webp
+```
+
+をlockへ置く。
+
+CIでdestinationのSHA-256を再計算する。
+
+それだけでも、`main` hotlinkよりかなり説明可能になる。
+
+中央assetを更新しても、consumerが勝手に変わらない。
+
+consumerが更新するときは、その差分がPRとして見える。
+
+**中央管理と公開安定性を両立するには、「最新を共有する」のではなく「採用versionを共有する」方が扱いやすかった。**

--- a/articles/2026-08-14-03-manifest-drift-gate.md
+++ b/articles/2026-08-14-03-manifest-drift-gate.md
@@ -1,92 +1,62 @@
 ---
-title: "再生成できるmanifestほど差分で守る"
+title: "CIが自分で直してからgreenになる。manifestの「更新忘れ」を差分で止める"
 emoji: "🧾"
 type: "tech"
 topics: ["python", "githubactions", "dataengineering", "testing", "ci"]
 published: false
 ---
 
-生成物をGit管理していると、CIで「もう一度生成して成功した」だけで安心したくなります。
+元データだけ更新して、manifestの更新を忘れた。
 
-しかし、manifestのような**生成物そのものが契約**になっている場合、それでは不十分です。元データだけ更新してmanifestを更新し忘れても、CIが最初にmanifestを再生成してしまえば、その不整合を自分で消してから検証できてしまうからです。
+本来ならCIに止めてほしい。
 
-この記事では、公開GitHub上の実装を題材に、次の2つを分離する設計を整理します。
-
-1. **artifactの内容がmanifestに記録されたSHA-256・byte sizeと一致するか**
-2. **PRにcommitされたmanifestが、現在の入力から再生成した結果と一致するか**
-
-結論は単純です。
-
-> **生成物の正しさと、生成物をcommitし忘れていないことは別の性質なので、別々にfail-closeで検証する。**
-
-## 問題：再生成が「古いmanifest」を隠してしまう
-
-たとえば、次の3ファイルを1つのmanifestで束ねるとします。
+しかしCIが最初にmanifestを再生成すると、古かったmanifestを自分で最新へ直してから検証できてしまう。
 
 ```text
-data/events.ndjson
-data/audit.json
-data/state.json
-```
+checkout時点
+artifact = new
+manifest = old
 
-manifestには各artifactのpath、SHA-256、byte sizeを保存します。
-
-```json
-{
-  "status": "PASS",
-  "artifacts": [
-    {
-      "path": "data/events.ndjson",
-      "sha256": "...",
-      "size_bytes": 1234
-    }
-  ]
-}
-```
-
-ここで `events.ndjson` だけ更新し、manifestの更新を忘れたとします。
-
-壊れたCIは次の順です。
-
-```text
-checkout
-  ↓
-manifestを再生成
-  ↓
-再生成後manifestを検証
-  ↓
+CI
+  ↓ manifestを再生成
+artifact = new
+manifest = new
+  ↓ verify
 PASS
 ```
 
-この流れでは、checkout直後に存在した「artifactは新しいのにmanifestは古い」という状態が消えています。
+結果はgreen。
 
-実際の公開実装 `KAFKA2306/semiconductor-earnings-model` では、`build_earnings_lineage_manifest.py` が複数artifactからSHA-256とbyte sizeを計算して `lineage_latest.json` を生成し、workflowはその後にmanifestを検証します。PRでは最後に `git diff --exit-code -- data/earnings_ledger/lineage_latest.json` を実行し、再生成によって差分が出た場合を失敗にします。
+でも、PRにcommitされていた状態は不完全だった。
 
-一次情報:
+`KAFKA2306/semiconductor-earnings-model` では、この「勝手に直してからgreen」を防ぐため、manifestの正しさと**commit漏れがないこと**を別々に検証している。
 
-- https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/scripts/build_earnings_lineage_manifest.py
-- https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/.github/workflows/earnings-lineage.yml
+- builder: https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/scripts/build_earnings_lineage_manifest.py
+- workflow: https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/.github/workflows/earnings-lineage.yml
+- verifier: https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/scripts/verify_earnings_lineage_manifest.py
 
-## 原因：2種類の不整合を1つの検査だと思ってしまう
+この記事で扱うのはmanifest formatではない。
 
-manifest運用には、少なくとも2種類の失敗があります。
+**green CIを見たとき、「そのcommit自身が必要な生成物を全部含んでいる」と信頼できるようにする設計**について書く。
 
-### 1. manifestとartifactの不整合
+## 2種類の「正しい」を分ける
 
-manifestに記録されたdigestやsizeと、実ファイルが一致しない状態です。
+manifest運用には、似ているが別の整合性がある。
 
-これはverifierで検出できます。
+### artifact integrity
+
+manifestに書かれたSHA-256やbyte sizeと、実fileが一致するか。
 
 ```text
-manifest.sha256 != sha256(file bytes)
-manifest.size_bytes != len(file bytes)
+manifest.sha256 == sha256(file bytes)
+manifest.size_bytes == len(file bytes)
 ```
 
-### 2. repository stateと再生成結果の不整合
+これはverifierで確認できる。
 
-manifest自体は構文的に正しくても、現在の入力から作り直すと内容が変わる状態です。
+### repository freshness
 
-これは「manifestを検証する」だけではなく、**再生成後にGit差分を見る**ことで検出できます。
+PRへcommitされたmanifestが、現在の入力から再生成した結果と一致するか。
 
 ```text
 committed manifest
@@ -96,292 +66,217 @@ rebuild from current inputs
 git diff --exit-code
 ```
 
-この2つは似ていますが、守っている対象が違います。
+こちらはhash verificationだけでは分からない。
 
-- verifier: **manifestが指しているbytesは本当にそのbytesか**
-- diff gate: **PRは現在のbytesに対応するmanifestまでcommitしたか**
+**正しいmanifestを生成できることと、そのmanifestがPRへ入っていることは別である。**
 
-## 設計判断：builder、verifier、repository diffを分離する
+## builderが成功したことを完成条件にしない
 
-公開実装では役割が3つに分かれています。
+`build_earnings_lineage_manifest.py` はartifactを読み、SHA-256とsizeを計算し、lineage manifestを生成する。
 
-### builder
+このbuilder自体が正しくても、CIの順序を間違えると stale manifest を隠せる。
 
-`build_earnings_lineage_manifest.py` はrequired artifactを列挙し、欠損を拒否したうえで、それぞれのSHA-256とbyte sizeを計算します。
+悪い順序:
 
-さらに、単にhashを作るだけではなく、複数のaudit artifactが同じrunに結びついていることや、audit statusが `PASS` であることも確認します。
+```text
+checkout
+→ build manifest
+→ verify manifest
+→ PASS
+```
 
-つまりbuilderは、**どのartifact集合を1つのlineageとして認めるか**を定義しています。
+改善後:
 
-### verifier
+```text
+checkout
+→ tests
+→ build manifest
+→ verify manifest
+→ git diff --exit-code -- manifest
+```
 
-`verify_earnings_lineage_manifest.py` はmanifestを入力として読み、各artifactをrepository bytesから再計算します。
+再生成はする。
 
-公開実装で拒否される条件には次が含まれます。
+しかし、**再生成した結果がcheckout時点と違えば失敗させる。**
 
-- manifestのstatusが `PASS` ではない
-- artifactsが空
-- 同じpathが重複
-- SHA-256が64桁の小文字hexではない
-- `size_bytes` が非整数または負数
-- artifact pathがrepository rootの外へ出る
-- manifest自身をartifactとしてbindする
-- artifactが存在しない
-- SHA-256 mismatch
-- byte size mismatch
+これで「CIが直せた」は成功条件にならない。
 
-一次情報:
+## verifierとdiff gateは守る対象が違う
 
-- https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/scripts/verify_earnings_lineage_manifest.py
+verifierは、manifest内の各artifactについて、
 
-Python標準ライブラリの `hashlib` は `sha256()` にbytesを渡してdigestまたはhex digestを得るインターフェイスを提供しています。上記実装もartifactをbytesとして読み、`hashlib.sha256(payload).hexdigest()` で再計算しています。
+- path
+- SHA-256
+- byte size
+- file existence
+- duplicate path
+- path traversal
+- status
 
-一次情報:
+などを確認する。
 
-- https://docs.python.org/3/library/hashlib.html
+これは「manifestが指している実体」を守る。
 
-### repository diff gate
-
-workflowはmanifestを再生成・検証したあと、pull requestでのみ次を実行します。
+一方、
 
 ```bash
 git diff --exit-code -- data/earnings_ledger/lineage_latest.json
 ```
 
-ここで差分があれば、builderが生成した正しいmanifestをまだPRへcommitしていないことになります。
-
-重要なのは、**再生成を禁止するのではなく、再生成して差分が出ないことを契約にする**点です。
-
-## 代替案と落とし穴
-
-### 代替案A：CIで毎回生成してartifactとしてだけ保存する
-
-repositoryにmanifestをcommitしない設計なら成立します。
-
-ただし、manifestをcode reviewの対象にしたい、commit単位でlineageを追いたい、repository checkoutだけで状態を復元したい場合は別です。その場合、commitされたmanifestと生成結果の一致が必要になります。
-
-### 代替案B：manifestのschemaだけ検証する
-
-path、digest、sizeの型が正しいことは確認できますが、実ファイルとの一致は確認できません。
-
-```json
-{
-  "sha256": "0000...0000",
-  "size_bytes": 1234
-}
-```
-
-のような値でも形式だけなら通ります。
-
-### 代替案C：hashだけ確認する
-
-内容同一性の主検査としてSHA-256は有効ですが、公開実装はbyte sizeも別に保持して照合しています。これはmanifestの可読な整合性情報を増やし、hash mismatchとsize mismatchを別の診断として出せます。
-
-### 採用する形：3層にする
+は、「PRが必要なmanifest更新まで含んでいるか」を守る。
 
 ```text
-入力artifactの意味的条件
-        ↓ builder
-manifest生成
-        ↓ verifier
-bytesとのbinding確認
-        ↓ diff gate
-commit漏れ確認
+verifier
+→ bytes bindingの正しさ
+
+diff gate
+→ commit completenessの正しさ
 ```
 
-1つの巨大なscriptへまとめるより、「何が壊れたか」が分かりやすくなります。
+一つの巨大な `verified: true` へ押し込まない。
 
-## 実装：最小構成を作る
+## PR reviewで見たいものをrepositoryへ残すなら、drift gateが必要になる
 
-以下は考え方を再現する最小例です。
+manifestをCI artifactとして毎回作るだけなら、repositoryへcommitしなくてもよい。
 
-### builder
+しかし、
 
-```python
-import hashlib
-import json
-from pathlib import Path
+- code reviewでmanifest差分を見たい
+- commit単位でlineageを残したい
+- checkoutだけで状態を復元したい
 
-ROOT = Path(".")
-TARGETS = [Path("data/a.txt"), Path("data/b.txt")]
+なら、manifest自体がrepository stateの一部になる。
 
-
-def sha256_file(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-manifest = {
-    "status": "PASS",
-    "artifacts": [
-        {
-            "path": path.as_posix(),
-            "sha256": sha256_file(path),
-            "size_bytes": path.stat().st_size,
-        }
-        for path in TARGETS
-    ],
-}
-
-Path("data/manifest.json").write_text(
-    json.dumps(manifest, indent=2) + "\n",
-    encoding="utf-8",
-)
-```
-
-### verifier
-
-```python
-import hashlib
-import json
-from pathlib import Path
-
-manifest = json.loads(Path("data/manifest.json").read_text())
-
-for item in manifest["artifacts"]:
-    path = Path(item["path"])
-    payload = path.read_bytes()
-    assert hashlib.sha256(payload).hexdigest() == item["sha256"]
-    assert len(payload) == item["size_bytes"]
-```
-
-### CI
-
-説明用workflow stagesとしては次の順です。
+その場合、
 
 ```text
-1. test builder / verifier
-2. rebuild manifest
-3. verify rebuilt manifest against repository bytes
-4. on pull request, require git diff to be empty for manifest
+生成可能
 ```
 
-GitHub上の公開実装もこの順で、test → build → verify → artifact upload → PRでmanifest差分確認、というstageを持っています。
+だけでは足りない。
 
-## 検証：壊れた失敗例を作る
+```text
+そのcommitに生成結果が含まれている
+```
 
-最小例で `data/a.txt` とmanifestを生成したあと、`a.txt` だけ変更します。
+ことまで必要になる。
+
+## 最小例は4ファイルで再現できる
+
+```text
+data/a.txt
+data/manifest.json
+build_manifest.py
+verify_manifest.py
+```
+
+最初に、
 
 ```bash
 printf 'v1\n' > data/a.txt
 python build_manifest.py
-git add data/a.txt data/manifest.json
+git add .
 git commit -m 'initial'
+```
 
+とする。
+
+次にsourceだけ変える。
+
+```bash
 printf 'v2\n' > data/a.txt
 ```
 
-### verifierを先に実行する場合
-
-古いmanifestをそのまま検証すれば、SHA-256 mismatchで停止します。
-
-### builderを先に実行する場合
+この状態で、
 
 ```bash
 python build_manifest.py
 python verify_manifest.py
 ```
 
-ここだけを見るとPASSします。builderが新しい `a.txt` に対応するhashへmanifestを書き換えたからです。
+だけ実行するとPASSできる。
 
-しかし続けて、
+builderがmanifestを新しいhashへ更新したからだ。
 
-```bash
-git diff --exit-code -- data/manifest.json
-```
-
-を実行すれば差分があるため失敗します。
-
-これが今回の中心です。
-
-> **再生成後の検証が成功したことと、PRが必要な生成物をcommit済みであることは同義ではない。**
-
-## 改善後の例
-
-正しい変更では、入力artifactとmanifestを一緒に更新します。
-
-```bash
-printf 'v2\n' > data/a.txt
-python build_manifest.py
-python verify_manifest.py
-git add data/a.txt data/manifest.json
-git commit -m 'update data and manifest'
-```
-
-CIで再度builderを実行してもmanifestは変わらないため、
+しかし、
 
 ```bash
 git diff --exit-code -- data/manifest.json
 ```
 
-は0で終了します。
+を続ければ失敗する。
 
-この状態なら、少なくとも次の3条件が揃っています。
+**「正しいmanifestを作れた」ではなく「最初から正しいmanifestをcommitしていたか」を観測できる。**
 
-- artifact bytesとmanifest bindingが一致する
-- manifestを現在の入力から決定的に再生成できる
-- PRに必要なmanifest更新が含まれている
+## generated artifactをcommitするなら、3つのstateを見る
 
-## 失敗と学び：生成物は「CIで作れた」だけでは管理できない
-
-生成物には2種類あります。
-
-1. repositoryに残さず、CI artifactとして毎回作ればよいもの
-2. repository stateの一部としてcommitし、review・履歴・再現性に使うもの
-
-後者を選んだなら、生成scriptが成功することだけでは品質条件になりません。
-
-必要なのは、**checkoutされたcommitが自己完結していること**です。
-
-そのため、commit管理するmanifestでは次を分けて考えると設計しやすくなります。
+設計を一般化すると次の3つになる。
 
 ```text
-生成可能性
+GENERATABLE
   builderが成功する
 
-内容整合性
-  verifierが実bytesとのbindingを確認する
+INTERNALLY_VALID
+  manifestと実artifactが一致する
 
-repository整合性
-  rebuildしてもgit diffが出ない
+COMMITTED_FRESH
+  再生成してもgit diffが出ない
 ```
 
-## 読者が試せる再現方法
+この3つを別々に持つと、失敗理由が分かりやすい。
 
-小さなrepositoryで次の4ファイルを作ります。
+例えば、
 
 ```text
-data/a.txt
-build_manifest.py
-verify_manifest.py
-data/manifest.json
+GENERATABLE = true
+INTERNALLY_VALID = true
+COMMITTED_FRESH = false
 ```
 
-1. `a.txt` を作る
-2. builderでmanifest生成
-3. 全ファイルをcommit
-4. `a.txt` だけ変更
-5. builder → verifierを実行してPASSすることを確認
-6. `git diff --exit-code -- data/manifest.json` が失敗することを確認
-7. manifestもcommitする
-8. 同じCIを再実行し、diffが空になることを確認
+なら、ロジックではなくcommit漏れが問題だとすぐ分かる。
 
-これで「生成結果の正しさ」と「commitの完全性」が別問題であることを数分で再現できます。
+## green CIの価値は「何を検査したか」で決まる
 
-## まとめ
+CIがgreenであること自体は証拠にならない。
 
-manifestを生成できることは重要ですが、生成できるからこそCIが不整合を消してしまうことがあります。
+CIが、checkout時点の不整合を上書きしてから検査していれば、greenは弱い。
 
-commit管理するmanifestでは、少なくとも次の3層を分けます。
+今回の設計では、
 
-- builderで正準manifestを決定的に生成する
-- verifierでmanifestと実artifact bytesを照合する
-- PRでは再生成後にGit差分がないことを確認する
+- builder
+- verifier
+- repository diff
 
-特に最後のdiff gateは地味ですが、**「入力は更新したのに生成物をcommitし忘れた」**という実務で頻出する失敗を、レビュー前に機械的に止められます。
+を分けることで、greenの意味を強くした。
 
-### 主要一次情報
+**PRを開いた人が追加作業をしなくても、そのcommitだけで再現できる状態か**を最後に見る。
 
-- https://github.com/KAFKA2306/semiconductor-earnings-model/pull/101
-- https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/scripts/build_earnings_lineage_manifest.py
-- https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/scripts/verify_earnings_lineage_manifest.py
-- https://github.com/KAFKA2306/semiconductor-earnings-model/blob/7595f0b0b7f7535d9eaea182fe5f2ba415bce8f4/.github/workflows/earnings-lineage.yml
-- https://docs.python.org/3/library/hashlib.html
+## このpatternはmanifest以外にも使える
+
+同じ問題は、commit管理するgenerated fileで起こる。
+
+- API schema
+- lock file
+- generated docs
+- index
+- catalog
+- snapshot metadata
+- codegen output
+
+CIが先に再生成すると、更新忘れを隠せる。
+
+だから、
+
+```text
+rebuild
+→ validate
+→ diff must be empty
+```
+
+という順序を使う。
+
+生成物をGitへ入れるなら、**「再生成できる」を「更新不要」と取り違えないこと**が重要だった。
+
+manifestが古いままのPRを、CI自身が直してgreenにする。
+
+その偽の安心を止めるために、最後の `git diff` が効いた。


### PR DESCRIPTION
## Summary

UX-first / sales-first刷新の第3波Aです。5本を「技術を実装した」説明から、利用者が結果をどう信頼できるかへ再構成しました。

### Honest classification
`2026-08-13-03-dont-infer-domain-from-language.md`
- 推測で一覧を埋めるより、`unclassified` を正しいunknown stateとして扱う
- semantic metadata coverageを改善対象として観測できるUXへ

Closes #72

### Effect size / allowed use
`2026-08-13-04-effect-size-is-not-a-conclusion.md`
- Cohen's d ≈ -0.760を残しつつ、classification / causal claimへ自動昇格させない
- metric / evidence_strength / allowed_useを分離

Closes #73

### Legacy limit / complete archive
`2026-08-13-04-legacy-limit-complete-archive.md`
- API互換より「61件目が消えない」product semanticsを中心へ
- legacy argumentとproduction complete semanticsを分離

Closes #74

### Shared asset pinning
`2026-08-13-05-pin-assets-commit-sha256.md`
- 中央管理assetを更新してもconsumer siteが勝手に変わらないUXへ
- asset ID / commit / SHA-256 / build / deploy read-backのchainを明確化

Closes #75

### Manifest drift
`2026-08-14-03-manifest-drift-gate.md`
- CIがstale manifestを自分で直してgreenにする偽の安心を中心sceneへ
- generatable / internally valid / committed freshを分離

Closes #79

## Validation intent
- 5 files only
- `published: false`維持
- 既存public evidenceを保持
- Article Pipeline CI successをmerge gateにする