### PR TITLE
Editorial portfolio reset: decision boundaries, human publication, Zenn retirement audit

### DIFF
--- a/.github/workflows/article-pipeline.yml
+++ b/.github/workflows/article-pipeline.yml
@@ -4,23 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: candidate or publish
+        description: candidate or select-draft
         required: true
         default: candidate
         type: choice
         options:
           - candidate
-          - publish
+          - select-draft
   push:
     branches: [main]
     paths:
       - ".github/workflows/article-pipeline.yml"
   schedule:
-    # Monday 09:00 JST.
+    # Monday 09:00 JST. Scheduled automation may create/review candidates only.
     - cron: "0 0 * * 1"
-    # Month-end finalization window: 28th-31st at 23:30 JST.
-    # pipeline.selection.is_month_end() allows only the actual last day.
-    - cron: "30 14 28-31 * *"
 
 permissions:
   contents: write
@@ -45,56 +42,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Apply fail-close editorial migration
-        shell: bash
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-
-          unpublish = [
-              Path("articles/codex-chatgpt-github-issue-bridge.md"),
-              Path("articles/liltoon-reimport-first-aid-qa.md"),
-              Path("articles/unity-mcp-editor-boundary.md"),
-              Path("articles/unity-vrchat-shader-troubleshooting-qa.md"),
-          ]
-          for path in unpublish:
-              text = path.read_text(encoding="utf-8")
-              if "published: true\n" in text:
-                  text = text.replace("published: true\n", "published: false\n", 1)
-                  path.write_text(text, encoding="utf-8")
-
-          core = Path("pipeline/core.py")
-          text = core.read_text(encoding="utf-8")
-          text = text.replace(
-              '        needle in path.read_text(encoding="utf-8", errors="ignore")\n',
-              '        "published: true" in path.read_text(encoding="utf-8", errors="ignore")\n'
-              '        and needle in path.read_text(encoding="utf-8", errors="ignore")\n',
-              1,
-          )
-          text = text.replace(
-              '        "published: true\\n"\n',
-              '        # Fail-close: generation never grants publication approval.\n'
-              '        "published: false\\n"\n',
-              1,
-          )
-          core.write_text(text, encoding="utf-8")
-          PY
-
       - name: Resolve mode
         id: mode
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
-            echo "manual=1" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "mode=candidate" >> "$GITHUB_OUTPUT"
-            echo "manual=0" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event.schedule }}" == "0 0 * * 1" ]]; then
-            echo "mode=candidate" >> "$GITHUB_OUTPUT"
-            echo "manual=0" >> "$GITHUB_OUTPUT"
-          else
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.mode }}" == "select-draft" ]]; then
             echo "mode=publish" >> "$GITHUB_OUTPUT"
+            echo "manual=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=candidate" >> "$GITHUB_OUTPUT"
             echo "manual=0" >> "$GITHUB_OUTPUT"
           fi
 
@@ -107,7 +63,7 @@ jobs:
           python -m unittest discover -s tests -v
           python -m pipeline.audit
 
-      - name: Generate or publish
+      - name: Generate candidate or select unpublished draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GRAPHITI_READ_TOKEN: ${{ secrets.GRAPHITI_READ_TOKEN }}
@@ -115,27 +71,44 @@ jobs:
           ARTICLE_MODEL: auto
           ARTICLE_MANUAL: ${{ steps.mode.outputs.manual }}
         shell: bash
-        run: |
-          python -m pipeline.cli "${{ steps.mode.outputs.mode }}"
+        run: python -m pipeline.cli "${{ steps.mode.outputs.mode }}"
 
-          # Fresh repositories must not remain permanently empty until month-end.
-          # After candidate generation, bootstrap exactly one publication when
-          # there is still no Zenn article. publish_best() keeps all source and
-          # quality gates; ARTICLE_MANUAL only bypasses the calendar restriction.
-          if [[ "${{ steps.mode.outputs.mode }}" == "candidate" ]]; then
-            if ! find articles -maxdepth 1 -type f -name '*.md' ! -name '.gitkeep' -print -quit | grep -q .; then
-              echo "bootstrap_publish=attempt"
-              ARTICLE_MANUAL=1 python -m pipeline.cli publish
-            fi
-          fi
+      - name: Assert automation never grants publication
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          newly_true = []
+          for path in Path("articles").glob("*.md"):
+              current = path.read_text(encoding="utf-8", errors="ignore")
+              if "published: true" not in current:
+                  continue
+              # Existing human-published files may remain true. This workflow is
+              # forbidden only from introducing a new true state.
+              import subprocess
+              previous = subprocess.run(
+                  ["git", "show", f"HEAD:{path.as_posix()}"],
+                  text=True,
+                  capture_output=True,
+                  check=False,
+              )
+              if previous.returncode != 0 or "published: true" not in previous.stdout:
+                  newly_true.append(path.as_posix())
+
+          if newly_true:
+              raise SystemExit(
+                  "automation attempted to grant publication: " + ", ".join(newly_true)
+              )
+          PY
 
       - name: Postflight audit
         run: python -m pipeline.audit
 
-      - name: Commit canonical outputs and publication policy
+      - name: Commit canonical candidate outputs
         shell: bash
         run: |
-          git add -A artifacts articles pipeline/core.py
+          git add -A artifacts articles
           if git diff --cached --quiet; then
             echo "No canonical output changes"
             exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,240 +1,343 @@
 # Articles Agent Operating Contract
 
-This repository is the canonical system for discovering, drafting, reviewing, selecting, and publishing KAFKA2306 technical articles.
+This repository is the canonical system for discovering, testing, drafting, reviewing, selecting, revalidating, and retiring KAFKA2306 technical articles.
 
-`README.md` explains the system to humans. `pipeline/contracts/article.md` defines the editorial contract. `AGENTS.md` defines how an autonomous agent may operate the repository safely and decide when work is complete.
+`README.md` describes the portfolio to humans. `pipeline/contracts/article.md` defines the editorial contract. This file defines what an autonomous agent may do and what it must never decide on its own.
 
 ## 1. Mission
 
-Produce evidence-backed articles that contain one verifiable, non-obvious discovery.
+Produce and maintain a small portfolio of evidence-backed articles that improve a reader's decision.
 
-Do not optimize for article count. Do not publish because a schedule exists. A month with zero publishable articles is valid.
+The target article does not merely explain a technology. It identifies a boundary that changes what the reader may reasonably trust, delegate, ship, infer, or reject.
 
-The canonical loop is:
+Canonical article shape:
 
 ```text
-public/private-safe idea seed
-  -> public evidence
-  -> one question
-  -> one hypothesis
-  -> one surprising finding
-  -> candidate draft
-  -> source gate
-  -> technical review
-  -> editorial review
-  -> bounded revision
-  -> selection
-  -> publication only when explicitly eligible
-  -> post-publication verification
+observed scene / failure / number
+  -> tempting initial interpretation
+  -> current primary evidence
+  -> falsification / boundary
+  -> updated mental model
+  -> portable decision rule
+  -> explicit non-goal
 ```
 
-## 2. Source-of-Truth Precedence
+Do not optimize for article count, publication frequency, word count, citation count, diagrams, or tool coverage.
 
-When sources disagree, use this order:
+A month with zero publishable articles is valid. Deleting or retiring a weak article is valid progress.
 
-1. current public primary-source evidence and directly fetched GitHub evidence;
-2. current repository code, config, schemas, and audit logic;
-3. `pipeline/contracts/article.md`;
-4. deterministic tests, reports, source-gate results, CI, and exact-head artifacts;
-5. `README.md`, architecture/editorial docs, and current ADR-like documents;
-6. Issue/PR prose and historical reports;
-7. memory or inference.
+## 2. Source-of-truth precedence
 
-Never let stale article prose override current evidence.
+When information conflicts, use this order:
 
-A generated sentence is not evidence. A model score is not evidence. A branch name is not evidence. An unverified URL is not evidence.
+1. the active user instruction for the current task;
+2. current official/public primary sources fetched now;
+3. current GitHub/production state fetched now;
+4. current repository code, config, schemas, and executable audit logic;
+5. `pipeline/contracts/article.md`;
+6. deterministic tests, exact-head CI, reports, and immutable artifacts;
+7. `README.md` and current design docs;
+8. Issue/PR prose and historical audit reports;
+9. memory, previous conversation context, or inference.
 
-## 3. Claim Provenance
+Historical prose is a hypothesis, not ground truth. Revalidate claims whose truth can change.
 
-Every material claim must be treated as one of:
+A generated sentence, model score, branch name, old screenshot, or unverified URL is not evidence.
 
-- **VERIFIED** — directly supported by fetched public evidence, repository state, a deterministic command, or CI result.
-- **OBSERVED** — explicitly provided by the user or task contract.
-- **INFERRED** — a conclusion derived from evidence; identify the inference boundary.
-- **UNVERIFIED** — not checked; never present as fact.
+## 3. Claim provenance
+
+Classify every material claim as one of:
+
+- **VERIFIED** — directly supported by currently fetched primary evidence, current repository state, deterministic execution, or exact-head CI.
+- **OBSERVED** — an observation explicitly supplied by the user/task or recorded in a public artifact.
+- **INFERRED** — a conclusion derived from verified evidence; the inference boundary must be visible.
+- **UNVERIFIED** — not checked; remove or label it, never silently upgrade it.
 - **FABRICATED** — forbidden.
 
-For numerical claims, preserve target, period, unit, comparison basis, and what the number does not prove.
+For numbers preserve target, period, unit, population/scope, comparison basis, and what the number does not prove.
 
-For causal claims, distinguish correlation, mechanism evidence, implementation dependency, and speculation.
+For causal language distinguish correlation, mechanism evidence, implementation dependency, and speculation.
 
-## 4. Privacy Boundary
+For quotations verify the original page and keep attribution adjacent.
 
-Graphiti and other private context are idea sources only.
+## 4. What counts as article value
 
-Never commit or publish:
+The unit of value is not knowledge transfer alone. It is **decision leverage**.
 
-- private diary text;
-- personal identifiers that are not already intentionally public;
-- tax, asset, health, travel, private relationship, or employer-internal information;
-- unpublished project details;
-- credentials, tokens, private URLs, local absolute paths, or hidden metadata.
+Before drafting, define:
 
-A private seed may suggest a topic, but every public article claim must be re-grounded in public evidence.
+- `reader_job` — the concrete decision or action the reader needs to make;
+- `reader_before` — what uncertainty, friction, risk, or false confidence exists before reading;
+- `observed_anomaly` — the specific failure, contradiction, number, or unexpected result;
+- `initial_hypothesis` — the tempting interpretation before investigation;
+- `proof_of_value` — the public evidence unique to this article;
+- `boundary` — what the evidence authorizes and what it does not authorize;
+- `hypothesis_update` — what changed after verification;
+- `decision_rule` — a portable rule the reader can apply elsewhere;
+- `reader_after` — the action/decision newly enabled;
+- `non_goal` — what remains unresolved;
+- `half_life` — which claims are volatile and when revalidation is needed;
+- `portfolio_overlap` — whether an existing article already does this job better.
 
-`python -m pipeline.audit` is a mandatory privacy/repository gate when its scope is affected.
+If these cannot be stated without vague language, return to topic selection.
 
-## 5. Canonical State Boundaries
+## 5. Topic rejection rules
 
-Repository state is intentionally separated:
+Reject or keep private when the candidate is only:
 
-- `artifacts/candidates/YYYY-MM/` — unpublished, public-safe article candidates;
-- `artifacts/reports/YYYY-MM/` — review/source evidence;
-- `pipeline/` — generation, review, selection, and audit implementation;
-- `pipeline/contracts/article.md` — editorial contract;
-- `articles/` — published article files only;
-- `images/` / `demos/` — supporting assets only when they improve the article and remain independently verifiable.
-
-Do not treat a candidate as published because it was merged to `main`.
-
-`published: false` is a hard state boundary. Merging a candidate with `published: false` does not authorize publication.
-
-Do not copy candidate files into `articles/` unless the publication contract is explicitly satisfied.
-
-## 6. Canonical Workline Rule
-
-Before creating a branch or PR:
-
-1. inspect open PRs and relevant branches;
-2. continue an existing canonical workline for the same article/change if one exists;
-3. do not create a competing implementation or duplicate article candidate;
-4. use one short-lived branch and one PR for pipeline/CI/contract changes;
-5. use direct-to-main only when the repository's current branch policy explicitly permits it and independent review is not required.
-
-Different article candidates may have separate PRs. The duplicate prohibition applies to the same outcome, not unrelated articles.
-
-When an older workline is superseded, close or consolidate it rather than leaving two canonical paths.
-
-## 7. Contract Before Change
-
-For non-trivial work, define:
-
-- **Contract** — what must change and what must remain unchanged;
-- **Outcome** — observable final state;
-- **Acceptance Criteria** — deterministic checks that prove the outcome;
-- **Evidence** — files, fetched URLs, reports, tests, CI runs, or publication receipts;
-- **Stopping Condition** — the fixed point after which additional edits are scope expansion.
-
-Do not broaden an article because adjacent facts are interesting.
-
-## 8. Article Selection Rule
-
-One article should contain one discovery.
-
-Reject or return to topic selection when the candidate is only:
-
+- an official-documentation summary;
+- an installation/setup guide;
+- a link collection or service directory;
+- a product roundup or "best stack" list without a controlled comparison;
 - a tool/library explanation;
