### PR TITLE
Make reader value and proof a blocking article contract

### DIFF
--- a/docs/EDITORIAL_DESIGN.md
+++ b/docs/EDITORIAL_DESIGN.md
@@ -4,7 +4,7 @@
 
 この文書は、記事生成器の編集判断を固定するための設計資料です。
 目標は、正確な記事を大量に作ることではありません。
-**検証できる一つの発見を、最後まで読みたくなる形で届けること**です。
+**検証できる一つの発見を、最後まで読みたくなり、読後に具体的な判断・行動・運用へつながる形で届けること**です。
 
 本文は単独で意味が通ることを前提にし、過去のrepository履歴や既存記事を読んでいることへ依存しません。
 
@@ -48,6 +48,8 @@ https://zenn.dev/aircloset/articles/d416342f46f16b
 実測・実装証拠
   ↓
 成立条件と限界
+  ↓
+読者がそのまま使える判断・手順
 ```
 
 ## Zennfes Spring 2026受賞例を観察する
@@ -128,21 +130,111 @@ technical_payoff
 強いタイトルは必要ですが、誇張は不要です。
 数字、失敗、矛盾、実測結果など、本文で検証できるものだけをタイトルの引きに使います。
 
-## 旧記事を回帰ケースとして扱う
+### 6. Reader before → afterを候補段階で決める
 
-`articles/primary-source-derived-data-provenance.md` は、一次情報の扱いとしては有用ですが、冒頭から制度名と設計語が並び、題材そのものの意外性よりデータ設計の説明が前に出ています。
+実装テーマが見つかっても、すぐ記事にしません。
+先に次を埋めます。
 
-https://github.com/KAFKA2306/articles/blob/main/articles/primary-source-derived-data-provenance.md
+```text
+reader_before
+  ↓
+reader_after
+```
 
-このケースから固定する回帰条件は次です。
+`reader_before` は「MCPを知らない」のような知識不足ではなく、
 
-- 強い題材を抽象概念の解説へ縮退させない
-- 単なる生成ミスを記事の中心的発見にしない
-- 数字が大きいだけで満足せず、その数字から何が意外に分かったかまで探索する
-- 一つの発見が見つからない場合は、記事を書くのではなくテーマ探索を続ける
+```text
+AIへPC作業を任せたいが、どこまで触るか分からず怖い
+```
 
-この旧記事を直すこと自体が目的ではありません。
-今後、同じ失敗構造の記事を自動生成しないことが目的です。
+のような利用者の摩擦です。
+
+`reader_after` は、
+
+```text
+MCPを理解できる
+```
+
+ではなく、
+
+```text
+低risk taskへAllowedRoot / read-only / result evidenceを置き、どこまで委任するか判断できる
+```
+
+のように具体的な判断・行動・運用へします。
+
+### 7. Design philosophyは技術選定ではなくtrade-offを書く
+
+`FastAPIを使った`、`GitHub Actionsを追加した` はdesign philosophyではありません。
+
+読者価値のため、何を優先し何を捨てたかを書きます。
+
+例:
+
+```text
+自動化率より誤投稿を防ぐことを優先し、remote identityを確認できないrunはpublishしない
+```
+
+これなら、別のtool stackでも同じ判断を再利用できます。
+
+### 8. Commercial pullはproofから作る
+
+sales-firstは広告文を足すことではありません。
+
+```text
+実際にどこまで動いているか
+何を止めたか
+どの規模で使ったか
+何が未実証か
+```
+
+を証拠付きで見せ、読者自身が「自分でも使えそう」「この種類の問題なら任せられそう」と判断できる状態を作ります。
+
+`お問い合わせください` を足してもproofは増えません。
+読者の次actionは、checklist、template、最小導入手順、decision tableなど本文から自然に導きます。
+
+### 9. 弱い記事は公開せず、統合・退役できる
+
+技術的に正しいから残す、という判断はしません。
+
+- 同じreader jobなら強い1本へ統合する
+- 固有proofがなければarchiveへ落とす
+- runtime証拠が不足するなら`published:false`を維持する
+- article countをKPIにしない
+
+2026-08-14の棚卸しでは、同じreader jobを扱う旧稿を統合し、固有incidentを証明できなかったfail-close稿をarchiveへ移しました。
+
+- `docs/article-portfolio-audit-2026-08-14.md`
+
+## Reader value blocking gate
+
+技術品質・story品質が基準を満たしても、次が残る記事は公開しません。
+
+- `weak_reader_value`: before→afterが本文だけで説明できない
+- `weak_differentiation`: 一般tutorial / docs / AI要約で代替できる
+- `missing_proof_of_value`: 価値主張とpublic evidenceが接続していない
+- `forced_commercial_cta`: 本文から自然に導けない問い合わせ・契約等を要求する
+- `technical_value_as_product`: 技術名・repository名・実装行為を価値そのものにしている
+
+これらはscore低下ではなくblocking issueです。
+
+## 固定見出しを強制しない
+
+候補dataには `reader_before` / `reader_after` / `design_philosophy` / `why_this_article` / `proof_of_value` / `desired_reader_action` / `non_goal` を必須化します。
+
+一方、公開本文に、
+
+```text
+## Vision
+## Design philosophy
+## Why
+## Commercial intent
+```
+
+を強制しません。
+
+意味構造は必要ですが、scene→問い→観測→仮説更新→proof→持ち帰りのstoryへ自然に統合します。
+テンプレート見出しを埋めただけの記事を増やさないためです。
 
 ## Publication gate
 
@@ -153,6 +245,8 @@ https://github.com/KAFKA2306/articles/blob/main/articles/primary-source-derived-
 - `story_overall >= 4.0`
 - editorial 全軸 `>= 3.8`
 - `interest >= 4.1`
+- reader value blocking issueが0件
+- `proof_of_value` と本文の実証範囲が一致する
 
 月末の候補比較では、技術品質より先に `story_overall`、`interest`、`discovery` を比較します。
-これにより、正確さが同程度なら、より強い発見と読ませる構造を持つ記事が選ばれます。
+これにより、正確さが同程度なら、より強い発見、読ませる構造、具体的なreader outcomeを持つ記事が選ばれます。

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -46,6 +46,26 @@
     "require_selected_from_candidates": true,
     "blocking_issue": "narrow_technical_title_entry"
   },
+  "reader_value_policy": {
+    "required_fields": [
+      "reader_before",
+      "reader_after",
+      "design_philosophy",
+      "why_this_article",
+      "proof_of_value",
+      "desired_reader_action",
+      "non_goal"
+    ],
+    "require_actionable_reader_after": true,
+    "forbid_generic_why": true,
+    "blocking_issues": [
+      "weak_reader_value",
+      "weak_differentiation",
+      "missing_proof_of_value",
+      "forced_commercial_cta",
+      "technical_value_as_product"
+    ]
+  },
   "benchmark_policy": {
     "positive_min_likes": 100,
     "positive_requires_confirmed_like_count": true,

--- a/pipeline/contracts/article.md
+++ b/pipeline/contracts/article.md
@@ -98,6 +98,73 @@ LAPRAS公式はAI Reviewを「他のエンジニアにとってどれくらい�
 
 **弱い問いを、長文・図・引用・丁寧な説明で補強しない。テーマ選定へ戻す。**
 
+## UX-first / sales-first reader value contract
+
+記事は技術更新ログではなく、**公開証拠から「この仕組み・判断・能力を自分でも使いたい」と合理的に判断できる営業資産**として設計する。
+
+ここでいうsales-firstは、問い合わせ文や契約CTAを増やすことではない。
+読者が本文だけで、
+
+1. 自分のどの摩擦が減るか
+2. 読後に何を判断・実行・運用できるか
+3. なぜその設計判断を採ったのか
+4. 一般tutorialや公式docsではなく、この実測・失敗・比較を読む理由は何か
+5. 実際にどこまで動いており、どこから先は未実証か
+
+を説明できる状態を指す。
+
+候補生成時点で、story fieldsに加えて次の7項目を必須とする。
+
+- `reader_before`: 読む前の具体的な摩擦・損失・不確実性。技術名ではなく利用者の状態を書く。
+- `reader_after`: 読後に可能になる具体的な判断・行動・運用。「Xを理解する」「Yを学ぶ」だけでは不合格。
+- `design_philosophy`: 読者価値を守るため、何を優先し何を捨て、どのtrade-offを受け入れたか。技術stack列挙は禁止。
+- `why_this_article`: 一般tutorial / 公式docs / AI要約では代替できない固有価値。実測、失敗、比較、制約、判断変更の最低1つへ接地する。
+- `proof_of_value`: 実績・実測・運用結果・比較・失敗fixture・production evidenceなど「本当に使える範囲」を示す公開証拠。空欄の候補はpublish不可。
+- `desired_reader_action`: 読後に自然に起こせる次action。試す、監査する、導入候補にする、関連成果物を見る等。本文から導けない問い合わせ・契約を強制しない。
+- `non_goal`: 記事が証明しないこと、未実証範囲、解決しない問題。
+
+### Candidate blocking rules
+
+次は候補段階で不合格にする。
+
+- `reader_after` が「理解できる」「学べる」の抽象表現だけ
+- `why_this_article` が「詳しく説明する」「分かりやすく解説する」の言い換えだけ
+- `proof_of_value` が空、または公開証拠へ接続できない
+- FastAPI / GitHub Actions / MCP / Pyodide / API統合 / repository等の技術名・実装行為を価値そのものとしている
+- reader problemが存在せず、実装変更そのものが記事化理由になっている
+- CTAだけを足してcommercial pullを作ろうとしている
+
+### Article blocking rules
+
+本文査読では、次をblocking issueとして扱う。
+
+- `weak_reader_value`: 本文だけでbefore→afterの状態変化を説明できない
+- `weak_differentiation`: 固有の実測・失敗・比較・制約・判断変更がなく、一般解説で代替できる
+- `missing_proof_of_value`: 価値主張と公開証拠・実績境界が接続していない
+- `forced_commercial_cta`: 本文から自然に導けない営業行動を要求している
+- `technical_value_as_product`: 技術名・実装行為をそのまま読者価値としている
+
+このblocking issueが1つでも残る記事は、technical/story scoreが合格でもpublish不可とする。
+
+### 見出しをテンプレート化しない
+
+`## Vision`、`## Design philosophy`、`## Why`、`## Commercial intent` を公開記事へ強制しない。
+これらは意味構造として必要だが、本文ではscene / 数字 / 失敗 / 仮説更新のstoryへ自然に統合する。
+
+固定見出しを満たしただけのテンプレート記事を増やさない。
+
+### Lifecycle
+
+技術的に正しくてもreader valueを作れない記事は、無理に営業文へ変えない。
+
+- `KEEP`: proofとreader valueが強い
+- `REWRITE`: 核とproofはあるが技術更新ログ寄り
+- `MERGE`: reader jobが他記事と重複する
+- `KEEP_PRIVATE`: 情報価値はあるが公開promotion条件が未達
+- `DELETE / ARCHIVE`: 固有proof・再利用価値が弱く統合先もない
+
+**記事数を増やすことはKPIにしない。弱い2本よりproofが集約された1本を優先する。**
+
 ## Broad-entry title contract
 
 タイトルは「技術を知っている人だけが検索して読む見出し」ではなく、**技術名を知らない読者でも問題を認識できる入口**として設計する。
