### PR TITLE
Refresh volatile articles against current primary sources

### DIFF
--- a/articles/claude-watermark-secret-key-detection.md
+++ b/articles/claude-watermark-secret-key-detection.md
@@ -1,209 +1,261 @@
 ---
-title: "Claudeの「秘密の透かし」は誰のため？ 検出と秘密鍵共有を分けて考える"
+title: "AIの「秘密の透かし」は誰が検出する？ 生成側の秘密と第三者検証を分けて考える"
 emoji: "🔐"
 type: "tech"
-topics: ["claude", "watermark", "security", "llm", "ai"]
+topics: ["watermark", "security", "llm", "ai", "provenance"]
 published: false
 published_at: 2026-08-13 09:00
 ---
 
-# Claudeの「秘密の透かし」は誰のため？ 検出と秘密鍵共有を分けて考える
+「AIが生成した文章に、外からは見えない透かしが入っている」と聞くと、次の疑問が出る。
 
-Claudeの生成テキストに機械検出可能なmarkingを入れるとしたら、誰がそれを判定できるのでしょうか。
+> 第三者が検出するには、生成側の秘密まで共有しないといけないのでは？
 
-この問いを考えると、すぐに「秘密鍵を第三者へ渡さなければ検出できないのでは？」という疑問が出ます。
+最初はClaudeを題材にこの疑問を考えていた。
 
-しかし、公開されているtext watermark研究を見ると、**検出できること**と**watermark keyを第三者へ配ること**は同じ問題ではありません。
+しかし、2026年8月14日にAnthropicの現行一次情報を確認し直すと、記事の前提を変える必要があった。
 
-この記事では、この1点だけを整理します。
+AnthropicのTransparency Hubは、Claudeが現在text-based outputsを提供していること、watermarkingについてindustry・academiaで技術動向を追い、適用法令への準備を進めていることを説明している。一方、その公開ページは**Claudeのtext outputへ現在どのwatermark方式を実装しているか、secret/keyをどう管理するか、第三者向けtext detectorを提供しているか**までは述べていない。
 
-なお、2026年8月13日時点で、AnthropicがClaudeのtext watermarkについて、sampling方式、key管理、detector APIの内部仕様を公開している一次情報は確認できませんでした。したがって、ClaudeがGoogle SynthID-Textや特定論文と同じ方式を使っているとは扱いません。
+- Anthropic Transparency Hub: https://www.anthropic.com/transparency/voluntary-commitments/security%26privacy
 
-## まず、公開研究では何が起きているか
+だから、Claudeに「秘密のtext watermarkが実装されている」という前提では書かない。
 
-Google DeepMindのSynthIDは、AI生成textへwatermarkを埋め込み、後から識別する技術を公開しています。
+代わりに、現在実装を公式に説明しているGoogle DeepMindのSynthIDを実例にして、もっと一般的な問いへ戻す。
 
-公式説明では、LLMが次tokenを選ぶときの確率分布へ追加情報を入れ、watermark patternを作ります。
+**AI生成物を第三者が検証できることと、生成側の秘密情報を第三者へ配ることは同じ要件なのか。**
+
+## まず、現在公開されている事実を分ける
+
+### Anthropicについて確認できること
+
+Anthropicの現行Transparency Hubは、Claudeのoutput transparencyに関してwatermarkingの技術動向を探索・追跡していると説明している。
+
+ここから言えるのは、watermarkingが検討対象であることまでだ。
+
+この記事では次を推測しない。
+
+```text
+Claudeには現在text watermarkが入っている
+Claudeは特定のsecret key方式を使っている
+Claudeには非公開detector APIがある
+ClaudeはSynthIDと同じ方式である
+```
+
+公開されていない内部設計を、別providerの技術から逆算しない。
+
+### SynthIDについて確認できること
+
+Google DeepMindの現行SynthIDページは、image / audio / text / videoへwatermarkを埋め込む技術を説明している。
+
+textについては、Gemini app / web experienceで生成されたtextのwatermarking・identificationへSynthIDを拡張し、LLMのtoken probability scoreを調整してwatermarkを生成すると説明している。
 
 - Google DeepMind SynthID: https://deepmind.google/models/synthid/
-- 公式技術解説: https://deepmind.google/blog/watermarking-ai-generated-text-and-video-with-synthid/
 
-重要なのは、watermarkが文章の末尾へ固定文字列を付ける方式ではないことです。生成時のtoken選択へ統計的な偏りを入れ、その偏りを後からscoreとして検出します。
+一方、同じ現行ページで一般ユーザー向けに案内されているGeminiのupload検証とSynthID Detector portalは、image / video / audioを対象として記載されている。
 
-概念的には次のように分けられます。
+つまり、**watermarking技術が存在すること**と、**誰でも使える同一形式のverification interfaceが存在すること**も別問題である。
 
-```text
-生成
-LLM token distribution
-        ↓
-watermarking rule
-        ↓
-選択分布をわずかに変える
-        ↓
-text
+## 「watermarkがある」を1bitで扱わない
 
-検出
-text
-  ↓
-同じwatermarking ruleに基づきscoreを計算
-  ↓
-watermarked / not watermarked を統計判定
-```
-
-この構造から分かるのは、**検出処理と文章生成処理は別に実装できる**ということです。
-
-## 「第三者が検出する」には2通りある
-
-ここで鍵管理を考えます。
-
-### 方式A: detectorを第三者へ配る
-
-第三者が必要な情報を持ち、自分でwatermark scoreを計算します。
+生成AIのprovenanceを評価するとき、最低限4つへ分けると整理しやすい。
 
 ```text
-third party
-  ├─ text
-  ├─ detector
-  └─ detectorに必要なkey / parameter
-       ↓
-     score
+1. Embedding
+   何を生成時に埋め込むか
+
+2. Secret / parameters
+   検出に必要な非公開情報があるか、誰が保持するか
+
+3. Detection
+   何を入力に、どの主体が判定するか
+
+4. Verification interface
+   外部利用者へ何を公開するか
 ```
 
-この方式は検出主体が独立できますが、秘密にしたい情報まで配布する設計なら、漏えい・解析・偽装への対策が必要になります。
+これらは別componentである。
 
-### 方式B: keyはprovider内部に置き、判定APIだけ公開する
+「watermarkあり」という説明だけでは、
+
+- providerだけが検出できるのか
+- 第三者がローカル検出できるのか
+- API経由で判定だけ受け取るのか
+- secretを配る必要があるのか
+- provider停止後も検証できるのか
+
+は分からない。
+
+## 第三者検証に「secretの配布」は必須ではない
+
+これは特定providerの現行実装を説明する話ではなく、architecture上の分離である。
+
+例えばverification service型なら、
 
 ```text
 third party
-  ↓ text
-provider detector API
-  ↓
-provider内部のkey / detector
-  ↓
-score / 判定だけ返す
+   ↓ content
+verification service
+   ↓
+private detector / parameters
+   ↓
+result
 ```
 
-この構成なら、第三者はwatermarkを確認できますが、keyそのものを受け取る必要はありません。
+とできる。
 
-したがって、
+第三者はcontentを送って判定結果を受け取るが、detector内部のsecret materialを直接受け取らない。
 
-> 第三者にも検出可能にしたい
-
-という要求から、
-
-> 秘密鍵を第三者全員へ配る必要がある
-
-とは導けません。
-
-## なぜ「鍵を公開しない検出」に意味があるのか
-
-watermarkに秘密情報を使う設計では、その情報が攻撃者へ渡ると、watermark除去や偽watermark生成を容易にする可能性があります。
-
-一方で、判定結果だけを返すAPIなら、key materialをprovider側に閉じたまま外部検証を提供できます。
-
-もちろん、API化すれば別の問題が生まれます。
-
-- provider停止時に検証できない
-- rate limitや料金に依存する
-- providerが判定ロジックを変更できる
-- 第三者がdetector自体を監査しにくい
-
-つまり設計問題は「秘密鍵を共有するかどうか」だけではありません。
-
-**検出可能性・独立監査性・攻撃耐性・運用依存性をどこで分けるか**です。
-
-## SynthIDからClaudeの内部実装を逆算しない
-
-ここがこの記事で最も重要な境界です。
-
-SynthIDがtoken probabilityへwatermarkを入れているからといって、Claudeも同じ方式とは言えません。
-
-同様に、公開研究にkeyed watermarkがあるからといって、Claudeにも同じ意味の秘密鍵があるとは断定できません。
-
-この記事で確実に言えるのは次だけです。
+一方、独立検証を優先するなら、
 
 ```text
-公開研究では
-「検出」と「key配布」を分離できる設計が存在する
+third party
+   ├─ content
+   └─ independently usable verifier
 ```
 