-- a best-practice summary;
-- a configuration mistake with no broader finding;
-- a URL/error cleanup story;
-- a repository inventory with no falsified hypothesis;
-- a collection of unrelated impressive results;
-- a generic AI-generated tutorial.
+- a repository changelog;
+- a generic best-practice summary;
+- a configuration mistake with no transferable boundary;
+- a secondary-source collage;
+- an invented framework without implementation/measurement/falsification;
+- an article whose central numbers cannot be reproduced or sourced;
+- an "Aを使ってBを作った" story with no hypothesis update;
+- a result where the conclusion was obvious before reading;
+- a weak question padded with prose, citations, diagrams, or rhetoric.
 
-A weak question must not be rescued by more prose, more citations, more diagrams, or stronger rhetoric.
+Do not promote technical novelty to reader value automatically.
 
-## 9. Evidence and Source Gate
+## 6. Preferred article families
 
-Before an article can be considered publishable:
+The portfolio may span different technologies, but strong articles usually belong to one of these families:
 
-- verify source URLs by actual HTTP retrieval when the pipeline contract requires it;
-- prefer primary/official sources for external claims;
-- preserve at least the source minimums defined by the current article contract;
-- use concrete KAFKA2306 GitHub evidence for repository-specific claims;
-- do not quote or paraphrase beyond what the source supports;
-- do not turn an implementation example into a universal claim without a separate justification;
-- distinguish direct measurement from inferred interpretation.
+1. **Authority boundary** — who/what is allowed to declare success or truth.
+2. **Verification boundary** — what a test, detector, CI result, screenshot, or tool success actually proves.
+3. **Delegation boundary** — what an AI/agent/process may safely do and what must remain externally constrained.
+4. **Release/runtime boundary** — build, validation, release, production, visual, or real-client completion are separated.
+5. **Provenance/decision history** — why a number or decision can be reconstructed later without hindsight rewriting.
+6. **Observation boundary** — internal state is separated from user-visible/real-world outcome.
 
-If a required source is inaccessible, stale, contradictory, or ambiguous, fail closed or weaken/remove the claim.
+These are not mandatory section templates. They are portfolio-level patterns.
 
-## 10. Editorial Contract
+## 7. Evidence gate
 
-Follow `pipeline/contracts/article.md` for the current editorial thresholds and title/story rules.
+Before an article can be publishable:
 
-Core invariant:
+- retrieve primary/official external sources now when the claim can change;
+- use current public KAFKA2306 GitHub evidence for repository-specific claims;
+- follow the source minimums in `pipeline/config.json` and `pipeline/contracts/article.md`;
+- verify URLs by real retrieval when required by the pipeline;
+- preserve immutable commit/run/artifact references when the exact historical state matters;
+- distinguish direct measurement from interpretation;
+- remove a claim if a source is inaccessible, contradictory, stale, or narrower than the prose;
+- never infer vendor internals from another vendor's implementation;
+- never convert NOT_RUN / unknown / pending into PASS / complete.
+
+A source count can satisfy a floor; it cannot rescue a weak claim.
+
+## 8. Claim calibration / authority rule
+
+For each important piece of evidence, explicitly ask:
 
 ```text
-scene / number / failure
-  -> unresolved question
-  -> initial hypothesis
-  -> evidence / experiment
-  -> hypothesis update
-  -> one takeaway
+What conclusion does this evidence permit?
+What stronger conclusion would exceed the evidence?
 ```
 
-Do not begin with a glossary or technology definition unless the article cannot be understood otherwise.
+Examples:
 
-Do not imitate an identifiable writer's style. Extract structural/editorial principles only.
+```text
+unit test PASS
+  permits: tested assertions passed
+  does not permit: product is correct in every user-visible state
 
-Do not manufacture suspense by hiding evidence or exaggerating certainty.
+MCP tool returned success
+  permits: the tool invocation completed as reported
+  does not permit: visual/runtime result is complete
 
-## 11. Images and Illustrations
+watermark detector score
+  permits: detector observed its defined signal under its assumptions
+  does not permit: universal proof of AI authorship
+```
 
-Images are supporting evidence/explanation, not decoration quotas.
+This calibration is a blocking editorial requirement.
 
-Add an image only when it does at least one of:
+## 9. Privacy boundary
 
-- compress a complex causal/data flow;
-- make a measured comparison easier to understand;
-- expose a state transition or architecture boundary;
-- show a concrete artifact/result that prose alone obscures.
+Private context is idea seed only.
 
-Rules:
+Never commit or publish private diary text, non-public personal identifiers, tax/asset/health/private relationship information, private travel details, employer-internal information, credentials, tokens, private URLs, local absolute paths, or unpublished confidential project details.
 
-- the article must remain understandable if the image fails to load;
-- image captions/nearby prose must not claim more than the underlying evidence;
-- generated illustrations must not be presented as screenshots, measurements, or historical evidence;
-- keep only final assets required by the article;
-- remove staging chunks, base64 helpers, temporary generation scripts, noop files, and intermediate artifacts before merge;
-- verify final image references resolve to repository files.
+If a private seed suggests a topic, re-ground every public claim in public evidence.
 
-## 12. Interactive Demos
+Run `python -m pipeline.audit` whenever its scope is affected.
 
-Interactive demos are optional progressive enhancement.
+## 10. Repository state boundaries
 
-Use them only when changing an input and recalculating materially improves understanding.
+State is intentionally separated:
 
-The article must still stand alone if the demo is unavailable.
+- `artifacts/candidates/YYYY-MM/` — unpublished public-safe candidates;
+- `artifacts/reports/YYYY-MM/` — source/review/selection evidence;
+- `pipeline/` — generation/review/selection/audit implementation;
+- `pipeline/contracts/article.md` — canonical editorial contract;
+- `articles/` — Zenn-compatible source for published articles and deliberately human-selected `published:false` drafts;
+- `images/` / `demos/` — supporting assets only when they materially improve understanding or verification.
 
-Do not claim a demo is executable until the actual public/static route has been fetched and tested when publication requires that route.
+`published: false` is a hard state boundary.
 
-Prefer one shared runtime over duplicate per-article runtimes.
+Merging, CI green, article selection, or placement under `articles/` does not authorize public publication.
 
-## 13. Builder / Auditor Separation
+## 11. Human-controlled publication
 
-Treat implementation and acceptance as separate phases.
+Zenn's official AI-content policy requires the author to verify accuracy and contribute their own experience/insight, and warns against posting faster than human verification can keep up.
 
-### Builder
+Primary references:
 
-May:
+- https://info.zenn.dev/2026-03-10-ai-contents-guideline
+- https://zenn.dev/guideline
+
+Therefore:
+
+- scheduled automation may discover, research, draft, audit, compare, and report;
+- scheduled automation must not change an article from `published: false` to `published: true`;
+- the internal `publish` command may only materialize a selected candidate as `published: false`;
+- public publication requires an explicit current human instruction or equivalent explicit approval state;
+- a calendar event, score threshold, merge, or "best candidate" result is never publication authorization.
+
+If instructions are ambiguous, fail closed at `published: false`.
+
+## 12. Portfolio lifecycle
+
+Publication is not the terminal state.
+
+Audit published articles as:
+
+- `KEEP` — current evidence, reader job, and decision rule remain strong;
+- `REVALIDATE` — core insight is durable but material facts are volatile;
+- `REWRITE` — evidence/kernel is worth preserving but presentation or calibration is below current standard;
+- `MERGE` — another article provides the same reader job with stronger proof;
+- `RETIRE` — stale, misleading, redundant, weakly evidenced, or no longer worth maintaining.
+
+Retirement is appropriate when one or more hold:
+
+1. the article encourages a stronger conclusion than its evidence supports;
+2. its central claim is no longer verifiable/current;
+3. a newer article strictly supersedes its reader job;
+4. it is mostly links/setup/docs summary and has no unique proof;
+5. it relies on arbitrary thresholds or unsupported numeric claims;
+6. title/body or promise/evidence are materially mismatched;
+7. maintenance/revalidation cost exceeds the durable reader value;
+8. keeping it dilutes the portfolio's decision/audit signature.
+
+Do not keep a weak article merely because it has already been published.
+
+## 13. Zenn retirement procedure
+
+Zenn's GitHub integration and article deletion are different operations.
+
+Official documentation states that complete deletion of a GitHub-managed article requires deleting it from the Zenn dashboard and from the connected repository; deleting only one side is insufficient and a repository copy can reappear.
+
+- https://zenn.dev/zenn/articles/connect-to-github
+
+When an agent cannot access the Zenn dashboard:
+
+1. mark the article `RETIRE` in the portfolio audit with exact public URL;
+2. remove the repository source only if it is repo-managed and the user authorized retirement;
+3. create/maintain one exact human-action checklist for dashboard deletion;
+4. never claim the public Zenn article was deleted until the public URL is fetched and confirmed absent;
+5. after the human dashboard deletion, re-fetch the URL and close the retirement item only when absence is verified.
+
+Do not create replacement slugs solely to simulate deletion.
+
+## 14. Post-publication revalidation
+
+Assign an approximate half-life to volatile claims.
+
+Examples:
+
+- pricing / quota / product availability — short half-life;
+- current API/tool behavior — medium, version-sensitive;
+- immutable experiment result at fixed commit — long;
+- standards/history at fixed version — long, but citation links still need availability checks.
+
+Revalidation checks:
+
+- central source still exists and supports the same claim;
+- product/version/pricing facts are still current where material;
+- linked GitHub artifact still resolves;
+- a newer article has not superseded the reader job;
+- title still matches the actual evidence;
+- no retrospective overclaiming has appeared after later results.
+
+## 15. Builder / auditor separation
+
+### Builder may
 
 - research public evidence;
 - draft/revise candidates;
-- add tests, images, demos, pipeline code, contracts, and reports;
+- create tests, images, demos, reports, and pipeline code;
 - run deterministic validation;
-- open/update the canonical PR.
+- open/update the canonical PR;
+- propose lifecycle transitions.
 
-### Auditor
+### Auditor must independently verify
 
-Must independently verify:
+- one central reader job and one discovery;
+- current source support for material claims;
+- claim calibration and non-goal;
+- privacy boundaries;
+- portfolio overlap;
+- candidate/published state;
+- image/demo evidence integrity;
+- exact-head CI where applicable;
+- no helper/staging residue;
+- publication state did not change without explicit authorization.
 
-- the article has one central question and one discovery;
-- material claims are supported by fetched evidence;
-- privacy boundaries hold;
-- candidate/published state is correct;
-- generated images/demos are not misrepresented as evidence;
-- current source/technical/editorial gates pass where applicable;
-- CI evidence belongs to the exact head SHA;
-- no helper/staging residue remains;
-- publication state was not changed without authorization.
+Implementation intent is never acceptance evidence.
 
-Implementation intent is never audit evidence.
+## 16. Images and demos
 
-## 14. Validation Ladder
+Use an image only when it compresses a causal/data flow, exposes a state/boundary, makes a measured comparison easier to understand, or shows a concrete artifact that prose obscures.
+
+Rules:
+
+- article remains understandable if the image fails;
+- generated illustrations are never presented as screenshots, measurements, or historical evidence;
+- captions do not claim more than the source artifact;
+- keep only final required assets;
+- remove staging/base64/helper generation residue before merge;
+- interactive demos are optional progressive enhancement, never a substitute for the written proof.
+
+## 17. Contract before change
+
+For non-trivial work define:
+
+- **Contract** — what changes and what must remain unchanged;
+- **Outcome** — observable final state;
+- **Acceptance Criteria** — deterministic checks;
+- **Evidence** — source URLs, files, CI runs, artifacts, or public receipts;
+- **Stopping Condition** — the fixed point after which further edits are scope expansion.
+
+Do not broaden an article because adjacent facts are interesting.
+
+## 18. Canonical workline / Git protocol
+
+Before creating a branch or PR:
+
+1. inspect current `main`, open PRs, and relevant branches;
+2. continue an existing canonical workline if it targets the same outcome;
+3. otherwise create one short-lived branch for one logical change;
+4. do not create competing implementations for the same outcome;
+5. keep one logical change in one commit where practical;
+6. prefer Git data API batching (`create_blob` -> `create_tree` -> `create_commit` -> `update_ref(force=false)`) for multi-file atomic changes;
+7. verify changed filenames and exact-head CI;
+8. inspect failed jobs/steps rather than blindly rerunning everything;
+9. merge only after acceptance criteria pass;
+10. verify merged `main` and any affected publication state.
+
+If a host-side safety system rejects a write, re-fetch current state and retry the exact canonical action once. Do not create duplicate branches/PRs as a workaround.
+
+## 19. Validation ladder
 
 Use the cheapest deterministic verifier that can falsify the change, then escalate.
 
-Current baseline:
+Baseline:
 
 ```bash
 python -m compileall pipeline demos/python-syntax-gate/syntax_gate.py
@@ -244,98 +347,45 @@ node --check demos/python-syntax-gate/app.mjs
 python -m pipeline.audit
 ```
 
-When a demo/static route is affected, run the repository's static route smoke equivalent.
-
-For PRs, verify GitHub Actions on the exact head SHA. A green run on another SHA is not evidence for the current head.
+For PRs, verify GitHub Actions on the exact head SHA. A green run on another SHA is not evidence.
 
 A verifier that did not run is not PASS.
 
-## 15. Publication Is a Separate Side Effect
+## 20. Cleanup is completion
 
-Drafting, merging, or passing CI does not imply publication authorization.
+Inspect for stale candidates, duplicate articles, orphaned images, superseded reports, temporary generation scripts, debug/noop files, accidental private data, obsolete branches, and stale lifecycle metadata.
 