@@ -156,6 +223,10 @@ LAPRAS公式はAI Reviewを「他のエンジニアにとってどれくらい�
 18. **一次情報・再現証拠を残す。** KAFKA2306 GitHub上の一次証拠を最低2件、外部仕様は公式一次情報URLで裏付ける。確認できない主張は削除する。
 19. **誇張タイトルを禁止する。** 驚きはデータから作り、表現から捏造しない。
 20. **近接記事のreader jobを重複させない。** 例として「最初の10分の応急切り分け」と「原因モデルを理解する深掘り」は別記事になり得るが、同じ説明を二重掲載しない。
+21. **reader before→afterをstoryへ埋め込む。** 技術説明を読ませること自体を成果にせず、読後にできる判断・行動・運用まで本文で到達させる。
+22. **design philosophyをtrade-offとして示す。** 「何を採用したか」ではなく、読者価値のため何を優先し何を捨てたかを書く。
+23. **proofを価値主張の直後へ置く。** 「安全」「使える」「自動化できる」と書くなら、その範囲を実測・実装・運用証拠で示す。未実証は明示する。
+24. **commercial pullを広告CTAで作らない。** 読者がその場で試せるchecklist、template、最小手順、decision table等へ変換する。
 
 ## Opening anti-patterns
 
@@ -182,21 +253,29 @@ LAPRAS公式はAI Reviewを「他のエンジニアにとってどれくらい�
 - `story_type`: anomaly / contradiction / failure / unexpected-connection / counterintuitive-result / magnitude のいずれか
 - `evidence_urls`: 発見を検証できる公開URL
 - `why_interesting`: 一般論ではなく、この題材固有の面白さ