-Claude固有の内部仕様については、Anthropicの一次情報が公開されるまで未確定として扱います。
+のように、provider外でも検証できる設計が必要になる。
 
-## EU AI Actが要求しているのは「秘密鍵共有」ではない
+この2つはtrade-offが違う。
 
-EU AI Act Regulation (EU) 2024/1689 Article 50(2) は、synthetic audio / image / video / textを生成するAI system providerに対し、出力をmachine-readable formatでmarkし、人工生成・操作されたことをdetectableにするよう求めています。
+| 設計 | secret管理 | 独立性 | provider依存 |
+|---|---|---|---|
+| Provider verification service | provider側へ閉じやすい | 低い | 高い |
+| Public / independently usable verifier | verifier設計次第 | 高めやすい | 低くできる |
+| Operator-only detection | 外部共有不要 | 低い | 非常に高い |
 
-一次情報:
-https://eur-lex.europa.eu/eli/reg/2024/1689/oj?locale=en
+重要なのは、**第三者検証可能性とsecret共有範囲を別の設計変数として扱うこと**だ。
 
-ここでも条文が要求しているのは、**machine-readable markingとdetectability**です。
+## 「検出できる」の中にも複数のUXがある
 
-「watermark secretを一般公開すること」までは書かれていません。
+利用者から見ると、どれも「watermarkを確認できる」ように見える。
 
-したがって制度面でも、
+しかし体験は違う。
+
+### providerへ聞く
 
 ```text
-detectableである
-!=
-secret keyを公開する
+contentを送る
+→ providerが判定
+→ resultを返す
 ```
 
-と分けて考える必要があります。
+簡単だが、provider availabilityや判定仕様へ依存する。
 
-## 検出器を評価するときの4つの質問
-
-text watermarkを採用するサービスを見るときは、次の4点を分けて確認すると混乱しにくくなります。
-
-1. **何をmarkしているか**  
-   token selectionなのか、metadataなのか、別の信号なのか。
-
-2. **誰がdetectできるか**  
-   providerだけか、一般ユーザーか、限定された第三者か。
-
-3. **何を共有する必要があるか**  
-   full detector、public parameter、secret key、API accessのどれか。
-
-4. **判定を独立検証できるか**  
-   provider停止後も検証できるのか、provider APIへの依存が残るのか。
-
-「watermarkがある」という1bitの説明だけでは、この4つは分かりません。
-
-## 読者が再利用できる最小モデル
-
-生成AIのprovenance機能を設計するときは、次のように役割を分けると整理しやすくなります。
+### 自分で検証する
 
 ```text
-Generator
-  └─ watermark embedding
-
-Key / secret service
-  └─ detectorに必要な秘密情報を保持
-
-Detector
-  └─ textからscoreを計算
-
-Verification interface
-  └─ 第三者へ結果を返す
+content + verifier
+→ local / independent verification
 ```
 
-この4つを1つの「watermark機能」に潰さないことが重要です。
+再現性は高めやすいが、公開できるverification materialの設計が必要になる。
 
-GeneratorとDetectorを別サービスにしてもよいし、keyをDetector内部だけに閉じてもよい。第三者へはverification interfaceだけを公開することもできます。
+### providerだけが内部利用する
+
+abuse monitoringや内部provenanceには使えても、一般ユーザーは直接確認できない。
+
+「detectable」という言葉だけでは、どのUXなのか分からない。
+
+## 実装を評価するときは5つ質問する
+
+AI生成物のmarking機能を見るとき、私は今後次を分けて確認する。
+
+1. **現在、本当に実装済みか**  
+   research / exploration / commitmentとproduction deploymentを分ける。
+
+2. **何をmarkしているか**  
+   text token selection、media signal、metadataなど。
+
+3. **誰がdetectできるか**  
+   provider、一般ユーザー、限定partner、独立第三者。
+
+4. **verificationに何が必要か**  
+   public verifier、API access、private parametersなど。
+
+5. **providerなしで将来も検証できるか**  
+   long-term provenanceとして使うなら重要になる。
+
+この5問を通すと、「watermarkがあるらしい」という曖昧な説明から、実際の利用可能性へ進める。
+
+## Claudeについては「未確認」を正しいstateにする
+
+この記事を書き直して一番大きく変わったのはここだった。
+
+旧稿では、Claudeにsecret watermarkがあると仮定したときの設計を中心に考えていた。
+
+現行一次情報へ戻ると、Anthropicはwatermarkingへの取り組み・準備を説明しているが、この記事で必要なClaude text watermarkの具体実装は公開確認できない。
+
+だからstateを、
+
+```text
+implemented_secret_text_watermark
+```
+
+ではなく、
+
+```text
+vendor_publicly_discusses_watermarking
+specific_claude_text_watermark_implementation = not established here
+```
+
+へ戻す。
+
+**分からないものを、別providerの例で埋めない。**
+
+これはwatermark技術そのものより、AI productを評価するときの重要な習慣だと思う。
+
+## 読者が自分のsystemへ持ち帰る最小model
+
+自社で生成物provenanceを設計するなら、最初から「watermark機能」という1boxにしない。
+
+```yaml
+provenance:
+  embedding:
+    mechanism: TBD
+
+  detection:
+    operator: TBD
+
+  verification_interface:
+    audience: TBD
+
+  secret_or_parameters:
+    holder: TBD
+
+  long_term_verifiability:
+    provider_independent: TBD
+```
+
+この形なら、
+
+- secretは閉じたい
+- 顧客には確認手段を提供したい
+- 監査者には独立verificationを提供したい
+
+といった要件を別々に議論できる。
 
 ## まとめ
 
-最初の疑問は「秘密鍵を第三者へ渡さないとwatermarkを検出できないのでは？」でした。
+最初の疑問は、
 
-公開研究から分かる答えは、もっと設計自由度があります。
+> 第三者へ検出させるなら、秘密鍵も渡さないといけないのでは？
 
-**第三者が検出できることと、第三者が秘密鍵を保持することは別です。**
+だった。
 
-providerがkeyを保持したままdetector APIだけを公開する設計も成立します。一方、独立監査性を重視するなら、別の公開検証方式が必要になります。
+今の結論はもっと分解されている。
 
-Claudeについては内部仕様を推測しません。Anthropicが公開していない部分を、SynthIDや他研究から埋めないこと自体が、この記事の証拠境界です。
+**第三者が検証できること、誰がdetectorを持つこと、secretを誰が保持すること、providerなしで独立検証できることは別の要件である。**
+
+そしてClaudeについては、2026年8月14日時点のAnthropic公開情報を超えて具体的なtext watermark実装を推測しない。
+
+公開実装の具体例が必要ならSynthIDを見る。
+
+vendor固有の事実が必要ならvendor自身の現在の一次情報へ戻る。
+
+その境界を守る方が、もっともらしい説明を作るより役に立つ。
 
 ## 一次情報
 
-- Google DeepMind — SynthID: https://deepmind.google/models/synthid/
-- Google DeepMind — Watermarking AI-generated text and video with SynthID: https://deepmind.google/blog/watermarking-ai-generated-text-and-video-with-synthid/
-- Regulation (EU) 2024/1689 Article 50: https://eur-lex.europa.eu/eli/reg/2024/1689/oj?locale=en
+- Anthropic Transparency Hub: https://www.anthropic.com/transparency/voluntary-commitments/security%26privacy
+- Google DeepMind SynthID: https://deepmind.google/models/synthid/