-Publication requires the active task or canonical pipeline state to explicitly authorize it.
+Delete only when the lifecycle decision and user authorization support deletion. Historical audit/evidence may remain when it is useful for explaining why an article was retired.
 
-Before publication:
+If unfinished work remains, leave exactly one canonical workline and record the blocker plus exact next action.
 
-1. confirm `published` state and publication contract;
-2. rerun required source/technical/editorial gates;
-3. verify the selected candidate is still the intended article;
-4. verify filename/slug policy;
-5. move/materialize only the intended article into `articles/` through the canonical path;
-6. verify generated publication diff;
-7. after deployment/sync, fetch the public result when possible;
-8. retain evidence of the published revision/URL.
-
-Do not publish a candidate merely because it is "finished".
-
-## 16. Git / PR / CI Protocol
-
-For repository changes:
-
-1. start from the latest intended base;
-2. continue the canonical branch if one exists;
-3. otherwise create one short-lived descriptive branch when review is warranted;
-4. keep the diff limited to the Contract;
-5. remove generation intermediates before PR acceptance;
-6. open/update one canonical PR;
-7. verify changed filenames and exact-head CI;
-8. inspect failed checks instead of retrying blindly;
-9. merge only when acceptance criteria are satisfied;
-10. verify merged `main` SHA and required main/deploy workflow;
-11. verify candidate/publication state after merge;
-12. rely on branch-hygiene automation or delete the merged branch when possible.
-
-If a host-side safety system rejects a GitHub write, re-fetch current state and retry the exact canonical action once. Do not create a duplicate branch/PR as a workaround.
-
-## 17. Cleanup Is Part of Completion
-
-Before final reporting, inspect for:
-
-- staging chunks;
-- `.b64` intermediates;
-- noop/debug files;
-- temporary image-generation scripts;
-- unused `.gitkeep` files introduced by the task;
-- generated caches;
-- duplicate images;
-- superseded PRs;
-- merged/redundant branches;
-- stale article-state metadata;
-- accidental private material.
-
-Do not delete unrelated valid article candidates or evidence.
-
-If unfinished work must remain, keep exactly one canonical workline and record the blocker and next action.
-
-## 18. Fixed Point
+## 21. Fixed point
 
 Stop when all are true:
 
-- requested outcome exists;
-- article/pipeline state is correct;
-- evidence and privacy gates are satisfied;
+- requested editorial/repository outcome exists;
+- material claims were re-grounded in current evidence;
+- reader job, boundary, decision rule, and non-goal are explicit;
+- portfolio lifecycle state is correct;
 - relevant tests/audits pass;
 - exact-head CI is verified when applicable;
-- publication state matches the explicit contract;
+- publication state matches explicit human authorization;
 - supporting assets resolve correctly;
 - task-created residue is gone;
-- linked PR/Issue state is correct;
-- no known blocker remains.
+- no known blocker remains except an external action the available tools cannot perform.
 
-Further polishing after this point is a new editorial task, not completion.
+Further polishing after this point is a new task.
 
-## 19. Final Report Contract
+## 22. Final report
 
 Report only verified state relevant to the task:
 
-- target article / Issue / PR URL;
-- what changed;
-- evidence/source gates checked;
-- tests/audits/CI and exact result;
-- PR/commit/merge SHA;
-- publication URL/receipt if publication occurred;
-- cleanup performed;
-- blocker and exact next action if unfinished.
+- target repo / PR / article URLs;
+- what was changed or retired;
+- source/portfolio gates checked;
+- tests/audits/CI exact result;
+- commit/PR/merge SHA;
+- public publication/deletion result only if directly verified;
+- external blocker and exact human action if one remains.
 
-Do not report publication when only a candidate was merged. Do not report evidence that was not fetched. Do not use completion theater.
+Do not report Zenn deletion when only a repository file or retirement checklist changed. Do not report evidence that was not fetched. Do not use completion theater.

--- a/README.md
+++ b/README.md
@@ -1,402 +1,260 @@
 # KAFKA2306/articles
 
-**証拠から「なぜこうなった？」を見つけ、読者が追体験できる一つの発見へ変える技術記事repository。**
+**観測された失敗・異常・数字から、読者が「何を信じてよいか」「どこまで任せてよいか」「次へ進んでよいか」を判断できる技術記事を作るrepository。**
 
-一般知識をAIで量産するためのrepoではありません。
-公開GitHub活動とprivacy-safeなprivate seedから問いを見つけ、一次情報へ再接地し、仮説更新・reader value・proofまで揃った記事だけを公開候補にします。
+このrepoは、技術ニュース、ツール紹介、AI要約、ベストプラクティス集を量産するための場所ではありません。
 
-> **Discover one surprising fact. Prove it. Turn it into something the reader can use.**
+公開する価値があるのは、一次情報と公開実装を追った結果、最初の予想が更新され、読者が別の現場へ持ち帰れる**判断規則**が残った記事です。
 
-## Vision
+> **Observe the failure. Find the boundary. Prove the boundary. Give the reader a decision rule.**
 
-記事を読んだ人が得るのは、技術名の知識ではなく、**「自分なら次にどう判断・実装・運用するか」を決められる状態**です。
+## What we are trying to publish
 
-このrepoでは、1本の記事を次の変化として設計します。
+過去のZenn記事を読み直すと、現在の強い記事には共通した形があります。
 
 ```text
-読む前
-  └─ 何が起きているか分からない / 失敗理由が曖昧 / どこまで信じてよいか分からない
+具体的なscene / failure / number
         ↓
-具体的なscene・数字・失敗
+もっともらしい最初の解釈
         ↓
-自然な予想
+現在の一次情報 + 公開artifactで検証
         ↓
-公開証拠で検証
+何が証明でき、何が証明できないかを分離
         ↓
-仮説更新
+最初の解釈を更新
         ↓
-読む後
-  └─ 判断できる / 試せる / 止められる / 説明できる / 運用へ持ち込める
+別の現場でも使えるdecision rule
 ```
 
-「正しく説明した」で終わらず、reader before → after を本文で成立させます。
+主題は技術名ではなく、**authority / verification / decision boundary** です。
 
-## Design philosophy
+典型的には次を分離します。
 
-### 1. 技術名より現象を先にする
+- implementation と validation
+- capability と authority
+- runner と policy / oracle
+- build と release と production verification
+- detection と independent verification
+- value と provenance
+- AIが実行できること と AIへ許可してよいこと
+- artifactが存在すること と visual / runtimeで完成していること
+- 最新ノート と 判断時点の証拠
 
-`MCP`、`Provenance`、`Pyodide`、`GitHub Actions` から記事を始めません。
+記事の価値は「詳しく説明した」ではなく、**読者がその境界を使って誤った判断を避けられること**です。
 
-先に、
+## The article signature
 
-- 61件目だけが消えた
-- 856件が7,699件になった
-- CIが自分でmanifestを直してからgreenになった
-- AI生成図に実行していない `CI SUCCESS` が描かれた
+公開候補は最低でも次を持ちます。
 
-のような、読者が意味を理解できる現象を置きます。
+1. **Reader job** — 読者は何を決めたいのか。
+2. **Observed anomaly** — 実際に何が起きたのか。数字、失敗、矛盾、反例のどれかを置く。
+3. **Initial hypothesis** — 最初は何が原因・正解だと思ったか。
+4. **Evidence** — 現在取得できる一次情報と公開artifact。
+5. **Boundary** — その証拠が許可する結論と、許可しない結論。
+6. **Hypothesis update** — 何を見て考えを変えたか。
+7. **Decision rule** — 読者が次回使える判定規則。
+8. **Non-goal** — この記事が証明していないこと。
+9. **Half-life** — どの事実が陳腐化しやすく、再検証が必要か。
 
-技術は、その謎を解くために必要になった位置でだけ登場させます。
-
-### 2. 一記事一発見
-
-候補は次のいずれかへ収束させます。
-
-- anomaly
-- contradiction
-- failure
-- unexpected connection
-- counterintuitive result
-- magnitude
-
-複数の正しい論点を詰め込むより、中心の問いを前進させない節を削ります。
-
-### 3. private contextはidea seed、public evidenceはclaim source
-
-private Graphiti weeklyは、題材候補を見つけるためのread-only seedです。
+### 良い記事の例となる問い
 
 ```text
-private seed
-   ↓ idea only
-public GitHub / official primary source
-   ↓ re-ground
-public claim
+「テストが通った」なら、誰が合格条件を決めたのか？
+「Unityを操作できた」なら、見た目と実挙動まで誰が監査したのか？
+「AI生成だと検出できる」なら、誰が独立して検証できるのか？
+「deployできた」なら、build / validation / release / productionのどこまで成功したのか？
+「数字が増えた」なら、source / scope / methodの何が変わったのか？
 ```
 
-private diary本文、個人情報、税務、資産、健康、旅行、私生活、勤務先内部情報、未公開情報をpublic evidenceへ昇格させません。
+## What we do not publish
 
-### 4. 「動いた」を完成にしない
+次は、正しく書けても原則として公開しません。
 
-必要に応じて、
+- 公式docsの要約
+- インストール手順だけの記事
+- リンク集・サービス一覧
+- 「2026年の最強stack」のような比較表だけの記事
+- tool / libraryの紹介だけの記事
+- repoの変更履歴を記事へ変えただけのもの
+- 二次情報を大量に並べたAIレポート
+- 実装・測定・反証がない独自framework
+- 根拠のない閾値、magic number、成功率
+- 「Aを使ってBを作った」で終わる成功談
+- 読む前から結論が常識的に決まっている記事
+- weak questionを長文・図・引用で救った記事
+- CTAを足しただけの営業記事
+
+**技術的に正しいことは必要条件であって、公開理由ではありません。**
+
+## Portfolio value
+
+記事数はKPIではありません。
+
+弱い記事は0点ではなく、読者から見た著者のsignalを薄め、古い主張の再検証コストを増やすため、**負のportfolio value** を持ち得ます。
+
+公開後も記事を次のstateで監査します。
+
+| State | 意味 |
+|---|---|
+| `KEEP` | 現在も証拠・判断規則・読者価値が強い |
+| `REVALIDATE` | 核は強いが、価格・仕様・市場など陳腐化しやすい事実を再確認する |
+| `REWRITE` | 核と証拠は残す価値があるが、現在の編集基準へ書き直す |
+| `MERGE` | より強い記事へ統合し、単独記事を残さない |
+| `RETIRE` | 誤解・重複・陳腐化・弱い証拠によりportfolioから外す |
+
+公開済みだから永久保存、とは扱いません。
+
+現行監査: [`docs/zenn-portfolio-audit-2026-08-15.md`](docs/zenn-portfolio-audit-2026-08-15.md)
+
+## Evidence contract
+
+外部事実は、公開時点で取得できる一次情報を優先します。
+
+最低条件は `pipeline/contracts/article.md` と `pipeline/config.json` を正準とします。原則は次です。
+
+- material claimのURLを実際に取得する
+- vendor仕様はvendor公式、標準はstandards body、GitHub固有事実はGitHub上のartifactで確認する
+- repo固有の主張は公開commit / PR / Issue / Actions / artifactへ接地する
+- 数字には対象、期間、単位、比較基準を残す
+- observation / inference / speculationを混ぜない
+- inaccessible / stale / contradictoryなsourceはfail-closeする
+- 取得できない事実を文章力で補完しない
+
+**証拠が許可する以上の結論を書かない**ことを最優先します。
+
+## Reader value contract
+
+記事は、読者の状態を変えなければ公開価値がありません。
 
 ```text
-tool success
-runtime compatibility
-validation
-allowed use
-production / public verification
+reader_before
+  ↓
+この記事固有のproof / failure / comparison
+  ↓
+reader_after
 ```
 
-を別stateとして扱います。
+`reader_after` は「理解した」「学んだ」では不十分です。
 
-未実証範囲を明示できない記事は、強い営業資産にはなりません。
+- 判断できる
+- 止められる
+- 採否を決められる
+- 検証できる
+- 再現できる
+- 安全に委任できる
+- 何が未確認か説明できる
 
-### 5. 弱い記事を長文化して救わない
+のように、次のactionへ接続させます。
 
-問い・reader value・proofが弱ければ、文章を足して合格にしません。
+## Publication is human-controlled
 
-- rewrite
-- merge
-- keep private
-- archive / delete
+Zenn公式は、AI利用時も**著者自身が正確性を検証し、経験・洞察を含めること**を「人が主体」として求めています。また、著者の確認が追いつかない速度の自動投稿や機械生成spamを問題視しています。
 
-を正規のlifecycleとして扱います。
+- https://info.zenn.dev/2026-03-10-ai-contents-guideline
+- https://zenn.dev/guideline
 