+- `reader_before`: 読む前の具体的な摩擦・損失・不確実性
+- `reader_after`: 読後に可能になる具体的な判断・行動・運用
+- `design_philosophy`: 読者価値を守る優先順位・trade-off
+- `why_this_article`: 一般解説では代替できない固有の実測・失敗・比較・制約・判断変更
+- `proof_of_value`: 公開証拠で確認できる実績・実測・運用結果
+- `desired_reader_action`: 本文から自然に導ける次action
+- `non_goal`: 記事が証明しないこと・解決しない範囲
 
 上記を埋められない候補は、記事化せずテーマ探索へ戻す。
 単なる生成ミス、ラベル誤り、URL間違い、設定漏れだけで終わる題材は、そこから一般化できる意外な発見がない限り主題にしない。
 
 `why_interesting` が「役に立つ」「安全になる」「理解できる」の言い換えだけなら不合格とする。
+`why_this_article` が「詳しく説明する」「分かりやすく解説する」の言い換えだけでも不合格とする。
 読者が既に知っている前提を、何がどう裏切るのかまで書けなければ不合格とする。
 
 ## Candidate maturation
 
-候補生成時点で一次情報ゲート、技術品質proxy、編集品質査読を実行する。
+候補生成時点で一次情報ゲート、技術品質proxy、編集品質査読、reader value contractを実行する。
 目標に届かない候補は `revision_limit` の範囲で自動改稿する。
-改稿では文章を足すより、主役でない節を切り、問いと証拠の距離を短くする。
+改稿では文章を足すより、主役でない節を切り、問い・reader value・proofの距離を短くする。
 改稿で悪化した場合は、評価済み版のうち最良の版を保持する。
 
-**問いが弱いという査読結果は、本文改稿で救済しない。候補選定へ戻す。**
+**問い・reader value・proofが弱いという査読結果は、営業文や長文化で救済しない。候補選定へ戻す。**
 
 ## Month-end selection
 
@@ -204,13 +283,14 @@ LAPRAS公式はAI Reviewを「他のエンジニアにとってどれくらい�
 
 1. 全候補を一次情報ゲートで再検証する。
 2. 全候補を3回独立査読し、各軸の中央値を採用する。
-3. 技術品質ゲートと編集品質ゲートの両方を満たす候補だけを公開可能集合にする。
+3. 技術品質ゲート、編集品質ゲート、reader value blocking gateをすべて満たす候補だけを公開可能集合にする。
 4. 正例コーパスの編集原理と比較し、scene、具体性、著者固有の観測、未解決の問いがない候補を落とす。
 5. タイトルが `narrow_technical_title_entry` なら公開可能集合から落とす。