--- a/articles/opencode-go-deepseek-v4-chatgpt-usage-scale.md
+++ b/articles/opencode-go-deepseek-v4-chatgpt-usage-scale.md
@@ -1,269 +1,320 @@
 ---
-title: "月10ドルのAIコーディング枠は、本当に『ほぼ無限』なのか？ 自分のChatGPT利用量と比べてみた"
+title: "月10ドルのAIコーディング枠は、自分には十分か？ OpenCode Goを「回数」ではなく容量で判断する"
 emoji: "♾️"
 type: "tech"
-topics: ["opencode", "deepseek", "chatgpt", "ai", "cost"]
+topics: ["opencode", "deepseek", "ai", "cost", "capacity"]
 published: false
 published_at: 2026-08-13 12:09
 ---
 
-# 月10ドルのAIコーディング枠は、本当に「ほぼ無限」なのか？ 自分のChatGPT利用量と比べてみた
+OpenCode GoのDeepSeek V4 Flashには、公式表で **月158,150 requests** という数字が出ている。
 
-2026年8月13日、OpenCode GoでDeepSeek V4 Pro / V4 Flashを見て、最初に出た感想はこれでした。
+最初に見ると、
 
-> これらってほぼ無限？
+> これってほぼ無限では？
 
-料金表だけ見ると、かなり大げさに見えます。
+と思う。
 
-ところがOpenCode公式が出している推定リクエスト数を見ると、少なくとも**人間が対話的にコーディングする用途では、上限を意識しない時間がかなり長そう**です。
+しかし、この読み方は正確ではない。
 
-さらに、自分のChatGPT利用量として手元に残していた集計と比べると、数字の桁がかなり違いました。
+2026年8月14日にOpenCode公式docsを確認すると、Goの利用制限は固定request数ではなく**ドル換算の利用額**で定義されている。
 
-この記事では、
+```text
+5時間  = $12 usage
+1週間  = $30 usage
+1か月  = $60 usage
+```
 
-- OpenCode Goで実際にどのくらい使えるのか
-- DeepSeek V4 ProとV4 Flashで何が違うのか
-- 自分のChatGPT利用量と比べると、どのくらい大きいのか
-- なぜ「文字通り無制限」とは言えないのか
+公式が載せている17,150回や158,150回は、観測された典型的なtoken / cache patternから換算した**推定request数**である。
 
-を、公開一次情報と手元の利用集計を分けて整理します。
+- OpenCode Go: https://opencode.ai/docs/go/
+- 日本語docs: https://opencode.ai/docs/ja/go/
 
-## まず結論
+この記事で知りたいのは「最大何回押せるか」ではない。
 
-OpenCode Goは、初月5ドル、その後10ドル/月です。
+**自分のAI coding workloadに対して、Goが日常の制約になるのかを判断できること**である。
 
-公式の利用上限は「回数」ではなく、利用額で決まります。
+## まず固定quotaではなく、capacityとして読む
 
-| 期間 | Goの利用上限 |
-|---|---:|
-| 5時間 | 12ドル相当 |
-| 1週間 | 30ドル相当 |
-| 1か月 | 60ドル相当 |
+OpenCode公式の2026年8月9日更新docsでは、DeepSeek V4 Pro / V4 Flashについて次の推定を掲載している。
 
-OpenCode公式:
-https://opencode.ai/docs/go/
-
-その上で、OpenCodeが通常の利用パターンから推定しているリクエスト数は次の通りです。
-
-| モデル | 5時間 | 1週間 | 1か月 |
+| Model | 5時間 | 1週間 | 1か月 |
 |---|---:|---:|---:|
 | DeepSeek V4 Pro | 3,450 | 8,550 | 17,150 |
 | DeepSeek V4 Flash | 31,650 | 79,050 | 158,150 |
 
-この数字だけを見ると、Flashは月15万回を超えます。
+大きい。
 
-ただし、ここで重要なのは**固定の回数制限ではない**ことです。
+ただし、これはhard quotaではない。
 
-OpenCode自身が「actual request count depends on the model you use」と説明しており、上の数字は典型的な入出力・キャッシュ量を仮定した推定値です。
+公式自身が、actual request countは使うmodelによって変わり、推定値はtypical request patternに基づくと説明している。
 
-## 「15万回使える」ではなく「典型的な使い方なら15万回相当」
+DeepSeekについて、その想定patternは次である。
 
-OpenCodeは推定に使った1リクエストあたりのパターンも公開しています。
+| Model | input | cached | output |
+|---|---:|---:|---:|
+| V4 Pro | 750 | 82,000 | 290 |
+| V4 Flash | 790 | 68,000 | 280 |
 
-DeepSeek V4 Proでは、
+つまり、同じ1 requestでも消費は同じではない。
 
-- input: 750 tokens
-- cached: 82,000 tokens
-- output: 290 tokens
+巨大な未cache contextや長いoutputを多用すれば、推定回数より速くusageを消費し得る。
 
-DeepSeek V4 Flashでは、
+逆にcacheがよく効くrequest patternなら、多数の往復を処理できる。
 
-- input: 790 tokens
-- cached: 68,000 tokens
-- output: 280 tokens
+**「月158,150回使える」ではなく、「公式が観測した典型patternなら月158,150 requests相当」と読む。**
 
-という観測パターンを置いています。
+## 自分に十分かを見るなら、累計message数より同じ期間の実測を見る
 
-公式:
-https://opencode.ai/docs/go/
+旧稿では、手元のChatGPT累計message数とOpenCodeの月次推定を単純比較していた。
 
-つまり、巨大な未キャッシュコンテキストを何度も送り、大量出力を続ければ、推定リクエスト数より早く利用額を消費します。
+これは規模感を見るには面白いが、契約判断には弱い。
 