-**記事数はKPIではありません。**
-
-## Why / 差別化
-
-このrepoの差別化は、LLM、Graphiti、Copilot CLI、Pyodide、GitHub Actionsそのものではありません。
-
-一般的なAI記事生成と違い、公開前に次を要求します。
-
-1. **何が意外だったか** — `central_question` / `surprising_finding`
-2. **何を最初に予想したか** — `initial_hypothesis`
-3. **何を見て考えが変わったか** — `hypothesis_update`
-4. **読者の何が変わるか** — `reader_before` / `reader_after`
-5. **なぜこの記事なのか** — `why_this_article`
-6. **本当に使える根拠は何か** — `proof_of_value`
-7. **何を証明しないか** — `non_goal`
-8. **読者が次に何を試せるか** — `desired_reader_action`
-
-これらを公開証拠から作れない候補は記事化しません。
-
-営業価値もCTAでは作りません。
-「お問い合わせください」を足す代わりに、本文から自然に使えるchecklist、template、decision table、最小導入手順へ変換します。
-
-正準contract:
-[`pipeline/contracts/article.md`](pipeline/contracts/article.md)
-
-編集設計:
-[`docs/EDITORIAL_DESIGN.md`](docs/EDITORIAL_DESIGN.md)
-
-現行portfolio監査:
-[`docs/article-portfolio-audit-2026-08-14.md`](docs/article-portfolio-audit-2026-08-14.md)
-
-## Discovery journey
+したがって、このrepoではautomationの責務を次に限定します。
 
 ```text
-Graphiti weekly (private, optional) ─┐
-                                    ├─> candidate discovery
-Public GitHub evidence ─────────────┘
-        ↓
-find one anomaly / contradiction / failure /
-unexpected connection / counterintuitive result / magnitude
-        ↓
-central question + initial hypothesis
-        ↓
-reader before / after + differentiation + proof
-        ↓
-draft as discovery story
-        ↓
-source gate
-        ↓
-technical review + editorial review + reader-value blocking gate
-        ↓
-revision by cutting weak sections
-        ↓
-best-of-month selection by story quality first
-        ↓
-articles/*.md
+scheduled automation
+  = discover / draft / source-check / review / compare / report
+
+manual selection
+  = candidateをZenn-compatible draftへ昇格する
+
+explicit human publication
+  = published: true を許可する
 ```
 
-候補生成時点で価値を定義するため、「書き終わってから営業っぽい一文を足す」という順序にはしません。
+**scheduleだけを理由に `published: true` へ変更してはいけません。**
 
-## Evidence / privacy boundary
+`pipeline publish` という内部command名は「公開候補を `articles/` のunpublished draftへmaterializeする」意味であり、Zennでpublicにする権限を持ちません。
 
-### Public claimに使えるもの
-
-- KAFKA2306 public GitHub code / commit / PR / issue / artifact
-- vendor / standards body / official documentation
-- 公開データの一次資料
-- 本文で再現できるfixture・test・measurement
-
-### Idea seedに留めるもの
-
-- private Graphiti weekly
-- private diary
-- 個人情報を含むconversation
-- 未公開業務情報
-- private financial / health / travel context
-
-private seedで気づいたテーマでも、公開記事のclaimはpublic evidenceへ再接地します。
-
-### Evidence gate
-
-最低条件:
-
-- primary-source URLs: 3件以上
-- KAFKA2306 GitHub evidence: 2件以上
-- external official primary source: 1件以上
-- URLは実HTTP取得で検証
-- 未確認を0件・成功・completeへ変換しない
-
-## Editorial contract
-
-### Story fields
-
-- `central_question`
-- `surprising_finding`
-- `initial_hypothesis`
-- `hypothesis_update`
-- `stakes`
-- `story_type`
-- `evidence_urls`
-- `why_interesting`
-
-### Reader-value fields
-
-- `reader_before`
-- `reader_after`
-- `design_philosophy`
-- `why_this_article`
-- `proof_of_value`
-- `desired_reader_action`
-- `non_goal`
-
-次はcandidate段階で不合格です。
-
-- `reader_after` が「理解する」「学ぶ」だけ
-- `why_this_article` が「詳しく説明する」「分かりやすく解説する」だけ
-- `proof_of_value` が空
-- 技術名・repository名・CI追加を価値そのものにしている
-
-本文査読では次をblocking issueとして扱います。
-
-- `weak_reader_value`
-- `weak_differentiation`
-- `missing_proof_of_value`
-- `forced_commercial_cta`
-- `technical_value_as_product`
-- `premature_conclusion_in_opening`
-- `narrow_technical_title_entry`
-
-technical / story scoreが高くても、blocking issueが残れば公開できません。
-
-## Quality gate
-
-### Technical floor
-
-| Axis | Minimum |
-|---|---:|
-| overall | 3.8 |
-| logic | 3.5 |
-| utility | 3.5 |
-| readability | 3.5 |
-| originality | 3.5 |
-| clarity | 3.5 |
-
-Target overall: **4.1**
-
-### Editorial floor
-
-| Axis | Minimum |
-|---|---:|
-| story overall | 4.0 |
-| interest | 4.1 |
-| discovery | 3.8 |
-| narrative | 3.8 |
-| context | 3.8 |
-
-Target story overall: **4.3**
-
-月末比較では、technical scoreより先に、
+## Repository state
 
 ```text
-story_overall
-→ interest
-→ discovery
-→ technical overall
+artifacts/candidates/YYYY-MM/
+  unpublished candidate。公開safeだがZenn sync surfaceではない。
+
+artifacts/reports/YYYY-MM/
+  source / review / selection evidence。
+
+articles/
+  Zenn-compatible source。published:true と明示承認された記事、および人間が選んだ published:false draftだけ。
+
+pipeline/
+  discovery / evaluation / audit implementation。
+
+pipeline/contracts/article.md
+  canonical editorial contract。
 ```
 
-を見ます。
+`published: false` はhard boundaryです。merge、CI green、選定、完成はpublication authorizationではありません。
 
-「他のエンジニアに役立つ」は品質床であり、「読みたい」の代用にはしません。
-
-## Candidate → review → publish
-
-### Weekly candidate
-
-**毎週月曜 09:00 JST** にcandidate modeを起動します。
-
-現行workflow:
-[`.github/workflows/article-pipeline.yml`](.github/workflows/article-pipeline.yml)
-
-処理:
-
-1. private Graphiti weeklyをread-onlyで取得できる場合だけ読む
-2. public GitHub evidenceを探索
-3. story + reader-value contractを満たす候補だけ残す
-4. source gateを実行
-5. technical / editorial / reader-value review
-6. 不合格なら最大3回、論点を増やさず改稿
-7. `artifacts/candidates/YYYY-MM/` と `artifacts/reports/YYYY-MM/` に保存
-
-### Month-end selection
-
-**実月末 23:30 JST** のwindowでpublish modeを起動します。
-`28–31日`にscheduleし、実際の月末かどうかは`pipeline.selection.is_month_end()`でfail-close判定します。
-
-1. 当月候補を全件再検証
-2. 査読を3回独立実行し中央値で判定
-3. source / technical / editorial / reader-value gateを全通過した集合だけ残す
-4. 最高品質1本だけ選ぶ
-5. 合格0本なら公開0本
-
-月1本は上限でありノルマではありません。
-
-## Zenn publication boundary
-
-`articles/*.md` は **Zenn-compatibleな正準article source** です。
-`published: false` のdraftもここに存在します。
-
-候補・査読証跡は `artifacts/` に隔離します。
-
-Zenn公式では、GitHub連携時のarticle slugは `articles/[slug].md` のファイル名で決まり、slugは半角英小文字・数字・ハイフン・アンダースコアの **12〜50文字**です。一度Zenn上で作成したslugは変更できないため、公開済みarticleを管理目的だけでrenameしません。
-
-一次仕様:
-
-- https://zenn.dev/zenn/articles/what-is-slug
-- https://zenn.dev/zenn/articles/markdown-guide
-
-### Filename policy
-
-新規公開article:
+## Candidate lifecycle
 
 ```text
-YYYY-MM-DD-NN-title.md
+public/private-safe idea seed
+  ↓
+current primary evidence
+  ↓
+reader job + anomaly
+  ↓
+question + initial hypothesis
+  ↓
+evidence / experiment
+  ↓
+boundary + hypothesis update
+  ↓
+decision rule + non-goal
+  ↓
+technical / editorial / reader-value review
+  ↓
+KEEP_PRIVATE / REWRITE / MERGE / RETIRE / human-selected draft
+  ↓
+explicit human publication only
+  ↓
+post-publication revalidation
+```
+
+候補が0本でも正常です。公開本数を埋めるために基準を下げません。
+
+## Title rule
+
+タイトルはtool名ではなく、読者が認識できる問題から入ります。
+
+```text
+一般語で分かるproblem
+  → 本文で証明できる具体的な異常・失敗・数字
+  → 必要なら検索用の正式技術名
 ```
 
 例:
 
 ```text
-2026-08-13-01-codex-chatgpt-github-issue-bridge.md
+弱い: Pyrefly / Ruff / Pydanticの比較
+強い: 型チェックが通っても、外部入力は検証されていない
 ```
 
-- `YYYY-MM-DD`: 公開処理を行うJST日付
-- `NN`: 同日内 `01`, `02`, ...
-- `title`: 短いASCII kebab-case
-- config上のtitle部分最大: 36文字
-- 既存公開slugはrenameしない
+タイトルで約束した異常を本文で証明できなければ不採用です。
 
-## Interactive examples are optional
+## Images and demos
 
-Zenn本文が成立するためにinteractive demoを必須にしません。
+画像は装飾quotaではなく、理解または証拠密度を上げる場合だけ使います。
 
-Zenn公式Markdown guideはリンクカードや対応済み外部サービスのembedを定義していますが、このrepoは**任意custom JavaScript / 独自Web Workerを記事本文へ注入できることを前提にしません**。
-
-Pyodide等を使う場合も別の静的Web成果物として扱い、次を要求します。
-
-- static本文だけで主張・再現方法が完結する
-- Python sourceをJavaScriptへ再実装しない
-- runtime / packageは実行操作までlazy load
-- demoごとのpackageを明示
-- 公開URLのE2E前に「実行できる」と記事へ書かない
-
-つまりinteractive demoは、**理解を明確に改善し、全体complexityを下げる場合だけのprogressive enhancement**です。
-
-関連Issue: #31
-
-## Repository structure
-
-```text
-.github/workflows/
-  article-pipeline.yml       # weekly candidate / month-end selection
-  article-pipeline-ci.yml    # compile + tests + repository/privacy audit
-  branch-hygiene.yml         # merged/redundant work branch cleanup
-
-pipeline/
-  cli.py                     # candidate / publish entry point
-  core.py                    # collection, source verification, persistence
-  editorial.py               # story/value shaping, drafting, review, revision
-  filenames.py               # Zenn-compatible publication filename contract
-  runtime.py                 # Copilot CLI fail-close response adapter
-  graphiti.py                # private weekly → in-memory seed
-  selection.py               # candidate maturation + month-end selection
-  audit.py                   # repository/privacy/editorial audit
-  config.json                # quality / value / path contract
-  contracts/article.md       # canonical article contract
-
-artifacts/
-  candidates/YYYY-MM/        # unpublished public-safe candidates
-  reports/YYYY-MM/           # source + review evidence
-  archive/                   # retired reusable notes, not article candidates
-
-articles/                    # Zenn-compatible canonical article sources
-
-docs/
-  ARCHITECTURE.md
-  EDITORIAL_DESIGN.md
-  article-portfolio-audit-2026-08-14.md
-
-tests/
-```
+- generated illustrationをscreenshot / measurement / historical evidenceとして扱わない
+- 本文は画像がなくても成立させる
+- diagramは1枚1messageを基本にする
+- visual claimは元artifactへ接地する
+- interactive demoは本文の代替にしない
 
 ## Quick verification
 
 ```bash
-python -m compileall pipeline
+python -m compileall pipeline demos/python-syntax-gate/syntax_gate.py
 python -m unittest discover -s tests -v
+node --check demos/_shared/pyodide-worker.mjs
+node --check demos/python-syntax-gate/app.mjs
 python -m pipeline.audit
 ```
 
@@ -406,70 +264,22 @@ Candidate generation:
 python -m pipeline.cli candidate
 ```
 
-Month-end selection:
+Human-triggered selection to an unpublished Zenn draft:
 
 ```bash