-6. `story_overall` → `interest` → `discovery` → `overall` → 最低技術軸 → 証拠数の順で比較する。
-7. 最高順位の1本だけを公開する。
-8. 公開可能集合が空なら0本で終了する。
-9. 同月に1本公開済みなら追加公開しない。
+6. `weak_reader_value` / `weak_differentiation` / `missing_proof_of_value` / `forced_commercial_cta` / `technical_value_as_product` が1つでも残る候補を落とす。
+7. `story_overall` → `interest` → `discovery` → `overall` → 最低技術軸 → 証拠数の順で比較する。
+8. 最高順位の1本だけを公開する。
+9. 公開可能集合が空なら0本で終了する。
+10. 同月に1本公開済みなら追加公開しない。
 
 ## Evaluation JSON
 

--- a/pipeline/editorial.py
+++ b/pipeline/editorial.py
@@ -35,6 +35,41 @@ TITLE_OPTION_ROLES = tuple(
 TITLE_BLOCKING_ISSUE = str(
     TITLE_POLICY.get("blocking_issue", "narrow_technical_title_entry")
 )
+VALUE_POLICY = dict(core.CONFIG.get("reader_value_policy", {}))
+VALUE_FIELDS = tuple(
+    str(field) for field in VALUE_POLICY.get("required_fields", [])
+)
+VALUE_BLOCKING_ISSUES = frozenset(
+    str(issue) for issue in VALUE_POLICY.get("blocking_issues", [])
+)
+ACTIONABLE_READER_AFTER_MARKERS = (
+    "できる",
+    "判断",
+    "選べる",
+    "実行",
+    "導入",
+    "確認",
+    "比較",
+    "説明",
+    "再現",
+    "止め",
+    "減ら",
+    "使える",
+    "運用",
+    "切り分け",
+    "移行",
+    "委任",
+)
+GENERIC_WHY_PHRASES = frozenset(
+    {
+        "詳しく説明する",
+        "詳しく解説する",
+        "わかりやすく説明する",
+        "わかりやすく解説する",
+        "分かりやすく説明する",
+        "分かりやすく解説する",
+    }
+)
 PREMATURE_CONCLUSION_MARKERS = (
     "結論はこれです",
     "結論は単純です",
@@ -79,16 +114,42 @@ def title_options_ready(topic: dict[str, object]) -> bool:
     return True
 
 
+def value_contract_ready(topic: dict[str, object]) -> bool:
+    if not VALUE_FIELDS:
+        return True
+
+    values = {
+        field: str(topic.get(field, "")).strip()
+        for field in VALUE_FIELDS
+    }
+    if any(not values[field] for field in VALUE_FIELDS):
+        return False
+
+    reader_after = values.get("reader_after", "")
+    if VALUE_POLICY.get("require_actionable_reader_after") is True:
+        if not any(marker in reader_after for marker in ACTIONABLE_READER_AFTER_MARKERS):
+            return False
+
+    why = values.get("why_this_article", "")
+    normalized_why = why.rstrip("。.!！ ")
+    if VALUE_POLICY.get("forbid_generic_why") is True:
+        if normalized_why in GENERIC_WHY_PHRASES:
+            return False
+
+    return True
+
+
 def story_ready(topic: dict[str, object]) -> bool:
     if any(not topic.get(key) for key in STORY_FIELDS):
         return False
     if str(topic.get("story_type")) not in set(core.CONFIG["story_types"]):
         return False
     urls = topic.get("evidence_urls")
-    return (
+    return bool(
         isinstance(urls, list)
         and len(urls) >= 2
         and title_options_ready(topic)
+        and value_contract_ready(topic)
     )
 
 
@@ -112,6 +173,17 @@ def choose_topic(signals: list[dict[str, object]]) -> dict[str, object]:
 - 読者の自然な予想または既存前提が、一次証拠によってどう崩れるかを明示できない候補は落とす。
 - `why_interesting` が「役に立つ」「安全になる」「理解しやすい」の言い換えだけなら落とす。
 - 文章を上手く書けば面白くなりそう、ではなく、事実そのものに読む理由がある候補だけを残す。
+
+さらに、候補ごとに読者価値を先に定義してください。
+- `reader_before`: 読む前の摩擦・損失・不確実性。技術名ではなく利用者の状態を書く。
+- `reader_after`: 読後に可能になる具体的な判断・行動・運用を書く。「理解する」「学ぶ」だけでは不可。
+- `design_philosophy`: その価値を守るため何を優先し、何を捨て、どのtrade-offを受け入れるかを書く。技術stack列挙は禁止。
+- `why_this_article`: 一般tutorial / 公式docs / AI要約では代替できない固有価値を書く。実測、失敗、比較、制約、判断変更のどれかを含める。
+- `proof_of_value`: PUBLIC_GITHUB_SIGNALSで確認できる実績・実測・運用結果・失敗証拠を書く。空欄は禁止。
+- `desired_reader_action`: 読後に自然に起こせる次actionを書く。根拠のない「問い合わせる」「契約する」を強制しない。
+- `non_goal`: 記事が証明しないこと、解決しない範囲を書く。
+- FastAPI / Actions / MCP / Pyodide / API統合など、技術名や実装行為そのものを価値として書かない。
+- 記事数を増やすことを価値にしない。reader valueとproofを作れない候補は落とす。
 
 タイトルは各候補で必ず3案作る:
 1. `general_problem`: 技術名を知らない人でも、自分に関係する問題だと分かる一般語の入口。
@@ -147,7 +219,14 @@ PUBLIC_GITHUB_SIGNALS:
   "story_type": "anomaly|contradiction|failure|unexpected-connection|counterintuitive-result|magnitude",
   "evidence_urls": ["https://github.com/KAFKA2306/...", "https://github.com/KAFKA2306/..."],
   "why_interesting": "この題材固有の面白さ。どの前提がどう裏切られるかまで書く",
-  "technical_payoff": "最後に一般化できる技術知見"
+  "technical_payoff": "最後に一般化できる技術知見",
+  "reader_before": "読む前の具体的な摩擦・不確実性",
+  "reader_after": "読後に可能になる具体的な判断・行動・運用",
+  "design_philosophy": "読者価値を守る優先順位・trade-off",
+  "why_this_article": "一般tutorialでは得られない固有の実測・失敗・判断変更",
+  "proof_of_value": "公開証拠で確認できる実績・実測・比較・運用結果",
+  "desired_reader_action": "本文から自然に導ける次action",
+  "non_goal": "この記事が証明しないこと・解決しない範囲"
 }}
 
 JSONのみ返してください。
@@ -155,7 +234,7 @@ JSONのみ返してください。
 """
     result = json.loads(
         core.model_call(
-            "あなたは事実検証を優先する技術編集者です。弱い問いを文章力で救済せず、前提を更新する強い問いと一つの発見で記事を選びます。タイトルは一般語の問題から入り、技術名は後から与えます。文体模倣はしません。",
+            "あなたは事実検証を優先する技術編集者です。弱い問いや弱い読者価値を文章力で救済せず、前提を更新する強い問い、公開証拠、読後の具体的な状態変化で記事を選びます。技術名は価値そのものにしません。文体模倣はしません。",
             user,
             temperature=0.0,
             json_mode=True,
@@ -163,7 +242,7 @@ JSONのみ返してください。
     )
     selected = result.get("selected")
     if not isinstance(selected, dict) or not story_ready(selected):
-        raise RuntimeError("topic selection did not produce a story-ready candidate")
+        raise RuntimeError("topic selection did not produce a story/value-ready candidate")
     return result
 
 
@@ -176,15 +255,20 @@ def enrich_topic(
 
     user = f"""
 既に選ばれた技術テーマを、そのまま説明記事にせず、
-公開証拠で検証できる一つの発見へ絞り直してください。
+公開証拠で検証できる一つの発見と具体的な読者価値へ絞り直してください。
 
 重要:
 - 元テーマにない事実を創作しない。
-- PUBLIC_GITHUB_SIGNALSで支えられない発見は採用しない。
+- PUBLIC_GITHUB_SIGNALSで支えられない発見・価値・実績は採用しない。
 - 単なる生成ミス、URL間違い、設定漏れだけの話にはしない。
 - 既知の原則を別技術へ適用しただけなら `publishable` を false にする。
 - 読者の自然な予想・既存前提を何も更新しない場合は `publishable` を false にする。
-- 十分な発見を作れない場合は `publishable` を false にする。
+- `reader_after` が「理解する」「学ぶ」だけなら `publishable` を false にする。
+- 技術名・ライブラリ名・repository名・CI追加を価値そのものにしない。
+- `why_this_article` が「詳しく説明する」「分かりやすく解説する」だけなら `publishable` を false にする。
+- `proof_of_value` が公開証拠へ接続できない場合は `publishable` を false にする。
+- `desired_reader_action` は本文の価値から自然に導く。相談・契約を無理に要求しない。
+- 十分な発見または読者価値を作れない場合は `publishable` を false にする。
 - タイトルは `general_problem` / `concrete_anomaly` / `searchable` の3案を作る。
 - 技術名を知らない読者がタイトル前半だけで問題を理解できるようにする。
 - `title` は3案のいずれかをそのまま採用する。
@@ -212,19 +296,26 @@ JSONのみ返してください。
   "story_type": "anomaly|contradiction|failure|unexpected-connection|counterintuitive-result|magnitude",
   "evidence_urls": ["...", "..."],
   "why_interesting": "...",
-  "technical_payoff": "..."
+  "technical_payoff": "...",
+  "reader_before": "...",
+  "reader_after": "...",
+  "design_philosophy": "...",
+  "why_this_article": "...",
+  "proof_of_value": "...",
+  "desired_reader_action": "...",
+  "non_goal": "..."
 }}
 """
     result = json.loads(
         core.model_call(
-            "あなたは技術テーマを一つの検証可能な発見へ絞る編集者です。問いが弱ければ公開不可にします。タイトルは一般語の問題から入ります。",
+            "あなたは技術テーマを一つの検証可能な発見とreader outcomeへ絞る編集者です。問い・読者価値・proofのどれかが弱ければ公開不可にします。技術名は価値そのものにしません。",
             user,
             temperature=0.0,
             json_mode=True,
         )
     )
     if result.get("publishable") is not True or not story_ready(result):
-        raise RuntimeError("topic could not be converted into a story-ready candidate")
+        raise RuntimeError("topic could not be converted into a story/value-ready candidate")
     return result
 
 
@@ -255,6 +346,13 @@ Markdown本文のみ。front matterは不要です。
 - `結論はこれです`、`結論は単純です`、`この記事で伝えたい結論は一つです` のような結論先出し定型句を使わない。
 - `initial_hypothesis` を置き、観測や実験で `hypothesis_update` へ進む。
 - `surprising_finding` 以外の論点を主役にしない。
+- `reader_before` の摩擦が本文の具体sceneとして見え、読み終わるまでに `reader_after` の判断・行動・運用へ到達させる。
+- `design_philosophy` は採用技術の列挙ではなく、何を優先し何を捨てたかというtrade-offとして自然に本文へ統合する。
+- `why_this_article` は一般論として宣言せず、実測・失敗・比較・制約・判断変更を本文で見せて証明する。
+- `proof_of_value` を「本当にどこまで動いたか」の境界として本文に置く。未実証範囲は `non_goal` と整合させる。
+- `desired_reader_action` は記事末尾へ広告CTAとして足さない。本文から自然に試せる最小手順、判断表、checklist、template等として組み込む。
+- `## Vision`、`## Design philosophy`、`## Why`、`## Commercial intent` の固定見出しを作らない。
+- 技術名、repository名、ライブラリ名、CI追加を読者価値そのものとして表現しない。
 - 公開URLを冒頭で一覧化しない。証拠は、その事実を使う位置へ置く。
 - 技術用語は必要になった位置で短く説明する。
 - 固有名詞は役割が分かる一文を添える。
@@ -267,7 +365,7 @@ Markdown本文のみ。front matterは不要です。
 - 最低でもKAFKA2306 GitHub URLを2件、外部の公式一次情報を1件含める。
 """
     return core.model_call(
-        "あなたは調査の過程を読者が追体験できる技術ライターです。正確さと面白さを両立し、一般語の問題と具体的なsceneから始め、文体模倣はしません。",
+        "あなたは調査の過程を読者が追体験できる技術ライターです。正確さ・面白さに加え、読む前から読んだ後への具体的な状態変化とproofを本文で成立させます。技術名や営業文句を価値そのものにしません。",
         user,
     )
 