-逆に、キャッシュがよく効く通常のコード作業なら、かなり多くの往復ができます。
-
-ここを省いて「月158,150回まで固定で使える」と書くのは不正確です。
-
-## 自分はChatGPTをどのくらい使っているのか
-
-ここで、自分のChatGPT利用量と比べてみます。
-
-手元に保存していたChatGPT利用集計では、
-
-- 累計メッセージ: **1,840件**
-- 直近サンプル: **40会話スレッド**
-- そのうち画像作成依頼を含むもの: **19会話**
-
-でした。
-
-この個人集計は公開Webの統計ではなく、自分のChatGPT利用履歴から作ったローカルな一次データです。
-
-なおOpenAI公式では、ChatGPTのSettings → Data controls → Export dataから、チャット履歴を含むデータを書き出せます。
-
-OpenAI公式:
-https://help.openai.com/en/articles/7260999-exporting-your-chatgpt-history-and-data
-
-現在の手元集計には「直近30日の送信メッセージ数」の時系列がないため、OpenCodeの月次枠と厳密に同期間比較することはできません。
-
-そのため、ここではまず**規模感だけ**を比較します。
-
-## 累計1,840メッセージを丸ごと比較するとどうなるか
-
-ChatGPTの1メッセージとOpenCodeの1リクエストは同じものではありません。
-
-それを承知で、単純に「1件」という単位だけで割るとこうなります。
-
-| OpenCode Go | 推定リクエスト数 | ChatGPT累計1,840件の何倍か |
-|---|---:|---:|
-| V4 Pro / 5時間 | 3,450 | 1.88倍 |
-| V4 Pro / 1週間 | 8,550 | 4.65倍 |
-| V4 Pro / 1か月 | 17,150 | 9.32倍 |
-| V4 Flash / 5時間 | 31,650 | 17.20倍 |
-| V4 Flash / 1週間 | 79,050 | 42.96倍 |
-| V4 Flash / 1か月 | 158,150 | 85.95倍 |
-
-一番驚いたのはここでした。
-
-**手元で集計していたChatGPTの累計1,840メッセージより、V4 Proの「5時間」の推定リクエスト数3,450回のほうが大きい。**
-
-Flashでは、5時間枠の推定31,650回だけで、1,840件の約17倍です。
-
-もちろん、これは期間を揃えた比較ではありません。
-
-それでも「普通の対話利用でこの上限を意識するのか？」という規模感を見るには参考になります。
-
-## ただし、これはChatGPTとOpenCodeの性能比較ではない
-
-ここはかなり重要です。
-
-この比較から、
-
-- DeepSeekがChatGPTより86倍使える
-- OpenCode 1リクエストがChatGPT 1メッセージと同じ価値
-- 月158,150回のコード修正が必ずできる
-
-とは言えません。
-
-ChatGPTの1会話では、Web検索、ツール実行、画像生成、長い推論など複数の処理が内部で動くことがあります。
-
-一方、OpenCodeの1リクエストも、コンテキスト量、キャッシュ、出力量によってコストが変わります。
-
-したがって今回比較しているのは**能力ではなく、ユーザーから見た利用回数のスケール**です。
-
-## DeepSeek V4自体の上限も大きい
-
-DeepSeek公式APIドキュメントでは、DeepSeek V4 Flash / Proについて、
-
-- context length: **1M**
-- maximum output: **384K**
-- JSON Output対応
-- Tool Calls対応
-
-とされています。
-
-DeepSeek公式:
-https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-
-OpenCodeの大量リクエスト枠だけでなく、1回のリクエストで扱えるコンテキスト自体も大きい構成です。
-
-## では「ほぼ無限」は正しいのか
-
-自分の使い方に限定すると、かなり近い表現だと思います。
-
-ただし、正確には次のように言うべきです。
-
-> **人間が対話的にコードを書く用途では、DeepSeek V4 Flashの上限はかなり意識しにくい。V4 Proも十分大きい。ただし自律エージェントを大量並列・長時間で回せば普通に到達し得る。**
-
-OpenCodeは複数エージェントを並列に動かせます。
-
-OpenCode公式:
-https://opencode.ai/
-
-人間が1つずつ質問する場合と、エージェントが自律的にIssueを読み、コードを調査し、修正し、テストし、再試行する場合では消費速度がまったく違います。
-
-「人間にはほぼ無限」と「コンピュータにも無限」は別です。
-
-## 自分ならFlashを通常運用、Proを昇格先にする
-
-この価格と上限を見る限り、運用はかなり単純にできます。
+期間が違うからだ。
 
 ```text
-通常のIssue処理
-README修正
-小さな実装
-テスト修正
-コード探索
-    ↓
-DeepSeek V4 Flash
-
-複雑な設計
-大規模レビュー
-Flashで詰まった問題
-高い推論品質を優先したい仕事
-    ↓
-DeepSeek V4 Pro
+ChatGPT累計
+vs
+OpenCode 5時間 / 1週間 / 1か月
 ```
 
-Flashを通常系にすると、OpenCode公式推定では月158,150リクエスト相当です。
+では同じ軸ではない。
 
-Proへ上げても月17,150リクエスト相当あります。
+刷新後は、**自分の直近7日または30日のAI coding workload**と比較する。
 
-「高価なモデルを節約しながら使う」というより、**安いモデルを常用し、難しい仕事だけ上位モデルへ昇格する**ほうが自然です。
-
-## 次にやるべき比較は「直近30日」
-
-今回の弱点は明確です。
-
-ChatGPT側の1,840件は累計値で、OpenCode側は5時間・週・月という期間別推定です。
-
-厳密に比較するなら、ChatGPT Data Exportから各メッセージの時刻を取得し、
-
-- 直近24時間のユーザーメッセージ数
-- 直近7日のユーザーメッセージ数
-- 直近30日のユーザーメッセージ数
-- 1会話あたりの中央値
-- 最も多く使った日の送信数
-
-を出すべきです。
-
-OpenAI公式のData Exportにはチャット履歴が含まれます。
-
-https://help.openai.com/en/articles/7260999-exporting-your-chatgpt-history-and-data
-
-この集計ができれば、次は次のような比較にできます。
+例えば、直近7日にagent/tool request相当の作業が2,000回だったとする。
 
 ```text
-自分のChatGPT実利用
-  1日   XXX messages
-  7日   XXX messages
- 30日   XXX messages
-
-OpenCode Go推定
-  Pro   8,550 requests / week
-        17,150 requests / month
-
-  Flash 79,050 requests / week
-        158,150 requests / month
+自分: 2,000 / week
+V4 Pro typical estimate: 8,550 / week
+V4 Flash typical estimate: 79,050 / week
 ```
 
-ここまで揃えば、「ほぼ無限」という感想を、単なる印象ではなく自分自身の利用実績に対する倍率で評価できます。
+この場合、単純なrequest countでは、
 
-## まとめ
+```text
+Pro:   23.4% of typical weekly estimate
+Flash:  2.5% of typical weekly estimate
+```
 
-今回確認できた事実は3つです。
+となる。
 
-1. OpenCode Goは初月5ドル、その後10ドル/月で、5時間12ドル相当・週30ドル相当・月60ドル相当の利用枠を持つ。
-2. OpenCode公式の典型利用推定では、DeepSeek V4 Proは月17,150回、V4 Flashは月158,150回。
-3. 手元のChatGPT利用集計は累計1,840メッセージで、単純な件数比較ではPro月次枠が9.32倍、Flash月次枠が85.95倍。
+もちろん1 requestの重さが違うので、これは最終結論ではない。
 
-ただし3は期間も処理単位も一致しないため、**倍率は性能比較ではなく規模感比較**です。
+しかし「ほぼ無限」という感想よりは、はるかに自分の利用へ接続できる。
 
-それでも、月10ドルのコーディング環境として見ると、DeepSeek V4 Flashの数字はかなり異常です。
+## さらに良いのは、consoleのusageを直接見ること
 
-次はChatGPT Data Exportから直近30日の実測値を取り、同じ期間に揃えて比較したいと思います。
+OpenCode公式はcurrent usageをconsoleで追跡できるとしている。
 