-python -m pipeline.cli publish
+ARTICLE_MANUAL=1 python -m pipeline.cli publish
 ```
 
-## Automation / runtime
+## Canonical documents
 
-GitHub Actionsの生成backendは **GitHub Copilot CLI** です。
-
-- `copilot-requests: write`
-- built-in `GITHUB_TOKEN`
-- CLIのread/write/shell/url/memory toolsは許可せず、text generation boundaryとして使う
-- `runtime.py` はJSON contractをfail-closeで正規化
-- private Graphiti readは別のread-only `GRAPHITI_READ_TOKEN`
-- token未設定時はGraphiti入力だけskip
-
-モデルやtoolが価値なのではなく、**同じeditorial contractを再現可能に実行するためのruntime**として扱います。
-
-## Branch lifecycle
-
-`main` だけを長寿命branchにします。
-
-- content pipelineの正準outputは`main`
-- pipeline / CI / contractのレビュー価値がある変更だけ短命branch + PR
-- merged branchはcleanup対象
-- open PRなし・unique patchなしのbranchは`branch-hygiene.yml`で整理
-- unique patchがあるbranchは自動で捨てない
-
-branch数を進捗指標にしません。
-
-## Issue workflow
-
-Issueは「記事を増やす依頼」ではなく、editorial contractとして扱います。
-
-最低限、
-
-```text
-reader problem
-→ value
-→ proof
-→ differentiation
-→ lifecycle decision / acceptance criteria
-```
-
-を持たせます。
-
-記事化できない場合も、`KEEP_PRIVATE / MERGE / DELETE-ARCHIVE` を正常な完了として扱います。
-
-## Editorial references
-
-- Zenn community guideline update 2026-02-03  
-  https://info.zenn.dev/2026-02-03-community-guidelines-update
-- Zenn guideline  
-  https://zenn.dev/guideline
-- Zenn AI content policy 2026-03-10  
-  https://info.zenn.dev/2026-03-10-ai-contents-guideline
-- Zenn Publication 2026/Q2  
-  https://info.zenn.dev/2026-07-02-publication-quarterly-award-2026q2
-- Zennfes Spring 2026 results  
-  https://info.zenn.dev/2026-07-24-zennfes-spring-2026-result
+- Editorial contract: [`pipeline/contracts/article.md`](pipeline/contracts/article.md)
+- Agent contract: [`AGENTS.md`](AGENTS.md)
+- Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- Current Zenn portfolio audit: [`docs/zenn-portfolio-audit-2026-08-15.md`](docs/zenn-portfolio-audit-2026-08-15.md)
+- Historical audit: [`docs/article-portfolio-audit-2026-08-14.md`](docs/article-portfolio-audit-2026-08-14.md)
 
 ---
 
-**このrepoで最終的に残したいのは、記事数ではありません。**
+**最終成果は記事数ではありません。**
 
-読者が「なぜそうなった？」を追い、公開証拠で確かめ、最後に自分の仕事へ持ち帰れる一つの発見です。
+読者が、誤った成功判定・過剰な一般化・権限の与えすぎ・証拠の読み違いを避け、次の判断を一段良くできる記事だけを残します。

--- a/docs/zenn-portfolio-audit-2026-08-15.md
+++ b/docs/zenn-portfolio-audit-2026-08-15.md
@@ -1,0 +1,234 @@
+# Zenn Portfolio Audit — 2026-08-15
+
+## Purpose
+
+Zennで公開されている記事を「昔書いたものだから残す」のではなく、**現在の読者へどんな判断能力を渡すか**で再評価する。
+
+今回の監査は、次の2集合を突き合わせた。
+
+1. Zenn上で個別公開URLを確認できたlegacy記事 10本
+2. current `KAFKA2306/articles` で `published: true` のZenn同期記事 9本
+
+合計 **19 public records** をportfolio review対象とした。
+
+Zenn profileの集計表示はcache/取得時点で差が出る可能性があるため、本監査ではprofile上の総数ではなく、**個別URLとcurrent repository stateを正準**にした。
+
+## External publication policy
+
+Zenn公式の2026-03-10 AIコンテンツ方針は、AI利用自体ではなく、著者が主体となって正確性を検証し、経験・洞察を含めることを求めている。また、著者の確認が追いつかない速度の投稿や機械生成spamを問題視している。
+
+- https://info.zenn.dev/2026-03-10-ai-contents-guideline
+- https://zenn.dev/guideline
+
+ZennのGitHub連携では、repository側の変更は同期される一方、記事の完全削除はZenn dashboard側の削除も必要と公式手順にある。
+
+- https://zenn.dev/zenn/articles/connect-to-github
+
+したがって本監査では、agentがdashboardを操作できないlegacy記事は `RETIRE_PENDING_ZENN_DASHBOARD` とする。public URLが消えるまで「削除済み」とは扱わない。
+
+## What the portfolio is actually about
+
+強い記事から抽出されるsignatureは、AI、GitHub、Unity、投資、CI/CDそのものではない。
+
+**「ある証拠が、どの判断までを許可するか」を分離する記事**である。
+
+反復している境界:
+
+```text
+implementation != validation
+capability != authority
+runner != policy / oracle
+build != release != production verification
+detection != independent verification
+value != provenance
+agent ability != delegated permission
+artifact exists != visual/runtime completion
+latest knowledge != decision-time evidence
+```
+
+強い記事は、toolを説明するのではなく、次の順で読者の判断を変える。
+
+```text
+失敗 / 異常 / 数字
+  -> もっともらしい誤解
+  -> 一次情報 / public artifact
+  -> 証明できる範囲の境界
+  -> 仮説更新
+  -> decision rule
+```
+
+## Lifecycle rubric
+
+- `KEEP`: 現在のportfolio signatureに強く一致し、証拠・reader job・decision ruleが十分。
+- `REVALIDATE`: 核は残すが、価格・quota・product stateなど短いhalf-lifeを持つ。
+- `REWRITE`: 核は価値があるが、現在の証拠/編集基準に不足。
+- `MERGE`: reader jobが別記事に上位互換されている。
+- `RETIRE_PENDING_ZENN_DASHBOARD`: current portfolioから外す。dashboard削除待ち。
+
+## Current repo-managed public articles — 9
+
+| Article | Public URL | Decision | Why |
+|---|---|---|---|
+| 人は他人を「何を任せられるか」で圧縮する——成果物が仕事の証拠になるまで | https://zenn.dev/kafka2306/articles/2026-08-13-02-how-people-compress-a-person | `KEEP` | skill列挙よりwork sample / verification / reuseで委任可能性を示す。career論ではなく「何を任せられるか」を証拠へ変換するdecision modelになっている。 |
+| Claude Codeにテストを全部任せるなら、先に「合格条件」を固定する | https://zenn.dev/kafka2306/articles/2026-08-15-hook-runner-is-not-policy | `KEEP` | runnerとpolicy/oracleを分離し、agent実行能力と合格条件を別authorityとして扱う。current signatureの中心。 |
+| 個人開発が123個になって分かった。ChatGPTに任せるべきはコードより「次の1件」だった | https://zenn.dev/kafka2306/articles/chatgpt-multiproject-autonomy | `KEEP` | PR数を自慢で終わらせず、state / contract / evidenceを外部化して「次を選ぶ」制御loopへ抽象化している。 |
+| AIの文章に「透かし」があると言われたら、誰がそれを証明できるのか | https://zenn.dev/kafka2306/articles/claude-watermark-secret-key-detection | `KEEP` | vendor未公開仕様を推測せず、embedding / secret / detection / verification interfaceを分離。未確認を正しいstateとして残す。 |
+| GitHub IssueからAIにローカルPCを任せてよいのか？ Unity・Blender・動画生成で考える安全な橋 | https://zenn.dev/kafka2306/articles/codex-chatgpt-github-issue-bridge | `KEEP` | coding-agent紹介ではなくlocal state / binary asset / GPUへ責務が広がるときの権限・証拠・completion boundaryを扱う。 |
+| ChatGPTを使い倒している私に、月10ドルのOpenCode Goが刺さった理由 | https://zenn.dev/kafka2306/articles/opencode-go-deepseek-v4-chatgpt-usage-scale | `REVALIDATE` | 「reasoning/control planeとlocal executionを分ける」という核は再利用可能。ただしprice / request estimate / provider planは短いhalf-lifeを持つため定期再検証が必要。 |
+| 2026年、Unity MCPはどこまで実用か――14件で見えた「作れるが、見た目と挙動を監査し切れない」壁 | https://zenn.dev/kafka2306/articles/unity-mcp-editor-boundary | `KEEP` | 複数の実運用例と自前repoを比較し、CAN_GENERATE != CAN_AUDIT_THE_RESULTを示す。authoringとvisual/gameplay/runtime auditを分離。 |
+| 速く出すために、勝手に出さない。GitHubとShopifyに学ぶRelease Engineering | https://zenn.dev/kafka2306/articles/validate-before-pages-deploy | `KEEP` | GitHub/Google/Shopifyの一次情報と自前追試を接続し、build / validate / release / verifyを分離。一般CI/CD解説よりdecision ruleが強い。 |
+| 第二の脳の次に必要なのは「意思決定のGit」だ——投資判断を後知恵バイアスから守る | https://zenn.dev/kafka2306/articles/why-i-could-buy-the-crash | `KEEP` | 知識保存ではなくdecision-time uncertaintyを固定するという別reader jobを持ち、結果を知った後の物語と当時の判断をdiff可能にする。 |
+
+### Current-public conclusion
+
+現行9本は、8本を`KEEP`、1本を`REVALIDATE`とする。
+
+削除対象を作るために基準を厳しくするのではない。現行群は2026-08の刷新を繰り返した結果、旧群より明確に現在のsignatureへ収束している。
+
+## Legacy public articles — 10
+
+### 1. Crash-Driven Development
+
+- URL: https://zenn.dev/kafka2306/articles/11cd731eebded1
+- Published: 2026-01-30
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD`
+
+価値の核は「失敗を隠さずstack traceを観測可能にする」にある。しかし記事全体は独自doctrineとして強く一般化され、現在の基準で必要なclaim calibration / public experiment / non-goalが弱い。
+
+**Reuse:** fail-loud / observable failureの核だけを、将来の検証可能な記事へ統合する。旧page自体は残さない。
+
+### 2. Astral Toolchain / Modern Python Zero-Fat
+
+- URL: https://zenn.dev/kafka2306/articles/2005501fe91754
+- Published: 2026-02-22
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD`
+
+Ruff/uv等のtoolchain紹介と独自「Zero-Fat」frameworkが中心。現在の基準では、どのfaultをどのauthorityが検出したかというcontrolled evidenceが不足し、tool stack自体が価値になっている。
+
+**Superseded by:** verification-stack系のcontrolled experimentsと、個別authorityを測る現在の方針。
+
+### 3. AAARTS autonomous alpha system
+
+- URL: https://zenn.dev/kafka2306/articles/c599b0556555a7
+- Published: 2026-03-01
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD`
+
+複数概念を束ねた大きなarchitecture提案だが、記事の中心価値に対して実運用・失敗fixture・再現証拠が薄い。現在なら「frameworkを提案した」では公開しない。
+
+**Reuse:** 個別componentが公開実験で反証可能になった場合のみ、別記事として再発見する。
+
+### 4. agent-resources article with biographical/AI policy report body
+
+- URL: https://zenn.dev/kafka2306/articles/9f9997babac335
+- Published: 2026-03-08
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD` — highest priority
+
+タイトルがagent-resourcesのdeveloper hubを約束する一方、本文は別人物の経歴・AI方針等を扱う長いreportへ逸脱しており、**title/body promise mismatch**が大きい。現在のportfolioに残す合理性がない。
+
+### 5. Windows Docker × Gemini CLI × everything-claude-code install commands
+
+- URL: https://zenn.dev/kafka2306/articles/cd6f21d4a26bdd
+- Published: 2026-03-19
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD`
+
+導入command中心で、version / provider / package stateに強く依存する短寿命how-to。固有experimentやportable decision ruleが弱い。
+
+### 6. AI agent directory-management guidelines
+
+- URL: https://zenn.dev/kafka2306/articles/5c21f4d010baeb
+- Published: 2026-03-27
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD`
+
+一般的best practiceと推奨値の組み合わせが中心。どのdirectory failureを何件観測し、どのruleで改善したかというground truthが不足する。
+
+**Reuse:** 実repoでcontext rot / file discovery / residueのfaultを測った記事へ統合可能。
+
+### 7. Zero-trust contract
+
+- URL: https://zenn.dev/kafka2306/articles/77e6af7be1d527
+- Published: 2026-05-13
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD` / `MERGE concept`
+
+「LLMの自己申告を受け入れずartifact / test / proofで完了判定する」という核は現在のsignatureそのもの。一方、旧稿は絶対表現・独自principle命名が強く、現在の `hook-runner-is-not-policy` 等が、より狭く・証拠付きで同じreader jobを上位互換している。
+
+**Superseded by:** https://zenn.dev/kafka2306/articles/2026-08-15-hook-runner-is-not-policy
+
+### 8. Adaptive Survivable Verification System (ASVS)
+
+- URL: https://zenn.dev/kafka2306/articles/5c3c93f798da3f
+- Published: 2026-05-17
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD`
+
+大きな独自verification frameworkを先に提示する構成で、現在の「failure first / boundary first / controlled evidence」方針と逆。frameworkそのものをauthorityにしてしまうリスクがある。
+
+### 9. AI活用してそうな情報サイトのクオリティがすごい
+
+- URL: https://zenn.dev/kafka2306/articles/1436dad81ab3ac
+- Published: 2026-06-11
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD` — highest priority
+
+実体は外部websiteのcategory別link list。固有の観測、比較protocol、検証、decision ruleがなく、現在のarticle contractではcandidate段階で不採用になる。
+
+### 10. GEO / AEO operations guideline
+
+- URL: https://zenn.dev/kafka2306/articles/6dd453d941b99f
+- Published: 2026-06-13
+- Decision: `RETIRE_PENDING_ZENN_DASHBOARD` — highest priority
+
+generic SEO/GEO checklistと多数の数値的推奨が中心。現在の基準では、各数値のprimary evidence / scope / reproductionを確認できない限り公開claimにしない。
+
+## Retirement order
+
+Zenn dashboardで削除する順序:
+
+1. https://zenn.dev/kafka2306/articles/9f9997babac335
+2. https://zenn.dev/kafka2306/articles/1436dad81ab3ac
+3. https://zenn.dev/kafka2306/articles/6dd453d941b99f
+4. https://zenn.dev/kafka2306/articles/2005501fe91754
+5. https://zenn.dev/kafka2306/articles/c599b0556555a7
+6. https://zenn.dev/kafka2306/articles/cd6f21d4a26bdd
+7. https://zenn.dev/kafka2306/articles/5c21f4d010baeb
+8. https://zenn.dev/kafka2306/articles/5c3c93f798da3f
+9. https://zenn.dev/kafka2306/articles/11cd731eebded1
+10. https://zenn.dev/kafka2306/articles/77e6af7be1d527
+
+最初の3本は、title/body mismatch、純link集、unsupported-number-heavy guidelineという理由で、現在のportfolio signalを最も強く薄める。
+
+## Exact human action for legacy deletion
+
+旧10本はcurrent `articles/` に対応sourceが存在しないweb-created legacy postsとして扱うため、available GitHub toolsだけではpublic deletionを完了できない。
+
+Zenn公式手順に従い、人間が各記事についてdashboardで削除を実行する。
+
+```text
+Zenn dashboard
+  -> 記事の管理
+  -> 対象article
+  -> 削除
+```
+
+削除後はpublic URLを再取得し、404/非公開を確認して初めてretirementを完了とする。
+
+**この監査documentを作っただけでは削除完了ではない。**
+
+## New portfolio rule
+
+今後、公開前に次の問いへ全部答える。
+
+```text
+Reader job:
+Observed anomaly:
+Initial hypothesis:
+Strongest public evidence:
+What the evidence proves:
+What it does NOT prove:
+Hypothesis update:
+Decision rule:
+Non-goal:
+Why this deserves a separate article:
+Half-life / revalidation trigger:
+```
+
+公開後も同じ問いで再監査する。
+
+**公開記事を増やすことより、弱い記事を退役させ、1本あたりの信頼密度を上げることを優先する。**