@@ -289,6 +387,15 @@ def evaluate(article: str) -> dict[str, object]:
 - narrative: scene→自然な予想→観測/実験→仮説更新→結論の因果が通るか
 - context: 本文だけで固有名詞・数値・技術の意味を追えるか
 
+読者価値もblocking判定してください。次の場合は `blocking_issues` に指定codeを入れてください。
+- `weak_reader_value`: 読む前の具体的な摩擦と、読後に可能になる判断・行動・運用を本文だけで説明できない。読後が「理解した」「学んだ」だけでも該当。
+- `weak_differentiation`: 一般tutorial / 公式docs / AI要約との違いが、実測・失敗・比較・制約・判断変更で証明されていない。
+- `missing_proof_of_value`: 「使える」「安全」「自動化できる」等の価値主張に、実装結果・実測・public evidence・明示的な未実証境界がない。
+- `forced_commercial_cta`: 本文の価値から自然に導けない問い合わせ・契約・購入等を要求している。
+- `technical_value_as_product`: FastAPI / Actions / MCP / Pyodide / API統合 / repository等、技術名や実装行為そのものを価値として売っている。
+
+`Vision` / `Design philosophy` / `Why` / `Commercial intent` という固定見出しの有無では判定しません。意味が自然な本文に統合されているかを見てください。
+
 タイトルの「入口の広さ」も必ず査読してください。
 タイトル前半が、repository名、内部クラス名、API名、ライブラリ名、略語、専門用語の知識を前提にし、
 それらを知らない読者が「何が問題なのか」「なぜ読むのか」を判断できない場合は、