-## 一次情報
+Goの制限自体がドル換算なら、本当に見たいKPIはrequest数だけではない。
+
+```text
+weekly usage consumed
+monthly usage consumed
+model mix
+request count
+```
+
+を一緒に見る。
+
+例えば、
+
+```yaml
+period: 7d
+requests: 2500
+usage_consumed_usd: 8.2
+weekly_limit_usd: 30
+```
+
+なら、
+
+```text
+request utilization ≈ 参考
+usage utilization = 27.3%
+```
+
+と評価できる。
+
+**Goが制約になるかは、最終的にはusage消費率で見る方が契約構造に合っている。**
+
+## FlashとProは「何回使えるか」だけで選ばない
+
+現行docsでは、DeepSeek V4 ProとFlashはどちらもGoのmodel listにある。
+
+公式表ではFlashの方がtypical request estimateが大きい。
+
+ただし、そこから
+
+```text
+Flashを通常運用
+Proを難問専用
+```
+
+と自動的に決めるのも早い。
+
+model選択には少なくとも、
+
+- quality
+- latency
+- tool behavior
+- context requirements
+- usage consumption
+
+がある。
+
+だからcapacity planningでは、先に役割を決める。
+
+例えば、
+
+```text
+routine code search / small edits
+→ cheaper high-capacity model候補
+
+complex architecture / difficult debugging
+→ higher-quality model候補
+```
+
+と分け、実測で入れ替える。
+
+**価格表からrouting policyを決めるのではなく、自分のtask classごとの成功率とusageで決める。**
+
+## 人間の対話利用とagent loopは分ける
+
+同じ月158,150 request相当でも、消費速度は運用で大きく変わる。
+
+人間が1回ずつ指示するなら、request frequencyには自然な上限がある。
+
+一方、自律agentは、
+
+```text
+issue読む
+→ search
+→ edit
+→ test
+→ retry
+→ review
+```
+
+を自動で繰り返す。
+
+複数repoを並列で処理すれば、human interactive useより速くusageを消費できる。
+
+だから「人間には十分そう」と「agent fleetにも十分」は分ける。
+
+私なら最低でも次を別metricにする。
+
+```yaml
+human_interactive_requests_7d: ...
+agent_requests_7d: ...
+retry_requests_7d: ...
+failed_work_requests_7d: ...
+```
+
+特にretry率が高いと、capacityを成果へ変換できていない。
+
+## 「何回使えるか」より「何件の仕事を完了できるか」へ進む
+
+AI codingで本当に欲しいのはrequest数ではない。
+
+例えば、
+
+```text
+1000 requests
+→ 30 issues completed
+```
+
+と、
+
+```text
+1000 requests
+→ 5 issues completed
+```
+
+では価値が違う。
+
+そこで運用KPIを、
+
+```text
+usage / completed issue
+requests / completed issue
+retry rate
+human intervention rate
+```
+
+へ寄せる。
+
+これなら、安いmodelが本当に安いのかも分かる。
+
+request単価が低くてもretryが多ければ、完了1件あたりの消費は大きくなる。
+
+## 5分でできるcapacity check
+
+OpenCode Goを検討するときは、次だけ取ればよい。
+
+### Step 1: 同じ期間を選ぶ
+
+7日か30日。
+
+### Step 2: 自分の実績を数える
+
+```text
+requests
+completed tasks
+retries
+human interventions
+```
+
+### Step 3: official typical estimateと比べる
+
+例えば7日なら、現行公式値は、
+
+```text
+V4 Pro   8,550 typical requests / week
+V4 Flash 79,050 typical requests / week
+```
+
+### Step 4: 可能ならconsole usageで補正する
+
+request countではなく実usage消費率を見る。
+
+### Step 5: 余裕率を出す
+
+```python
+capacity_margin = 1 - actual_usage / limit
+```
+
+あるいはrequest近似なら、
+
+```python
+request_margin = 1 - actual_requests / typical_estimated_requests
+```
+
+後者はあくまで近似と表示する。
+
+## 「ほぼ無限」という言葉を使わなくてよくなった
+
+公式の数字は十分大きい。
+
+DeepSeek V4 Flashの月158,150、Proの月17,150というtypical estimateは、capacityの大きさを示すには有用である。
+
+しかし自分にとって大事なのは、数字の大きさそのものではなかった。
+
+**自分の7日・30日の実利用を測れば、Goが制約になるかを自分で判定できる。**
+
+その状態なら「ほぼ無限」という曖昧な感想は要らない。
+
+余裕が80%あるのか、20%しかないのか。
+
+どのmodelがusageを使っているのか。
+
+1件のissueを完了するのに何requestかかっているのか。
+
+そこまで見れば、月額プランを「安そう」ではなく、自分のworkflowに対するcapacityとして評価できる。
+
+## 2026年8月14日時点の一次情報
 
 - OpenCode Go: https://opencode.ai/docs/go/
-- OpenCode: https://opencode.ai/
-- DeepSeek API models & pricing: https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-- OpenAI ChatGPT Data Export: https://help.openai.com/en/articles/7260999-exporting-your-chatgpt-history-and-data
+- OpenCode Go 日本語docs: https://opencode.ai/docs/ja/go/
+
+OpenCode自身が、model list・利用制限は今後変更される可能性があると明記している。この記事の数値を将来読む場合は、必ず現行docsを再確認する。

--- a/articles/video-storyboard-ir-provider-compile.md
+++ b/articles/video-storyboard-ir-provider-compile.md
@@ -1,5 +1,5 @@
 ---
-title: "同じ動画指示なのに、生成AIを変えると壊れる。仕様差を実行前に止めた"
+title: "生成AIのAPI仕様が変わっても、映像の意図まで書き直さない。Storyboardを正準にする"
 emoji: "🎬"
 type: "tech"
 topics: ["python", "ai", "architecture", "videogeneration", "testing"]
@@ -7,31 +7,95 @@ published: false
 published_at: 2026-08-12 14:09
 ---
 
-1つのShotに、開始画像と終了画像を指定する。さらに同じShotへreference videoも付ける。
+動画生成AIのadapterを作った2日後、記事を読み直すためにMiniMaxの現行docsを確認した。
 
-台本としては不自然ではありません。しかしMiniMax-H3 V2の公式Create APIでは、**first/last-frame mode と reference mode は排他的**です。
+すると、旧稿で中心にしていたAPI前提が、もう現在の公開仕様と一致していなかった。
 
-- MiniMax-H3 V2 Create: https://platform.minimax.io/docs/api-reference/video-generation-v2-create
+2026年8月14日時点のMiniMax公式Video Generation guideは、video生成を次の4 modeとして説明している。
 
-この矛盾をAPIへ送ってから知るのでは遅い。
+```text
+Text-to-Video
+Image-to-Video
+First-and-Last-Frame Video
+Subject-Reference Video
+```
 
-一方で、Kling側では今回のadapterが表現できるrequest modeが別で、現行adapterが保持できない `reference_video` / `reference_audio` を黙って捨てることもできません。
+- Current Video Generation guide: https://platform.minimax.io/docs/guides/video-generation
+- First & Last Frame API: https://platform.minimax.io/docs/api-reference/video-generation-fl2v
+- Subject-Reference API: https://platform.minimax.io/docs/api-reference/video-generation-s2v
 
-ここで問題になったのは「providerごとに違うJSONをどう作るか」ではありませんでした。
+First & Last Frameは現在 `MiniMax-Hailuo-02` を使う専用contractとして公開され、Subject-Referenceは `subject_reference` を使う別modeとして案内されている。
 
-**人間が書いた同じ映像意図を、provider Aでは表現でき、provider Bでは表現できないとき、その差をどこで失敗させるか。**
+旧稿はMiniMax H3 V2の `content[]` contractを現在仕様のように説明していたため、その部分を残さない。
 
-そこで台本からAPI requestへ直接落とす線をやめ、間にprovider-neutralな **Storyboard IR（Intermediate Representation / 中間表現）** を置きました。
+一方で、実装した **Storyboard IR** は捨てなくてよかった。
 
-Kling側のStoryboard adapterはmerge済みです。MiniMax-H3 V2 adapterはDraft PRとして実装・テスト中で、この記事では **live generationを実行済みとは扱いません**。
+なぜならStoryboard側にはMiniMaxのendpoint名もKlingのrequest fieldも入れていなかったからだ。
 
-- Kling merged PR: https://github.com/KAFKA2306/kling/pull/1
-- Kling merge commit: https://github.com/KAFKA2306/kling/commit/1e014f7da47bc162afd90076ad67b66c97ba4543
-- MiniMax Draft PR: https://github.com/KAFKA2306/2511youtuber/pull/56
+```text
+映像として何を作りたいか
+        ↓
+Storyboard IR
+        ↓
+provider-specific compiler
+        ↓
+current provider request
+```
 
-## 1. 問題：動画生成APIは「prompt文字列」だけでは抽象化できない
+この記事で扱うのはAPI差分の暗記ではない。
 
-最初は、provider adapter をこれくらいにしたくなります。
+**生成AIを替えたり仕様が更新されたりしても、人間が書いた映像意図までprovider都合で作り直さないための設計**について書く。
+
+## 実装は両方merge済み。でもlive generation成功とは呼ばない
+
+2026年8月12日に作った2つのadapterは現在どちらもmerge済みである。
+
+### Kling
+
+- PR #1: https://github.com/KAFKA2306/kling/pull/1
+- merge commit: https://github.com/KAFKA2306/kling/commit/1e014f7da47bc162afd90076ad67b66c97ba4543
+
+PRでは、provider-neutralな `VideoStoryboard` / `Shot` から、現在のrepository request modelでlosslessに表現できる範囲だけをcompileする。
+
+- no reference → Text-to-Video plan
+- first frame + optional last frame → Image-to-Video plan
+- 1–4 reference images → Multi-Image plan
+- unsupported reference video/audio → fail
+- provider-incompatible duration → fail
+
+ただしtestsはfake client boundaryまでで、real Kling API callは行っていない。
+
+### MiniMax
+
+- PR #56: https://github.com/KAFKA2306/2511youtuber/pull/56
+- merge commit: https://github.com/KAFKA2306/2511youtuber/commit/fea2a741cad9285f256bb11954e7caf10769636d
+
+このPRもStoryboard IR、timeline validation、deterministic compiler、provider adapter、audit structureをmainへmerge済みである。
+
+ただしPR本文自身が、verification boundaryを**deterministic request compilation / mocked / fail-closed**までとし、MiniMaxへのlive callやYouTube publishは行っていないと明記している。
+
+つまり現在確認済みなのは、
+
+```text
+IRを作れる
+validationできる
+provider requestへcompileできる
+unsupported intentを止められる
+```
+
+まで。
+
+```text
+実動画が高品質に生成できた
+live APIが現在のprovider仕様でもそのまま通る
+公開まで成功した
+```
+
+とは扱わない。
+
+## provider-neutralにするのはpromptではなく「意図」
+
+最初は共通interfaceを、
 
 ```python
 generate_video(
@@ -41,342 +105,372 @@ generate_video(
 )
 ```
 