--- a/pipeline/audit.py
+++ b/pipeline/audit.py
@@ -35,6 +35,7 @@ def audit_layout() -> None:
 
     required = [
         core.ROOT / "README.md",
+        core.ROOT / "AGENTS.md",
         core.ROOT / "pipeline" / "config.json",
         core.ROOT / "pipeline" / "cli.py",
         core.ROOT / "pipeline" / "core.py",
@@ -136,18 +137,25 @@ def audit_editorial_contract() -> None:
         core.ROOT / "pipeline" / "contracts" / "article.md"
     ).read_text(encoding="utf-8")
     required_markers = (
-        "ひとつの発見",
-        "冒頭500文字",
-        "100以上",
-        "品質床",
         "initial_hypothesis",
         "hypothesis_update",
+        "reader_job",
+        "observed_anomaly",
+        "proof_of_value",
+        "boundary",
+        "decision_rule",
+        "reader_after",
+        "non_goal",
+        "half_life",
+        "portfolio_overlap",
         "story_overall",
         "interest",
         "discovery",
         "narrative",
         "context",
-        "一文で持ち帰れる結論",
+        "品質床",
+        "explicit human approval",
+        "published:true",
     )
     for marker in required_markers:
         if marker not in contract:
@@ -156,6 +164,33 @@ def audit_editorial_contract() -> None:
     cli = (core.ROOT / "pipeline" / "cli.py").read_text(encoding="utf-8")
     if "install_editorial_pipeline()" not in cli:
         fail("editorial pipeline is not installed by cli.py")
+
+
+def audit_publication_boundary() -> None:
+    selection = (
+        core.ROOT / "pipeline" / "selection.py"
+    ).read_text(encoding="utf-8")
+    workflow = (
+        core.ROOT / ".github" / "workflows" / "article-pipeline.yml"
+    ).read_text(encoding="utf-8")
+    core_source = (
+        core.ROOT / "pipeline" / "core.py"
+    ).read_text(encoding="utf-8")
+
+    if 'os.environ.get("ARTICLE_MANUAL") == "1"' not in selection:
+        fail("draft selection lacks explicit manual authority")
+    if "or is_month_end(core.now_jst())" in selection:
+        fail("calendar month-end still grants draft selection authority")
+    if 'cron: "30 14 28-31 * *"' in workflow:
+        fail("scheduled month-end publication path remains")
+    if "bootstrap_publish=attempt" in workflow:
+        fail("bootstrap publication path remains")
+    if "select-draft" not in workflow:
+        fail("manual unpublished-draft selection mode missing")
+    if "Assert automation never grants publication" not in workflow:
+        fail("workflow lacks publication-state assertion")
+    if '"published: false\\n"' not in core_source:
+        fail("pipeline materialization is not fail-closed at published:false")
 
 
 def audit_privacy() -> None:
@@ -195,6 +230,7 @@ def main() -> int:
     audit_layout()
     audit_config()
     audit_editorial_contract()
+    audit_publication_boundary()
     audit_privacy()
     audit_articles()
     print("AUDIT_PASS")

--- a/pipeline/contracts/article.md
+++ b/pipeline/contracts/article.md
@@ -2,312 +2,374 @@
 
 ## Goal
 
-毎週、公開GitHub活動とprivacy-safeなGraphiti seedから記事候補を育てる。
-月末に全候補を同一条件で再評価し、公開可能な候補のうち
-**最も読み進めたくなる1本だけ**を公開する。
-品質ゲートを通る候補がなければ、その月は0本とする。
-ノルマのための公開はしない。
+公開するのは、**一次情報と公開実装を追った結果、読者の判断を更新する一つの発見が残った記事だけ**とする。
 
-正確さは必要条件であって、十分条件ではない。
-公開記事は、本文単独で状況を理解でき、ひとつの強い問いを追い、
-検証によって予想が更新され、最後にひとつの発見を持ち帰れることを必須とする。
+このrepoは記事数、更新頻度、tool coverage、word countを最適化しない。
 
-さらに、**「役に立つ模範解答」を作ることと「読みたい記事」を作ることを同一視しない。**
-LAPRAS相当の技術品質は品質床として使うが、記事選定の目的関数にはしない。
+正確さは必要条件であって十分条件ではない。良い記事は、読者に新しい知識を渡すだけでなく、
 
-## Popularity benchmark contract
+```text
+何を信じてよいか
+何をまだ信じてはいけないか
+どこまで機械へ任せてよいか
+何を満たしたら次へ進んでよいか
+```
 
-人気記事の構造を学ぶときは、個別記事の実績を確認する。
+を判断できる状態へ変える。
 
-1. **正例コーパスへ入れる個別記事は、確認可能ないいね数100以上を必須とする。**
-2. 100未満の記事は、正例として学習しない。必要なら中立例またはアンチパターン候補として扱う。
-3. いいね数100以上は品質の十分条件ではない。一次情報、実体験、構造上の学びが確認できる記事だけを正例に残す。
-4. Publication平均、著者の知名度、PV推定、SNS反応を個別記事の100+確認の代用にしない。
-5. 正例から抽出するのは `scene_before_concept`、具体的な結果、実測規模、失敗、制約、問いの作り方などの**編集原理**であり、語尾・言い回し・キャラクターなどの文体模倣は禁止する。
-6. 正例コーパスは `pipeline/benchmarks/zenn-positive.json` に証拠URL付きで固定し、確認できない記事を追加しない。
+## Canonical article shape
 
-Zenn公式の2026/Q2 Publication表彰では、1位Publicationの平均いいね数は65だが、代表する個別記事は「300を超えるいいね」と明記されている。したがって、このrepoではPublication平均ではなく**個別記事単位**で正例を選ぶ。
+```text
+1. observed scene / failure / number
+2. natural initial interpretation
+3. current primary evidence + public artifact
+4. falsification / boundary
+5. hypothesis update
+6. portable decision rule
+7. non-goal / unproven area
+```
 
-- https://info.zenn.dev/2026-07-02-publication-quarterly-award-2026q2
-- https://zenn.dev/aircloset/articles/d416342f46f16b
+技術名、framework名、製品名は入口ではなく、この問いを解くために必要な位置で登場させる。
 
-## Editorial evidence
+## Required candidate fields
 
-Zenn公式は、一般的な知識の再掲より、具体的な試行錯誤と書き手固有の視点を重視すると明示している。
-また、AI利用時も人が主体となり、著者自身による正確性の検証、経験、洞察を含めることを求めている。
+執筆前に最低限次を定義する。
 
-- https://info.zenn.dev/2026-02-03-community-guidelines-update
-- https://info.zenn.dev/2026-03-10-ai-contents-guideline
-- https://zenn.dev/guideline
+- `reader_job`: 読者が実際に決めたいこと・進めたいこと。
+- `reader_before`: 読む前の摩擦・損失・不確実性・false confidence。
+- `observed_anomaly`: 実測された異常、失敗、矛盾、数字、反例。
+- `central_question`: 1本で答える問い。
+- `initial_hypothesis`: 調査前にもっともらしかった解釈。
+- `surprising_finding`: 証拠で更新された発見。
+- `hypothesis_update`: 何を見て考えが変わったか。
+- `proof_of_value`: この文章固有の公開証拠・実測・失敗・比較。
+- `boundary`: 証拠が許可する結論と、許可しない結論。
+- `decision_rule`: 別の現場へ持ち帰れる判定規則。
+- `reader_after`: 読後に可能になる具体的な判断・行動。
+- `desired_reader_action`: 読後に自然に試せる次action。
+- `non_goal`: 証明しないこと、未実証範囲。
+- `half_life`: 価格・quota・仕様など再検証が必要な事実。
+- `portfolio_overlap`: 既存記事で代替できない理由。
 
-堀元見氏が公開している「良い問い」に関する記事では、既存の枠を少しだけずらす `gap spotting` より、前提を疑う問いを重視する考え方が紹介されている。このrepoでは文体を模倣せず、**問いが弱い記事は文章力で救済しない**という編集原理だけを利用する。
-
-- https://note.com/kenhori2/n/nc90dfc3f3255
-
-## Technical quality floor
-
-LAPRAS AI Reviewで公開されている5軸を参考に、内部proxyとして0.0〜5.0で評価する。
-
-- `logic`: 論理性
-- `utility`: 実用性
-- `readability`: 読みやすさ
-- `originality`: 独自性
-- `clarity`: 明確性
-
-LAPRAS公式はAI Reviewを「他のエンジニアにとってどれくらい役に立つか」という観点の評価として説明している。
-したがって、これらは**公開に必要な品質床**であり、面白さや人気の代理指標にはしない。
-
-- https://talent-help.lapras.com/ja/articles/8039514-ai%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC%E6%A9%9F%E8%83%BD%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6
-
-この値はLAPRAS上の実測値ではない。
-`overall` は上記5軸の算術平均としてのみ扱う。
-
-## Editorial quality axes
-
-技術品質とは別に、次の4軸を0.0〜5.0で評価する。
-
-- `interest`: 続きを知りたくなる未解決の問い・意外性・具体性があるか
-- `discovery`: 記事全体が、検証可能なひとつの発見へ収束しているか
-- `narrative`: 問い → 仮説 → 観測/実験 → 仮説更新 → 結論の因果が通っているか
-- `context`: 本文だけで固有名詞・数値・技術の意味を追えるか
-
-`story_overall` は上記4軸の算術平均とする。
-技術品質が高くても、この4軸が弱い記事は公開しない。
+既存pipeline互換のため、`design_philosophy` / `why_this_article` / `why_interesting` / `stakes` / `story_type` / `evidence_urls` も保持する。
 
 ## Question gate
 
-文章を書く前に、問いそのものを査読する。
+文章を書く前に、問い自体を査読する。
 
-次のどれかが成立しない候補は執筆へ進めない。
+次の最低1つが必要。
 
-- 読者の自然な予想と、観測結果の間に差がある
-- 既存の前提を一次情報で覆した
-- 実測値に無視できない桁差・変化量がある
-- 実装中に「簡単だと思った場所とは別の場所」が難所になった
-- 一見無関係な2つの事象が、検証可能な因果で接続した
-- 失敗から、一般的な設計判断が更新された
+- 読者の自然な予想と観測結果がずれた。
+- 一次情報によって当初前提を撤回した。
+- 実測値に無視できない桁差・変化量がある。
+- 簡単だと思った場所とは別の場所が本当の難所だった。
+- successに見えた結果が、別のverification layerでは未完だった。
+- 同じ言葉で潰れていた2つ以上のauthority / stateを分離した。
+- failureから一般化可能なdecision ruleが更新された。
 
-次は原則として不採用にする。
+次は原則不採用。
 
-- 既知のベストプラクティスを別の技術へ適用しただけ
-- 技術用語を整理しただけ
-- 公式ドキュメントを要約しただけ
-- 「Aを使ってBを作った」で予想外の観測がない
-- 設定漏れ、URL間違い、生成ミスだけで終わる
-- 読む前から結論が常識的に予想できる
+- 公式docsの要約。
+- setup / install手順だけ。
+- link集。
+- tool比較表だけ。
+- 「Aを使ってBを作った」だけ。
+- repository changelog。
+- generic best practice。
+- secondary-source collage。
+- 実装・測定・反証のない独自framework。
+- magic number / arbitrary thresholdを中心にした記事。
+- 読む前から結論が常識的に予想できる記事。
 
-**弱い問いを、長文・図・引用・丁寧な説明で補強しない。テーマ選定へ戻す。**
+**弱い問いを長文・図・引用・文体で救済しない。topic selectionへ戻す。**
 
-## UX-first / sales-first reader value contract
+## Authority / boundary gate
 