@@ -297,7 +404,7 @@ def evaluate(article: str) -> dict[str, object]:
 逆に、入口を広く見せるために本文の証拠より大きな主張へ広げている場合も、logic / clarityを下げ、blocking issueに理由を記録してください。
 
 甘く採点しないでください。
-LAPRAS相当の技術品質は「他のエンジニアに役立つか」の品質床であり、面白さの代理ではありません。
+LAPRAS相当の技術品質は「他のエンジニアに役立つか」の品質床であり、面白さや読者価値の代理ではありません。
 技術的に正しくても、次の場合は `interest` を3.5以下にしてください。
 - 用語説明や一般論がsceneより先行する。
 - 冒頭で記事全体の最終結論を閉じ、続きを読む必要をなくしている。
@@ -308,7 +415,7 @@ LAPRAS相当の技術品質は「他のエンジニアに役立つか」の品�
 
 具体物が遅い、論点が散る、結論が予想通り、導入を読んでも続きを知りたくならない場合は編集品質を下げてください。
 クリックを誘うだけで本文が回収しない場合も `interest` を下げてください。
-100+人気記事の文体を模倣したかではなく、scene before concept、具体的結果、実測、著者固有の経験、制約開示という編集原理が素材に根ざしているかを見てください。
+100+人気記事の文体を模倣したかではなく、scene before concept、具体的結果、実測、著者固有の経験、制約開示、reader before→afterという編集原理が素材に根ざしているかを見てください。
 
 {core.PROMPT}
 