-しかし実際の差は prompt の外側にあります。
+くらいにしたくなる。
 
-MiniMax-H3 V2 の公式Create APIは `content[]` に text / image / video / audio を入れ、各mediaに `role` を付けます。Text-to-Videoでは concrete ratio が必要で、Image-to-Videoでは画像から比率が決まり `adaptive` 扱いになります。また first/last frame と reference media は混在できません。
+しかし動画の意味はprompt文字列の外にもある。
 
-一方、今回 merge した Kling adapter は、既存SDKの request model が表現できる範囲に限定して、Storyboardを `text_to_video` / `image_to_video` / `multi_image_to_video` の3 routeへ compile します。現行adapterで保持できない `reference_video` / `reference_audio` は捨てずにエラーにします。
+- 何秒から何秒までか
+- 何を見せるか
+- camera/composition
+- subject state
+- motion
+- first / last frame
+- reference asset
+- 維持したいstyle
+- 禁止したい表現
+- source evidence
 
-つまり共通化すべきものはAPI requestではありません。**映像として何を作りたいか**です。
+そこでStoryboard側へ、provider APIではなくcreative intentを置く。
 
-![Storyboard IR boundary](/images/video-storyboard-ir-provider-compile/01-ir-boundary.png)
+```python
+Shot(
+    shot_id="s01",
+    start_sec=0,
+    end_sec=4,
+    message="新製品の主役を見せる",
+    composition="close-up",
+    subject_state="front-facing",
+    reference_asset_ids=["hero"],
+    negative_constraints=["no extra text"],
+)
+```
 
-## 2. Storyboardを「映像の意図」の正準形にする
+ここには、
 
-Storyboard IR の中心は `VideoStoryboard` と `Shot` です。
+```text
+MiniMax endpoint
+Kling endpoint
+provider model ID
+request JSON field
+```
 
-`Shot` は単なる自然言語ではなく、少なくとも次を持ちます。
+を入れない。
 
-- `shot_id`
-- `start_sec`, `end_sec`
-- `message`
-- `composition`
-- `subject_state`
-- `motion[]`
-- `typography[]`
-- `style_invariants[]`
-- `reference_asset_ids[]`
-- `negative_constraints[]`
-- `source_evidence_ids[]`
+**人間が変えたいのは映像意図で、provider fieldではない。**
 
-ここで重要なのは、**provider-specific field を入れないこと**です。
+## current MiniMax docsが分かれていること自体が、IRの必要性を示す
 
-Klingのendpoint名も、MiniMaxの`content[]`もStoryboard側には置きません。Storyboardは「何秒から何秒まで、何を伝え、何を参照し、何を維持するか」だけを表します。
+現行MiniMax guideは同じvideo generationでも複数modeを持つ。
 
-![Shot contract](/images/video-storyboard-ir-provider-compile/02-shot-contract.gif)
+First & Last Frameでは、
 
-## 3. runtimeまで待つと、間違いの責任範囲が広すぎる
+```text
+first_frame_image
+last_frame_image
+prompt
+model = MiniMax-Hailuo-02
+```
 
-provider APIへ直接requestすると、例えば12秒動画を要求して失敗したとき、原因候補が広がります。
+というcontractがある。
 
-- providerが12秒を受け付けない
-- endpointが違う
-- aspect ratioが違う
-- first/last frameとreference mediaを混在させた
-- shot timeline自体が重複している
-- prompt compilerが壊れている
-- network/authenticationの問題
+Subject Referenceでは、
 
-そこで、まずproviderに依存しない矛盾をIR生成時に落とします。
+```text
+subject_reference
+prompt
+model = S2V-01
+```
 
-実装では以下をvalidation errorにしています。
+という別のcontractがある。
 
-- shotの `end_sec <= start_sec`
-- storyboard全体のduration超過
-- shot overlap
-- `gap_policy="forbid"` なのに空白区間がある
+利用者の意図としては、
+
+```text
+最初はこの絵
+最後はこの絵
+この人物らしさを維持
+```
+
+と自然に書ける。
+
+しかしselected provider/modeが、その3つを同時にlosslessに表現できるとは限らない。
+
+ここでadapterが勝手に1つを捨てると、APIは成功しても別の映像になる。
+
+だからcompile結果は、
+
+```text
+representable
+```
+
+か、
+
+```text
+capability mismatch
+```
+
+にする。
+
+**「だいたい近いrequest」へ丸めない。**
+
+## API errorよりcompile errorの方が、利用者には分かりやすい
+
+providerへ送ってから失敗すると、原因候補が増える。
+
+```text
+network
+credential
+quota
+model availability
+request shape
+unsupported combination
+creative intent itself
+```
+
+一方、requestを作る前なら、
+
+```text
+このShotはselected modeでは表現できない
+```
+
+と短く返せる。
+
+例えば、
+
+```python
+raise CapabilityMismatch(
+    provider="minimax",
+    requested_roles=["first_frame", "last_frame", "subject_reference"],
+    reason="selected compile target cannot preserve all roles losslessly",
+)
+```
+
+のようにする。
+
+これなら利用者は、
+
+- modeを変える
+- referenceを減らす
+- Shotを分ける
+- providerを変える
+
+のどれかを選べる。
+
+**remote taskを作る前に、設計上の不可能を人間が理解できる。**
+
+## IR自身の矛盾はproviderより前で止める
+
+providerが何であっても壊れているStoryboardもある。
+
+実装では、例えば次をIR validationで止める。
+
+- `end_sec <= start_sec`
+- Shot overlap
+- total duration overflow
+- forbidden gap
 - unknown reference asset
-- duplicate shot ID / asset ID
-
-例えば 0–5秒のShot Aと4–8秒のShot Bは、network requestへ到達しません。
-
-![Timeline fail close](/images/video-storyboard-ir-provider-compile/03-timeline-fail-close.gif)
+- duplicate Shot ID
+- one-shot-one-message違反
 
 ```python
 if shot.start_sec < previous_end:
     raise ValueError("overlaps the previous shot")
 ```
 
-このチェックはKlingにもMiniMaxにも関係ありません。だからIR側に置きます。
+これをprovider adapterへ置かない理由は単純だ。
 
-## 4. 1つのShotに複数の論点を詰めると、provider以前に崩れる
+**KlingでもMiniMaxでも壊れているから。**
 
-生成動画のpromptを組み立てていると、1 Shotの `message` に箇条書きを詰めたくなります。
+validation responsibilityを、
 
-しかしそれを許すと、「1ショットで何を見るべきか」が不明になります。さらにproviderがmulti-shot narrativeを理解できる場合でも、こちらのタイムラインとprovider内部のshot分解が二重化します。
+```text
+creative / timeline invariant
+→ IR
 
-そこで `Shot.message` は1 non-empty lineに限定しました。list-like patternもrejectします。
+provider capability
+→ compiler / adapter
 
-```python
-nonempty_lines = [
-    line.strip()
-    for line in self.message.splitlines()
-    if line.strip()
-]
-if len(nonempty_lines) != 1:
-    raise ValueError("one-shot-one-message")
+network / remote task
+→ provider client
 ```
 
-![One shot one message](/images/video-storyboard-ir-provider-compile/04-one-shot-one-message.gif)
+へ分ける。
 
-これは生成品質を保証する魔法ではありません。狙いは、**失敗したときにどのShotの意味が曖昧だったかを特定できること**です。
-
-## 5. Reference assetはURIではなく「役割」を持たせる
-
-画像URLを単純な `images: list[str]` にすると、provider変換時に意味が消えます。
+## reference assetにはURIだけでなくroleを持たせる
 
 同じ画像でも、
 
-- first frame
-- last frame
-- reference image
-
-では意味が違います。
-
-そのため `ReferenceAsset` は `kind` と `role` を分離しています。
-
-```python
-AssetKind = Literal["image", "video", "audio"]
-AssetRole = Literal[
-    "first_frame",
-    "last_frame",
-    "reference_image",
-    "reference_video",
-    "reference_audio",
-]
+```text
+first frame
+last frame
+reference image
+subject reference
 ```
 