-記事は技術更新ログではなく、**公開証拠から「この仕組み・判断・能力を自分でも使いたい」と合理的に判断できる営業資産**として設計する。
-
-ここでいうsales-firstは、問い合わせ文や契約CTAを増やすことではない。
-読者が本文だけで、
-
-1. 自分のどの摩擦が減るか
-2. 読後に何を判断・実行・運用できるか
-3. なぜその設計判断を採ったのか
-4. 一般tutorialや公式docsではなく、この実測・失敗・比較を読む理由は何か
-5. 実際にどこまで動いており、どこから先は未実証か
-
-を説明できる状態を指す。
-
-候補生成時点で、story fieldsに加えて次の7項目を必須とする。
-
-- `reader_before`: 読む前の具体的な摩擦・損失・不確実性。技術名ではなく利用者の状態を書く。
-- `reader_after`: 読後に可能になる具体的な判断・行動・運用。「Xを理解する」「Yを学ぶ」だけでは不合格。
-- `design_philosophy`: 読者価値を守るため、何を優先し何を捨て、どのtrade-offを受け入れたか。技術stack列挙は禁止。
-- `why_this_article`: 一般tutorial / 公式docs / AI要約では代替できない固有価値。実測、失敗、比較、制約、判断変更の最低1つへ接地する。
-- `proof_of_value`: 実績・実測・運用結果・比較・失敗fixture・production evidenceなど「本当に使える範囲」を示す公開証拠。空欄の候補はpublish不可。
-- `desired_reader_action`: 読後に自然に起こせる次action。試す、監査する、導入候補にする、関連成果物を見る等。本文から導けない問い合わせ・契約を強制しない。
-- `non_goal`: 記事が証明しないこと、未実証範囲、解決しない問題。
-
-### Candidate blocking rules
-
-次は候補段階で不合格にする。
-
-- `reader_after` が「理解できる」「学べる」の抽象表現だけ
-- `why_this_article` が「詳しく説明する」「分かりやすく解説する」の言い換えだけ
-- `proof_of_value` が空、または公開証拠へ接続できない
-- FastAPI / GitHub Actions / MCP / Pyodide / API統合 / repository等の技術名・実装行為を価値そのものとしている
-- reader problemが存在せず、実装変更そのものが記事化理由になっている
-- CTAだけを足してcommercial pullを作ろうとしている
-
-### Article blocking rules
-
-本文査読では、次をblocking issueとして扱う。
-
-- `weak_reader_value`: 本文だけでbefore→afterの状態変化を説明できない
-- `weak_differentiation`: 固有の実測・失敗・比較・制約・判断変更がなく、一般解説で代替できる
-- `missing_proof_of_value`: 価値主張と公開証拠・実績境界が接続していない
-- `forced_commercial_cta`: 本文から自然に導けない営業行動を要求している
-- `technical_value_as_product`: 技術名・実装行為をそのまま読者価値としている
-
-このblocking issueが1つでも残る記事は、technical/story scoreが合格でもpublish不可とする。
-
-### 見出しをテンプレート化しない
-
-`## Vision`、`## Design philosophy`、`## Why`、`## Commercial intent` を公開記事へ強制しない。
-これらは意味構造として必要だが、本文ではscene / 数字 / 失敗 / 仮説更新のstoryへ自然に統合する。
-
-固定見出しを満たしただけのテンプレート記事を増やさない。
-
-### Lifecycle
-
-技術的に正しくてもreader valueを作れない記事は、無理に営業文へ変えない。
-
-- `KEEP`: proofとreader valueが強い
-- `REWRITE`: 核とproofはあるが技術更新ログ寄り
-- `MERGE`: reader jobが他記事と重複する
-- `KEEP_PRIVATE`: 情報価値はあるが公開promotion条件が未達
-- `DELETE / ARCHIVE`: 固有proof・再利用価値が弱く統合先もない
-
-**記事数を増やすことはKPIにしない。弱い2本よりproofが集約された1本を優先する。**
-
-## Broad-entry title contract
-
-タイトルは「技術を知っている人だけが検索して読む見出し」ではなく、**技術名を知らない読者でも問題を認識できる入口**として設計する。
-
-原則の順序は次とする。
+material claimごとに次を確認する。
 
 ```text
-一般語で分かる問題・欲求
-  ↓
-本文で証明できる具体例・異常・失敗
-  ↓
-必要なら正式な技術名・検索語
+この証拠は何を証明する？
+この証拠では何を証明できない？
+この結果を根拠に、読者はどのactionまで進めてよい？
 ```
 
-各候補では、本文を書く前に最低3案を必ず作る。
+記事は、通常ひとつ以上の境界を明示する。
 
-1. `general_problem`: メモ、記録、失敗、権限、数字、見え方など、技術名を知らなくても意味が分かる問題から入る。
-2. `concrete_anomaly`: 本文で検証できる数値、矛盾、失敗、反転、実測結果から入る。
-3. `searchable`: 正式技術名を残すが、前半には一般語の問題または具体例を置く。
+- capability != authority
+- implementation != validation
+- runner != policy / oracle
+- build != release != production verification
+- test pass != user-visible correctness
+- tool success != runtime completion
+- detection != independent verification
+- current value != provenance
+- agent ability != delegated permission
+- generated artifact != visually/runtime accepted artifact
 
-採用タイトルはこの3案のいずれかをそのまま使う。同じ文の言い換えを3案と数えない。
+境界がない記事は、単なる説明記事になっていないか再検討する。
 
-次を原則禁止する。
+## Evidence gate
 
-- repository名、内部クラス名、ファイル名を主語にする
-- API名、ライブラリ名、略語、専門用語だけでタイトルを開始する
-- `Xを使ってYを作った` だけで、読者の問題や意外な結果が見えない
-- 一般化によって本文の実測・証拠範囲を超える
-- クリックさせるためだけに断定を強める
+原則として公開時点のprimary / official sourceを使う。
 
-専門用語を禁止するのではない。**一般語で意味を理解させてから正式名称を与える。**
-たとえば `dry-run`、`entity resolution`、`provenance`、`MCP`、`compileall` は、問題が分かった後のタイトル後半・本文・検索語として使う。
+最低source countは `pipeline/config.json` を正準とする。
 
-公開前査読では、タイトル前半だけを読んで「何が困るのか」「何が意外なのか」を第三者が説明できない場合、`narrow_technical_title_entry` をblocking issueとする。
-ただし入口を広げるために事実を広げてはならない。実測したケースと一般化した設計原則を本文で分離する。
+必須原則:
 
-## Story-first writing contract
+1. material external claimは実HTTP取得で検証する。
+2. vendor仕様はvendor公式、標準はstandards body、製品価格・quotaは現行公式pageを優先する。
+3. KAFKA2306固有の成果はpublic commit / PR / Issue / Actions / artifactで検証する。
+4. historical stateが重要ならmutable branchよりfixed commit/runを使う。
+5. 数字にはtarget / period / unit / scope / comparison basisを付ける。
+6. observation / inference / speculationを分離する。
+7. sourceが取得不能・矛盾・古い場合はclaimを弱めるか削除する。
+8. 未実行をPASS、unknownを0、candidateをproductionへ昇格させない。
+9. 別providerの実装を使って未公開vendor内部を推測しない。
+10. citation countは品質の代理にならない。
 
-1. **主役は技術名ではなく現象にする。** 異常値、矛盾、失敗、意外な接続、反直感的な結果、大きな桁差のいずれかを1つ選ぶ。
-2. **ひとつの記事に、ひとつの発見だけを置く。** 面白い事実が複数ある場合は最も強い1つを選び、残りは削るか別記事へ分ける。
-3. **冒頭はscene / 数字 / 失敗から始める。** 「一般に〜」「Xとは〜」の説明から始めない。
-4. **冒頭500文字で問いを成立させるが、答えを閉じない。** 何が起きたか、自然な予想は何か、何が食い違ったかを示し、読者に一つの未解決状態を残す。
-5. **冒頭で最終結論を言い切らない。** `結論はこれです`、`結論は単純です`、`この記事で伝えたい結論は一つです` のように探索を終了させる導入は原則禁止する。先に結果を示す場合も、その結果が新しい疑問を生む構造にする。
-6. **タイトルは観測事実・反転・数値・問いを売る。** fail-close、Provenance、MCP、IRなどの抽象語は主役ではなく補助語にする。
-7. **具体物を抽象説明より先に置く。** 実データ、ログ、失敗した出力、差分、実測値、画面、再現コードのいずれかを、最初の概念図より前に出す。
-8. **読者が再現できない固有体験を、最低1つは残す。** 自分の失敗、実測、判断変更、運用制約、実装差分など、一般的な要約では代替できない情報を含める。
-9. **最初の仮説を明示する。** その仮説がデータ・実験・実装結果によってどう変わったかを書く。最初から正解を知っていたように書かない。
-10. **技術は謎を解く道具として登場させる。** provenance、CI、RAG、MCPなどの概念そのものを記事の目的にしない。読者が疑問を持った後に必要な分だけ説明する。
-11. **専門用語は必要になった瞬間だけ導入する。** 一文の説明と、その場の具体例を付ける。先回りした用語集は禁止する。
-12. **数字は意味まで説明する。** 対象、期間、単位、比較基準に加え、その数字が何を示し、何を示さないかを書く。
-13. **失敗や制約を隠さない。** 面白さを作るために断定を強めない。事実が弱い場合はテーマ選定へ戻す。
-14. **本文単独で理解を完結させる。** repository名、過去記事、社内事情、略語を知っていることを前提にしない。固有名詞は役割を一文で説明する。
-15. **説明の網羅性より、問いへの寄与を優先する。** 正しい節でも中心の問いを前進させなければ削る。参照マニュアル化しない。
-16. **最後は一文で持ち帰れる結論にする。** 記事全体を一文に圧縮できない場合は、論点が広すぎると判定する。
-17. **一般論を水増ししない。** 検証した事実と実装上の判断がない節は削除する。
-18. **一次情報・再現証拠を残す。** KAFKA2306 GitHub上の一次証拠を最低2件、外部仕様は公式一次情報URLで裏付ける。確認できない主張は削除する。
-19. **誇張タイトルを禁止する。** 驚きはデータから作り、表現から捏造しない。
-20. **近接記事のreader jobを重複させない。** 例として「最初の10分の応急切り分け」と「原因モデルを理解する深掘り」は別記事になり得るが、同じ説明を二重掲載しない。
-21. **reader before→afterをstoryへ埋め込む。** 技術説明を読ませること自体を成果にせず、読後にできる判断・行動・運用まで本文で到達させる。
-22. **design philosophyをtrade-offとして示す。** 「何を採用したか」ではなく、読者価値のため何を優先し何を捨てたかを書く。
-23. **proofを価値主張の直後へ置く。** 「安全」「使える」「自動化できる」と書くなら、その範囲を実測・実装・運用証拠で示す。未実証は明示する。
-24. **commercial pullを広告CTAで作らない。** 読者がその場で試せるchecklist、template、最小手順、decision table等へ変換する。
+## Reader value gate
 
-## Opening anti-patterns
+`reader_after` は次のようなactionable stateを要求する。
 
-次の導入は、技術的に正しくても `interest` を高く採点しない。
+- 採否を決められる
+- 止める条件を決められる
+- 委任範囲を決められる
+- 何を追加検証すべきか決められる
+- failure stateを分類できる
+- 変更前後を説明できる
+- 同じmistakeを別domainで避けられる
 
-- 一般論 → 定義 → 箇条書き → 結論
-- 背景説明だけで最初の具体物が500文字以上後に出る
-- 冒頭で記事全体の答えを完全に要約する
-- repository / PR / URLを大量に並べてから物語が始まる
-- 「この記事では〜を整理します」で始まり、その後も事件が起きない
-- タイトルから想像した内容をそのまま順当に説明するだけ
+`理解できる` / `学べる` だけでは不合格。
 
-## Topic selection contract
+`why_this_article` は一般tutorial / docs / AI要約で代替できない、実測・失敗・比較・反証・判断変更の最低1つへ接地する。
 
-候補は「技術的に価値がある」だけでは選ばない。各候補に次の項目を必須とする。
+`proof_of_value` が空ならpublish不可。
 
-- `title_options`: `general_problem` / `concrete_anomaly` / `searchable` の3案
-- `title`: `title_options` から採用した1案
-- `central_question`: 読者が続きを読みたくなる一文の問い
-- `surprising_finding`: 一文で言える検証済みまたは検証可能な発見
-- `initial_hypothesis`: 調査前に自然だった予想
-- `hypothesis_update`: 何を見て予想が変わるのか
-- `stakes`: その差がなぜ重要なのか
-- `story_type`: anomaly / contradiction / failure / unexpected-connection / counterintuitive-result / magnitude のいずれか
-- `evidence_urls`: 発見を検証できる公開URL
-- `why_interesting`: 一般論ではなく、この題材固有の面白さ
-- `reader_before`: 読む前の具体的な摩擦・損失・不確実性
-- `reader_after`: 読後に可能になる具体的な判断・行動・運用
-- `design_philosophy`: 読者価値を守る優先順位・trade-off
-- `why_this_article`: 一般解説では代替できない固有の実測・失敗・比較・制約・判断変更
-- `proof_of_value`: 公開証拠で確認できる実績・実測・運用結果
-- `desired_reader_action`: 本文から自然に導ける次action
-- `non_goal`: 記事が証明しないこと・解決しない範囲
+## Portability and durability
 
-上記を埋められない候補は、記事化せずテーマ探索へ戻す。
-単なる生成ミス、ラベル誤り、URL間違い、設定漏れだけで終わる題材は、そこから一般化できる意外な発見がない限り主題にしない。
+一回の特殊事例を記事化する場合、少なくとも一つのportable abstractionを抽出する。
 
-`why_interesting` が「役に立つ」「安全になる」「理解できる」の言い換えだけなら不合格とする。
-`why_this_article` が「詳しく説明する」「分かりやすく解説する」の言い換えだけでも不合格とする。
-読者が既に知っている前提を、何がどう裏切るのかまで書けなければ不合格とする。
+良い抽象化:
 