@@ -332,7 +439,7 @@ JSONのみ返してください。
 """
     result = json.loads(
         core.model_call(
-            "あなたは独立した技術記事の編集査読者です。正確さ・有用性と、実際に読み進めたくなる構造を別々に採点します。タイトルは技術名を知らない第三者の視点でも査読します。",
+            "あなたは独立した技術記事の編集査読者です。正確さ・有用性・読み進めたくなる構造・reader value・proofを別々に判定し、技術名や強制CTAで価値を偽装した記事を通しません。",
             user,
             temperature=0.0,
             json_mode=True,
@@ -411,6 +518,8 @@ def passes_quality(review: dict[str, object], sources_ok: bool) -> bool:
     blocking_set = set(blocking) if isinstance(blocking, list) else set()
     if {"premature_conclusion_in_opening", TITLE_BLOCKING_ISSUE} & blocking_set:
         return False
+    if VALUE_BLOCKING_ISSUES & blocking_set:
+        return False
     return bool(
         sources_ok
         and _score(review.get("overall")) >= float(gate["minimum_overall"])
@@ -435,7 +544,7 @@ def revise(
 ) -> str:
     user = f"""
 以下の記事を全面改稿してください。
-文章量を増やすことではなく、問い・発見・因果を強くすることが目的です。
+文章量を増やすことではなく、問い・発見・因果・reader valueを強くすることが目的です。
 Markdown本文のみ返してください。
 
 品質契約:
@@ -458,15 +567,21 @@ ARTICLE:
 - `discovery` が弱い場合、最も強い一つ以外の論点を削る。
 - `narrative` が弱い場合、scene→予想→観測→更新→結論の因果順に組み直す。
 - `context` が弱い場合、必要な固有名詞だけをその場で一文説明する。
+- `weak_reader_value` がある場合、読者の具体的なbefore sceneと、読後に可能になる判断・行動・運用を本文へ接続する。「理解できる」だけで終えない。
+- `weak_differentiation` がある場合、一般論を削り、著者固有の実測・失敗・比較・制約・判断変更を中心へ移す。固有証拠がなければ公開不可のままにする。
+- `missing_proof_of_value` がある場合、公開証拠で確認できる実績・実測・運用境界を追加する。証拠がなければ価値主張を弱めるか削る。
+- `forced_commercial_cta` がある場合、問い合わせ・契約等の強制CTAを削り、読者がその場で試せる最小手順・checklist・templateへ置き換える。
+- `technical_value_as_product` がある場合、技術名や実装行為を主語から外し、利用者の摩擦・成果・能力へ書き換える。
+- `Vision` / `Design philosophy` / `Why` / `Commercial intent` の固定見出しは新設しない。意味をstoryへ統合する。
 - URL一覧がsceneより先にある場合、URLを事実の使用箇所へ移す。
 - 中心の問いを前進させない正しい節を削る。網羅性を増やさない。
 - 既知のベストプラクティス適用だけで問いが弱い場合、無理に文章で救済せずblocking issueを残す。
 - 存在確認できないURL・断定・数値は削除する。