-さらに role と kind が矛盾したらrejectします。
+では意味が違う。
 
-![Asset role matrix](/images/video-storyboard-ir-provider-compile/05-asset-role-matrix.gif)
+単なる `images: list[str]` へすると、provider変換時にその意味が消える。
 
-ここまでがprovider-neutral contractです。
-
-## 6. MiniMax-H3：公式V2仕様をadapterで検証してから `content[]` へ落とす
-
-MiniMax-H3 V2 の公式Create APIでは、2026年8月12日時点で以下が確認できます。
-
-- endpoint: `POST /v2/video_generation`
-- model: `MiniMax-H3`
-- `content[]` は text / image_url / video_url / audio_url
-- promptとなる non-empty text item が必須
-- resolution: `768P` または `2K`
-- duration: 整数4–15秒
-- Text-to-Videoはconcrete ratio必須
-- first/last-frame mode と reference mode は排他的
-- reference imageは最大9
-- reference videoは最大3
-- reference audioは最大3
-- reference video/audioの合計durationは15秒以下
-
-公式Create docs:
-https://platform.minimax.io/docs/api-reference/video-generation-v2-create
-
-adapterはStoryboardを受け取り、まずこれらをvalidateしてからrequestへcompileします。
-
-```python
-request = {
-    "model": "MiniMax-H3",
-    "content": content,
-    "resolution": storyboard.resolution_target,
-    "duration": int(storyboard.duration_seconds),
-    "ratio": ratio,
-}
-```
-
-![MiniMax compile](/images/video-storyboard-ir-provider-compile/06-minimax-compile.gif)
-
-APIを呼ばない `compile_request()` を独立させているため、API keyが無くてもrequest shapeまではテストできます。live call は `create_task()` 側で `MINIMAX_API_KEY` を要求します。
-
-## 7. Kling：同じStoryboardから3つのrequest modeへcompileする
-
-Kling側はmerge済みの `KlingStoryboardCompiler` が、reference semanticsからrouteを決定します。
-
-- referenceなし → Text-to-Video
-- first frame + optional last frame → Image-to-Video
-- 1–4 reference images → Multi-Image-to-Video
-
-実装:
-https://github.com/KAFKA2306/kling/blob/master/usecases/storyboard.py
-
-![Kling compile modes](/images/video-storyboard-ir-provider-compile/07-kling-compile-modes.gif)
-
-Klingの公式VIDEO 3.0 user guideは現在、multi-shot、15秒、element reference、native audioなど広い製品能力を説明しています。
-
-https://app.klingai.com/cn/quickstart/klingai-video-3-model-user-guide
-
-ただし、**今回のadapterがその最新製品能力をすべて表現しているとは扱っていません。**
-
-mergeしたadapterは「このrepoの現在のrequest modelがlosslessに表現できる範囲」に限定しています。
-
-## 8. Provider capability mismatchは「丸める」のではなく止める
-
-最も危険なのは、adapterが親切に見える変換をすることです。
-
-例えばKling adapterの現行request modelが5秒または10秒しか受け付けないとき、Storyboardが12秒なら10秒へ丸めることもできます。
-
-今回はしません。
-
-```python
-if duration not in {5, 10}:
-    raise ValueError(
-        "current Kling request models support exact durations of 5 or 10 seconds"
-    )
-```
-
-reference video/audioも同じです。現行adapterがそのroleを保持できないなら、黙ってdropせずrejectします。
-
-![Capability mismatch](/images/video-storyboard-ir-provider-compile/08-capability-mismatch.gif)
-
-12秒Storyboardを10秒動画として生成してしまうと、生成は「成功」しても、設計上は別物です。
-
-## 9. 生成AIが非決定的でも、生成前のcompileは決定的にできる
-
-MiniMax側のテストでは、12秒・5 shot fixtureについて同じStoryboardを2回compileし、prompt一致を確認しています。
-
-Kling側でも同じStoryboardから同じ `KlingStoryboardPlan` が出ることをテストしています。
-
-さらにauditに以下を残す設計にしました。
-
-- storyboard ID
-- provider
-- model
-- request parameters
-- compiled prompt
-- task ID
-- response
-- compiler version
-- generated artifact hash
-
-![Audit chain](/images/video-storyboard-ir-provider-compile/09-audit-chain.gif)
-
-非決定的な動画生成の手前に、決定的に監査できるcompile chainを置きます。
-
-## 10. mocked API successを「動画生成成功」と呼ばない
-
-Kling merged PRのテストは `FakeClient` を使い、compiled endpointとpayloadがclientへ渡ることを確認します。実network callはしません。
-
-MiniMax Draft PRでも `compile_request()` はnetworkなしで検証し、API keyなしの `create_task()` はfailします。
-
-したがって現時点で言えるのは、
-
-**確認済み**
-- Storyboard schema validation
-- timeline validation
-- one-shot-one-message lint
-- provider request compilation
-- deterministic compilation
-- fake/mock client boundary
-
-**この記事の根拠からは言えない**
-- 実MiniMax生成成功
-- 実Kling生成成功
-- 生成動画の品質改善率
-- YouTube公開成功
-
-です。
-
-![Verification boundary](/images/video-storyboard-ir-provider-compile/10-verification-boundary.gif)
-
-compile-time contractの成功とlive generationの成功を別のEvidenceとして扱います。
-
-## 11. 再現方法
-
-### Kling側
-
-```bash
-git clone https://github.com/KAFKA2306/kling.git
-cd kling
-git checkout 1e014f7da47bc162afd90076ad67b66c97ba4543
-pytest -q tests/test_storyboard_adapter.py
-```
-
-見るべきテストは次です。
-
-- deterministic Text-to-Video plan
-- first/last frame → Image-to-Video
-- reference images → Multi-Image
-- incompatible duration → fail
-- unsupported reference video → fail
-- last frame without first frame → fail
-- fake client submit
-
-### MiniMax側
-
-現時点ではDraft PRなので、PR headを取得してテストします。
-
-```bash
-git clone https://github.com/KAFKA2306/2511youtuber.git
-cd 2511youtuber
-git fetch origin pull/56/head:storyboard-ir-minimax-h3
-git checkout storyboard-ir-minimax-h3
-pytest -q tests/test_storyboard_video_generation.py
-```
-
-MiniMax公式仕様と突き合わせる場合は、必ず現行docsを確認します。
-
-- Create: https://platform.minimax.io/docs/api-reference/video-generation-v2-create
-- Query: https://platform.minimax.io/docs/api-reference/video-generation-v2-query
-
-## 12. 何が失敗だったか
-
-### 失敗1：provider requestを正準データモデルにする
-
-provider Aのfieldを正準にすると、provider Bを追加した瞬間に`Optional` fieldだらけになります。
-
-解決は、provider-neutral IRとprovider adapterの分離です。
-
-### 失敗2：対応できない仕様を近似して通す
-
-12秒→10秒の丸めや、reference audioのdropは、API requestとしては通っても映像意図を変えます。
-
-解決はfail-closeです。
-
-### 失敗3：mock testをE2E成功と書く
-
-request compileが正しくても、auth、rate limit、provider runtime、生成品質は別問題です。
-
-解決はverification boundaryを明記することです。
-
-## まとめ
-
-同じStoryboardでも、KlingとMiniMaxでは「表現できる映像意図」の境界が違います。
-
-その差をprovider固有JSONへ埋め込むと、失敗はnetwork requestの後まで遅れます。
-
-そこで、
+だからIRでは、asset identityとcreative roleを分ける。
 
 ```text
-Script
-  -> Storyboard IR
-  -> Validation
-  -> Provider Compiler
-  -> Provider Request
-  -> Generation
-  -> Audit
+asset_id = hero
+kind = image
+role = first_frame
 ```
 