-## Candidate maturation
+```text
+GitHub Pagesが無効だった
+  -> deploy availabilityとartifact validityを分ける
 
-候補生成時点で一次情報ゲート、技術品質proxy、編集品質査読、reader value contractを実行する。
-目標に届かない候補は `revision_limit` の範囲で自動改稿する。
-改稿では文章を足すより、主役でない節を切り、問い・reader value・proofの距離を短くする。
-改稿で悪化した場合は、評価済み版のうち最良の版を保持する。
-
-**問い・reader value・proofが弱いという査読結果は、営業文や長文化で救済しない。候補選定へ戻す。**
-
-## Month-end selection
-
-月末は、その月に蓄積した全候補から `pipeline_meta` を除いた公開本文だけを対象にする。
-
-1. 全候補を一次情報ゲートで再検証する。
-2. 全候補を3回独立査読し、各軸の中央値を採用する。
-3. 技術品質ゲート、編集品質ゲート、reader value blocking gateをすべて満たす候補だけを公開可能集合にする。
-4. 正例コーパスの編集原理と比較し、scene、具体性、著者固有の観測、未解決の問いがない候補を落とす。
-5. タイトルが `narrow_technical_title_entry` なら公開可能集合から落とす。
-6. `weak_reader_value` / `weak_differentiation` / `missing_proof_of_value` / `forced_commercial_cta` / `technical_value_as_product` が1つでも残る候補を落とす。
-7. `story_overall` → `interest` → `discovery` → `overall` → 最低技術軸 → 証拠数の順で比較する。
-8. 最高順位の1本だけを公開する。
-9. 公開可能集合が空なら0本で終了する。
-10. 同月に1本公開済みなら追加公開しない。
-
-## Evaluation JSON
-
-```json
-{
-  "logic": 0.0,
-  "utility": 0.0,
-  "readability": 0.0,
-  "originality": 0.0,
-  "clarity": 0.0,
-  "overall": 0.0,
-  "interest": 0.0,
-  "discovery": 0.0,
-  "narrative": 0.0,
-  "context": 0.0,
-  "story_overall": 0.0,
-  "blocking_issues": [],
-  "revision_actions": []
-}
+Unity MCPがsuccessを返した
+  -> authoring successとvisual/runtime auditを分ける
 ```
+
+悪い抽象化:
+
+```text
+このrepositoryではこのfileをこのように直した
+```
+
+さらに`half_life`を持たせる。
+
+- price / quota / provider lineup: short
+- current product behavior / API: medium, version-sensitive
+- immutable experiment at fixed commit: long
+- stable principle supported by multiple primary sources: long
+
+volatile factが記事の価値の中心なら `REVALIDATE` を前提にする。
+
+## Portfolio novelty / overlap
+
+公開前に既存記事を比較する。
+
+次の場合は新規公開より `MERGE` を優先する。
+
+- 同じreader jobを扱う。
+- 同じdecision ruleへ収束する。
+- 新記事のproofが既存記事の補強にすぎない。
+- 新しいtool名だけが違う。
+
+**記事数を増やすことは価値ではない。proofを集約してsignalを強くする。**
+
+## Title contract
+
+タイトルは技術名より、読者が認識できるproblem / anomalyから始める。
+
+候補は最低3案作る。
+
+1. `general_problem`
+2. `concrete_anomaly`
+3. `searchable`
+
+選択titleはこの候補内から選ぶ。
+
+原則:
+
+```text
+plain-language problem
+  -> concrete proofable anomaly
+  -> technical search term only when useful
+```
+
+`MCP`, `Pyrefly`, `Pydantic`, `Zod`, `GitHub Actions` 等を知らないと意味が分からないtitleは、技術名を知らない読者が問題を認識できる入口へ戻す。
+
+本文で証明できない数字・強い断定をtitleへ置かない。
+
+## Story contract
+
+本文は説明順ではなく発見順を優先する。
+
+```text
+scene
+  -> unresolved question
+  -> initial hypothesis
+  -> evidence / experiment
+  -> failure or contradiction
+  -> updated model
+  -> decision rule
+```
+
+記事冒頭で結論を全部説明して発見を消さない。ただし、意図的に情報を隠してsuspenseを作らない。
+
+中心の問いを前進させない節は削る。
+
+## Technical quality floor
+
+LAPRAS AI Reviewで公開されている5軸を参考にした**内部proxy**を使用する。LAPRAS上の実測値ではない。
+
+- `logic`
+- `utility`
+- `readability`
+- `originality`
+- `clarity`
+
+`overall` は5軸の算術平均。
+
+現行minimum/targetは `pipeline/config.json` を正準とする。
+
+このscoreは品質床であり、公開価値の目的関数ではない。
+
+## Editorial quality floor
+
+既存pipeline互換の4軸を維持する。
+
+- `interest`
+- `discovery`
+- `narrative`
+- `context`
+
+`story_overall` は4軸の算術平均。
+
+さらにblocking reviewでは最低限次を確認する。
+
+- `weak_reader_value`
+- `weak_differentiation`
+- `missing_proof_of_value`
+- `forced_commercial_cta`
+- `technical_value_as_product`
+- `premature_conclusion_in_opening`
+- `narrow_technical_title_entry`
+- `uncalibrated_claim`
+- `missing_decision_rule`
+- `portfolio_redundancy`
+
+既存実装がまだ新blocking codeを機械判定しない場合も、人間/agent auditではblockingとして扱う。
+
+## Images
+
+画像はsupporting evidence / explanationでありquotaではない。
+
+追加するのは、次のどれかを満たす場合だけ。
+
+- causal / state flowを短くする
+- measured comparisonを理解しやすくする
+- boundaryを可視化する
+- actual artifactを示す
+
+生成画像に存在しないCI結果、数字、URL、screenshot-like evidenceを描かせない。
+
+articleは画像なしでも成立させる。
+
+## Publication boundary
+
+Zenn公式方針:
+
+- https://info.zenn.dev/2026-03-10-ai-contents-guideline
+- https://zenn.dev/guideline
+
+このrepoではautomationとpublicationを分離する。
+
+```text
+schedule
+  -> candidate discovery / drafting / review only
+
+manual pipeline selection
+  -> selected candidateをarticles/へ published:false でmaterialize
+
+explicit human approval
+  -> published:true
+```
+
+schedule、月末、score、CI green、mergeはpublication authorizationではない。
+
+内部function/CLI名が`publish`でも、`published:false`を作るだけならpublic publicationとは呼ばない。
+
+## Lifecycle after publication
+
+公開後も次のstateを持つ。
+
+- `KEEP`
+- `REVALIDATE`
+- `REWRITE`
+- `MERGE`
+- `RETIRE`
+
+`RETIRE` 判定:
+
+- central claimが現在検証できない
+- evidenceより強い結論を誘発する
+- title/body promise mismatch
+- newer articleにreader jobを完全に上位互換された
+- generic summary / link list / setup guideでunique proofがない
+- unsupported magic numberが主張の中核
+- maintenance costがdurable valueを上回る
+- portfolio signatureを薄める
+
+Zenn上の削除はZenn公式GitHub連携手順に従い、repo-managed articleではdashboardとrepoの両方を扱う。
+
+- https://zenn.dev/zenn/articles/connect-to-github
+
+agentがdashboard操作できない場合は、public deletionを完了したと報告してはいけない。
+
+## Publication portfolio review cadence
+
+候補生成とは別に、公開記事を定期的に再監査する。
+
+最低確認項目:
+
+1. public URLが存在する。
+2. titleとbodyの約束が一致する。
+3. material sourceが現在もclaimを支持する。
+4. volatile factsを再検証した。
+5. newer articleとのoverlapを確認した。
+6. decision ruleが今も再利用可能。
+7. overclaim / hindsight rewriteがない。
+8. lifecycle stateを更新した。
+
+公開記事数を増やすより、弱い記事をretireしてportfolio signalを強くすることを優先する。
+
+## Final publication test
+
+公開を承認する前に、次を一文ずつ答えられること。
+
+```text
+Reader job:
+Observed anomaly:
+Initial hypothesis:
+Strongest public evidence:
+What that evidence proves:
+What it does NOT prove:
+Hypothesis update:
+Decision rule:
+Non-goal:
+Why this deserves a separate article:
+Half-life / revalidation trigger:
+```
+
+一つでも曖昧なら `published:false` を維持する。

--- a/pipeline/selection.py
+++ b/pipeline/selection.py
@@ -107,14 +107,13 @@ def generate_public_candidate() -> Path:
 
 
 def is_month_end(moment: datetime) -> bool:
+    """Calendar helper retained for historical reports/tests, not publication authority."""
     return (moment + timedelta(days=1)).month != moment.month
 
 
 def scheduled_publish_allowed() -> bool:
-    return (
-        os.environ.get("ARTICLE_MANUAL") == "1"
-        or is_month_end(core.now_jst())
-    )
+    """Only an explicit human-triggered pipeline run may select a Zenn draft."""
+    return os.environ.get("ARTICLE_MANUAL") == "1"
 
 
 def evaluate_monthly_candidates(paths: list[Path]) -> list[dict[str, object]]:
@@ -227,7 +226,7 @@ JSONのみ返してください。
 
 
 def finalize_publication_filename(old_path: Path, article: str) -> Path:
-    """Rename only the newly generated artifact; existing publications are untouched."""
+    """Rename only the newly generated unpublished draft; existing publications are untouched."""
     policy = core.CONFIG["filename_policy"]
     moment = core.now_jst()
     file_title = publication_file_title(article)
@@ -259,9 +258,15 @@ def finalize_publication_filename(old_path: Path, article: str) -> Path:
 
 
 def publish_best() -> Path | None:
+    """Select the strongest current candidate into articles/ as published:false.
+
+    Despite the historical function name, this function is not authorized to
+    publish publicly on Zenn. Explicit ARTICLE_MANUAL=1 is required even for
+    draft selection/materialization.
+    """
     if not scheduled_publish_allowed():
         print(
-            "publish=skipped reason=not_month_end "
+            "publish=skipped reason=explicit_human_selection_required "
             f"date={core.now_jst():%Y-%m-%d}"
         )
         return None
@@ -305,7 +310,7 @@ def publish_best() -> Path | None:
     save_monthly_selection_report(
         evaluated,
         selected=selected,
-        status="selected",
+        status="selected_unpublished_draft",
     )
     old_path = core.publish(
         str(selected["article"]),

--- a/tests/test_publication_boundary.py
+++ b/tests/test_publication_boundary.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from pipeline import core, selection
+
+
+class PublicationBoundaryTests(unittest.TestCase):
+    def test_draft_selection_requires_explicit_manual_authority(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(selection.scheduled_publish_allowed())
+        with patch.dict(os.environ, {"ARTICLE_MANUAL": "0"}, clear=True):
+            self.assertFalse(selection.scheduled_publish_allowed())
+        with patch.dict(os.environ, {"ARTICLE_MANUAL": "1"}, clear=True):
+            self.assertTrue(selection.scheduled_publish_allowed())
+
+    def test_calendar_month_end_is_not_publication_authority(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(selection.scheduled_publish_allowed())
+
+    def test_core_materializes_only_unpublished_articles(self) -> None:
+        source = (core.ROOT / "pipeline" / "core.py").read_text(encoding="utf-8")
+        self.assertIn('"published: false\\n"', source)
+
+    def test_workflow_has_no_scheduled_publication_path(self) -> None:
+        workflow = (
+            core.ROOT / ".github" / "workflows" / "article-pipeline.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn('cron: "0 0 * * 1"', workflow)
+        self.assertNotIn('cron: "30 14 28-31 * *"', workflow)
+        self.assertIn("select-draft", workflow)
+        self.assertIn("Assert automation never grants publication", workflow)
+        self.assertNotIn("bootstrap_publish=attempt", workflow)
+
+    def test_contract_makes_human_publication_explicit(self) -> None:
+        contract = (
+            core.ROOT / "pipeline" / "contracts" / "article.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("explicit human approval", contract)
+        self.assertIn("published:true", contract)
+        self.assertIn("decision rule", contract.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Contract
Zenn公開記事を読み直し、現在の強い記事の共通項を `authority / verification / decision boundary` として抽象化する。README / AGENTS / canonical article contract / automationを同じ基準へ揃え、弱いlegacy記事をretirement対象として明示する。

## Outcome
- READMEを「何を信じ・任せ・進めてよいかを判断できる記事」中心へ刷新
- AGENTSにclaim calibration、portfolio lifecycle、Zenn retirement、human-controlled publicationを追加
- article contractをfailure/anomaly → evidence → boundary → decision ruleへ再設計
- scheduled pipelineからmonth-end publish pathとbootstrap publishを削除
- `selection.scheduled_publish_allowed()` を `ARTICLE_MANUAL=1` のみへfail-close
- automationが新規 `published: true` を作れないassertionを追加
- 2026-08-15時点のZenn public portfolio 19 recordsを監査し、current 9本は8 KEEP + 1 REVALIDATE、legacy 10本はRETIRE_PENDING_ZENN_DASHBOARDへ分類
- publication boundary regression testsを追加

## Evidence boundary
Zenn dashboard削除はこのGitHub connectorから実行できないため、legacy 10本はpublic deletion未完了。exact URLと削除優先順をaudit documentへ固定し、public URLが消えるまでは「削除済み」と報告しない。

## Acceptance criteria
- exact-head CI passes
- `python -m unittest discover -s tests -v` / `python -m pipeline.audit` がworkflow上でpass
- scheduled workflowがcandidate以外を選べない
- pipeline-generated articleは `published: false`
- no unrelated article publication state changes