-- 面白さのために新しい事実を作らない。
+- 面白さや営業価値のために新しい事実を作らない。
 - 最後を一文の持ち帰りで閉じる。
 """
     return core.model_call(
-        "あなたは記事の論点を削って強くするリビジョン担当です。タイトルと冒頭を一般語の問題から入り、答えを消してsceneと問いを前に出します。",
+        "あなたは記事の論点を削って強くするリビジョン担当です。sceneと問いに加え、reader before→after、trade-off、固有proofを自然な本文へ統合し、技術名や営業CTAで価値を偽装しません。",
         user,
         temperature=0.0,
     )

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -53,6 +53,33 @@ class PipelineContractTests(unittest.TestCase):
             "narrow_technical_title_entry",
         )
 
+    def test_reader_value_policy_is_canonical(self) -> None:
+        policy = core.CONFIG["reader_value_policy"]
+        self.assertEqual(
+            policy["required_fields"],
+            [
+                "reader_before",
+                "reader_after",
+                "design_philosophy",
+                "why_this_article",
+                "proof_of_value",
+                "desired_reader_action",
+                "non_goal",
+            ],
+        )
+        self.assertTrue(policy["require_actionable_reader_after"])
+        self.assertTrue(policy["forbid_generic_why"])
+        self.assertEqual(
+            set(policy["blocking_issues"]),
+            {
+                "weak_reader_value",
+                "weak_differentiation",
+                "missing_proof_of_value",
+                "forced_commercial_cta",
+                "technical_value_as_product",
+            },
+        )
+
     def test_popularity_benchmark_is_not_a_low_engagement_training_set(self) -> None:
         policy = core.CONFIG["benchmark_policy"]
         self.assertEqual(policy["positive_min_likes"], 100)
@@ -128,6 +155,28 @@ class PipelineContractTests(unittest.TestCase):
             editorial.passes_quality(otherwise_passing, sources_ok=True)
         )
 
+    def test_reader_value_blockers_are_publication_blockers(self) -> None:
+        otherwise_passing = {
+            "logic": 5.0,
+            "utility": 5.0,
+            "readability": 5.0,
+            "originality": 5.0,
+            "clarity": 5.0,
+            "overall": 5.0,
+            "interest": 5.0,
+            "discovery": 5.0,
+            "narrative": 5.0,
+            "context": 5.0,
+            "story_overall": 5.0,
+        }
+        for issue in core.CONFIG["reader_value_policy"]["blocking_issues"]:
+            review = dict(otherwise_passing)
+            review["blocking_issues"] = [issue]
+            with self.subTest(issue=issue):
+                self.assertFalse(
+                    editorial.passes_quality(review, sources_ok=True)
+                )
+
     def test_story_gate_is_stricter_than_technical_gate(self) -> None:
         review = {
             "logic": 5.0,
@@ -162,7 +211,31 @@ class PipelineContractTests(unittest.TestCase):
         topic["title"] = "3案にないタイトル"
         self.assertFalse(editorial.title_options_ready(topic))
 
-    def test_story_ready_requires_one_complete_discovery(self) -> None:
+    def test_reader_value_contract_requires_action_proof_and_specific_why(self) -> None:
+        topic = {
+            "reader_before": "CSVを書き込むまで既存データと衝突する行が分からない",
+            "reader_after": "書き込み前に各行の予定actionを確認し、人間確認が必要な行だけ止められる",
+            "design_philosophy": "一括適用の速さより非破壊性を優先し、diagnoseとwriteを分離する",
+            "why_this_article": "booksの実migrationでCLIとbrowserが同じ診断coreへ収束した判断変更を追う",
+            "proof_of_value": "公開commitのfixtureでexisting_holding / review / invalidを判定し、catalog非変更をtestしている",
+            "desired_reader_action": "既存importerへno-writeのdiagnose stepを追加する",
+            "non_goal": "実書き込み時のtransaction競合までは解決しない",
+        }
+        self.assertTrue(editorial.value_contract_ready(topic))
+
+        weak_after = dict(topic)
+        weak_after["reader_after"] = "dry-runについて理解する"
+        self.assertFalse(editorial.value_contract_ready(weak_after))
+
+        generic_why = dict(topic)
+        generic_why["why_this_article"] = "分かりやすく解説する"
+        self.assertFalse(editorial.value_contract_ready(generic_why))
+
+        missing_proof = dict(topic)
+        missing_proof["proof_of_value"] = ""
+        self.assertFalse(editorial.value_contract_ready(missing_proof))
+
+    def test_story_ready_requires_one_complete_discovery_and_reader_value(self) -> None:
         topic = {
             "title": "856件が7,699件になった。でも計算ミスではなかった",
             "title_options": {
@@ -181,6 +254,13 @@ class PipelineContractTests(unittest.TestCase):
                 "https://github.com/KAFKA2306/investor2/b",
             ],
             "why_interesting": "データ量と推定可能性が同じ方向に動かない",
+            "reader_before": "同じKPIが更新されると前の値が誤りだったのかscope差なのか分からない",
+            "reader_after": "source / scope / methodを比較し、数字が変わった理由を説明できる",
+            "design_philosophy": "単一のverified flagより変更理由の追跡可能性を優先し、一次資料と派生集計を分離する",
+            "why_this_article": "856→7,699という実数の反転を、17文書の公開evidenceで復元したcaseを扱う",
+            "proof_of_value": "17文書と5,026 purchases + 2,673 salesの公開snapshotがある",
+            "desired_reader_action": "重要KPIへsource / scope / methodを追加する",
+            "non_goal": "7,699をOGE公式合計とは扱わない",
         }
         self.assertTrue(editorial.story_ready(topic))
         topic.pop("hypothesis_update")


### PR DESCRIPTION
## Summary

Issue #67 の実装です。UX-first / sales-first を記事ごとの意味contractとしてpipelineへ追加し、技術的に正しいだけの記事を候補・公開gateで止めます。

### Candidate contract
新規候補で必須:
- `reader_before`
- `reader_after`
- `design_philosophy`
- `why_this_article`
- `proof_of_value`
- `desired_reader_action`
- `non_goal`

`reader_after` が「理解する / 学ぶ」だけ、genericな`why_this_article`、proof欠落はstory-readyになりません。

### Editorial blocking gate
追加blocking issues:
- `weak_reader_value`
- `weak_differentiation`
- `missing_proof_of_value`
- `forced_commercial_cta`
- `technical_value_as_product`

これらはtechnical/story scoreが高くてもpublish不可です。

### Writing contract
- reader before→afterをstoryへ統合
- design philosophyをtrade-offとして書く
- proofを価値主張へ接続
- fixed `Vision / Design philosophy / Why / Commercial intent` headingsは強制しない
- 技術名・repository名・CI追加を価値そのものにしない
- commercial pullを強制CTAではなくchecklist / template / decision table等へ変換
- weak articlesはprivate / merge / archive / delete可能、article countはKPIにしない

### Tests
- reader value policy config
- valid reader value fixture
- abstract `reader_after` rejection
- generic `why_this_article` rejection
- missing proof rejection
- all reader-value blocking issues reject publication
- existing story-ready fixture upgraded to value-ready

Closes #67

## Validation
Article Pipeline CI is the merge gate:
- compile
- contract/unit tests
- JS syntax
- static route smoke
- repository/privacy audit
- clean checkout