-へ分けました。
+provider compilerはこのroleを見て、current provider modeへmapできるか判断する。
 
-**providerで意味を保存できないなら、近いrequestへ丸めず、生成前にcompile errorとして止める。**
+mapできなければfailする。
 
-生成AIが非決定的でも、その手前の設計・変換・検証まで非決定的にする必要はありません。
+**URLを運ぶのではなく、意図を運ぶ。**
 
-## 参照した一次情報
+## provider仕様が変わったら、adapterだけを更新する
 
-- MiniMax-H3 V2 Create Video Generation Task: https://platform.minimax.io/docs/api-reference/video-generation-v2-create
-- MiniMax-H3 V2 Query Task: https://platform.minimax.io/docs/api-reference/video-generation-v2-query
-- Kling VIDEO 3.0 Model User Guide: https://app.klingai.com/cn/quickstart/klingai-video-3-model-user-guide
-- KAFKA2306/kling PR #1: https://github.com/KAFKA2306/kling/pull/1
-- KAFKA2306/kling merge commit: https://github.com/KAFKA2306/kling/commit/1e014f7da47bc162afd90076ad67b66c97ba4543
-- KAFKA2306/2511youtuber PR #56: https://github.com/KAFKA2306/2511youtuber/pull/56
+今回の再監査で一番分かりやすかった点である。
+
+旧MiniMax adapterは、merge時点のH3 V2 contractを実装している。
+
+2026年8月14日の現行docsは別のmodel/mode構成を案内している。
+
+ここでStoryboardまでprovider-specificだったら、既存のShot dataやauthoring UIまで作り直す必要がある。
+
+IRが中立なら、更新対象を狭くできる。
+
+```text
+Storyboard data        unchanged
+Editorial authoring    unchanged
+Timeline validation    unchanged
+Asset role semantics   unchanged
+
+MiniMax compiler       update required
+Provider tests         update required
+Live verification      required
+```
+
+**仕様変更のblast radiusをadapterへ閉じ込める。**
+
+これはvendor lock-inを完全になくすという話ではない。
+
+provider固有能力を使うほど差は出る。
+
+それでも「人間が何を作りたかったか」を別layerに残しておけば、migration時に失うものを明示できる。
+
+## compilerはversionとevidenceを残す
+
+動画生成自体は非決定的でも、その前のcompileは決定的にできる。
+
+```yaml
+storyboard_id: demo-001
+provider: minimax
+provider_contract_observed_at: 2026-08-14
+compiler_version: ...
+compile_status: ...
+request_summary: ...
+source_evidence:
+  - current MiniMax video guide
+```
+
+live callまで行った場合は、さらに、
+
+```text
+task ID
+response
+artifact hash
+runtime verification
+```
+
+を別stateとして追加する。
+
+`compile passed` を `generation succeeded` へ昇格しない。
+
+## current docsへ追従できていないadapterを「対応済み」と表示しない
+
+今回、MiniMax PR #56がmerge済みであること自体は事実である。
+
+しかし、merge済み = current API validatedではない。
+
+現行provider docsとadapter contractがずれているなら、stateを分ける。
+
+```yaml
+implementation:
+  merged: true
+
+provider_contract:
+  current_docs_rechecked: true
+  adapter_currently_revalidated: false
+
+live_generation:
+  status: NOT_RUN
+```
+
+この表示なら、
+
+> コードはあるが、現在のproviderへそのまま投入してよいとはまだ言えない
+
+と分かる。
+
+これもUXである。
+
+**「対応済み」の1bitより、どこまで確認済みかを見せる。**
+
+## provider変更時のdecision matrix
+
+新しいprovider/modeへ移るとき、次の表を作るとよい。
+
+| Intent | IRに保持 | Target providerで表現可能 | Action |
+|---|---|---|---|
+| text message | yes | yes | compile |
+| first frame | yes | yes | compile |
+| last frame | yes | mode-dependent | select mode / fail |
+| subject identity | yes | mode-dependent | select mode / fail |
+| reference video | yes | adapter-dependent | fail if lossless mappingなし |
+| exact duration | yes | provider-dependent | fail / split shot |
+
+ここで重要なのは、`no` を自動で消さないことだ。
+
+**差分を人が選べる状態にする。**
+
+## この設計で減らしたいのは、API errorより書き直し
+
+もちろんcompile-time validationでremote failureも減らせる。
+
+しかし長期的な価値は別にある。
+
+動画生成providerは変わる。
+
+model名も、endpointも、request fieldも変わる。
+
+そのたびに、
+
+```text
+台本
+Shot設計
+referenceの意味
+editorial intent
+```
+
+までprovider仕様に引きずられて書き直すのは重い。
+
+だから、
+
+```text
+what to create
+```
+
+と、
+
+```text
+how this provider accepts it today
+```
+
+を分ける。
+
+今回、旧稿のMiniMax仕様がもう現行docsと違っていたことで、その設計価値がむしろ明確になった。
+
+**APIが変わることを防ぐのではなく、APIが変わっても創作意図まで巻き込まれない構造にする。**
+
+## 2026年8月14日時点の一次情報・実装証拠
+
+MiniMax current docs:
+
+- Video Generation guide: https://platform.minimax.io/docs/guides/video-generation
+- First & Last Frame: https://platform.minimax.io/docs/api-reference/video-generation-fl2v
+- Subject-Reference: https://platform.minimax.io/docs/api-reference/video-generation-s2v
+
+Repository evidence:
+
+- Kling PR #1: https://github.com/KAFKA2306/kling/pull/1
+- Kling merge commit: https://github.com/KAFKA2306/kling/commit/1e014f7da47bc162afd90076ad67b66c97ba4543
+- MiniMax PR #56: https://github.com/KAFKA2306/2511youtuber/pull/56
+- MiniMax merge commit: https://github.com/KAFKA2306/2511youtuber/commit/fea2a741cad9285f256bb11954e7caf10769636d


### PR DESCRIPTION
## Summary

UX-first / sales-first刷新の最終current-source waveです。時間変動する外部仕様を2026-08-14時点の一次情報へ再接地し、古い事実をそのまま残さないようにしました。

### AI watermark / Claude
`claude-watermark-secret-key-detection.md`
- Claudeにsecret text watermark実装がある前提を撤回
- Anthropic Transparency Hubの現行公開姿勢へ更新
- SynthIDをcurrent public implementation exampleとして分離
- embedding / secret / detection / verification interfaceを別componentへ

Closes #83

### OpenCode Go capacity
`opencode-go-deepseek-v4-chatgpt-usage-scale.md`
- 累計ChatGPT message数との期間不一致比較を削除
- Goの制限がrequest quotaではなくusage valueであることを中心へ
- DeepSeek V4 Pro/Flashのofficial typical request estimatesをcurrent docsへ再接地
- 同期間のactual usage / completed task / retryで契約価値を判断するcapacity guideへ

Closes #91

### Storyboard IR / provider drift
`video-storyboard-ir-provider-compile.md`
- stale MiniMax H3 V2 current-spec説明を撤去
- current MiniMax guideの Text / Image / First-and-Last / Subject-Reference modesへ更新
- MiniMax PR #56がすでにmergedであることをread-back
- merged implementationとcurrent provider validation/live generationを分離
- provider仕様変更のblast radiusをadapterへ閉じることを中心価値へ

Closes #98

## Primary sources rechecked
- Anthropic Transparency Hub
- Google DeepMind SynthID
- OpenCode Go official docs
- MiniMax official Video Generation docs
- current GitHub PR states for Kling #1 / 2511youtuber #56

## Validation
- 3 articles only
- all remain `published: false`
- volatile claims carry an explicit observed date / current-doc boundary
- Article Pipeline CI success is the merge gate