### PR TITLE
直近記事をAGENTS.mdの読者価値契約で全面刷新

### DIFF
--- a/articles/2026-08-15-affected-set-is-a-contract.md
+++ b/articles/2026-08-15-affected-set-is-a-contract.md
@@ -1,137 +1,130 @@
 ---
-title: "速いCIより、正しいaffected setを先に測る"
+title: "CIを速くしたのに、必要なテストまで消えていないか"
 emoji: "🧭"
 type: "tech"
 topics: ["monorepo", "ci", "nx", "turborepo", "testing"]
 published: false
 ---
 
-モノレポのCI改善では、最初に「何秒短くなったか」を見たくなる。しかし、affected executionで先に決めるべきなのは速度ではない。**変更したprojectから、実行対象に含めるべきproject集合を正しく導けるか**である。
+CI短縮で最初に見るべきなのは秒数ではない。
 
-この順序を逆にすると、速いCIが単に必要な検証を飛ばしているだけでも成功に見える。
+**変更したとき、本当に実行すべきprojectを落としていないか**である。
 
-## 先にground truthを固定した
+affected executionは強力だが、対象集合を間違えると「速くなった」のではなく「必要な検証を飛ばした」だけでもgreenになる。
 
-今回のfixtureは4つの依存projectと、独立したdocs projectからなる。比較前に、変更点ごとの期待affected setを固定した。
+今回、toolを選ぶ前にrepository側の期待affected setを固定した。
 
 - `core`変更 → `core`, `ui`, `web`, `api`
 - `ui`変更 → `ui`, `web`
 - `docs`変更 → `docs`
 
-これはbenchmark結果から作った期待値ではない。fixtureの依存関係から事前に定義したground truthである。1 mutant = 1 root fault、raw diagnostics != defect count、correctness before speedという既存protocolも維持した。
+この3ケースをground truthとして、orchestratorの出力を照合した。
 
-再現用fixtureとraw evidenceは `benchmarks/verification-stack-v2/` に固定している。
+## 速さより先に集合を固定する理由
 
-- protocol: https://github.com/KAFKA2306/articles/blob/f7368d064d1840a5f66d92563d16deaabb5b3285/benchmarks/verification-stack-v2/PROTOCOL.md
-- ground truth: https://github.com/KAFKA2306/articles/blob/f7368d064d1840a5f66d92563d16deaabb5b3285/benchmarks/verification-stack-v2/workspace/ground-truth.json
-- raw workspace result: https://github.com/KAFKA2306/articles/blob/f7368d064d1840a5f66d92563d16deaabb5b3285/benchmarks/verification-stack-v2/results/controlled/workspace.json
+CI時間は観測しやすい。一方、false negativeは見えにくい。
 
-## 同じ「affected」でも、観測対象は同じとは限らない
+```text
+変更
+  ↓
+affected判定を誤る
+  ↓
+必要なtest/buildを実行しない
+  ↓
+CIは速くgreenになる
+```
 
-controlled runでは、Nxの `nx show projects --affected` は3変更すべてで事前ground truthと一致した。
+最悪なのは、性能改善として成功に見えることだ。
+
+だから先に次のcontractを作る。
+
+```text
+f(change) -> expected projects
+```
+
+代表caseが3件でも、速度benchmarkより先に「落としてはいけない対象」を検証できる。
+
+## 今回の観測
+
+Nxの`nx show projects --affected`は、固定した3 caseでproject-level ground truthと一致した。
 
 | change | expected | Nx observed |
-| --- | --- | --- |
+|---|---|---|
 | core | core, ui, web, api | core, ui, web, api |
 | ui | ui, web | ui, web |
 | docs | docs | docs |
 
-一方、Turborepoの `turbo run build --affected --dry=json` は `core` 変更では期待した4 build packageを含んだが、`ui` 変更では `core, ui, web` を返し、事前ground truth `ui, web` より `core` が1つ多かった。
+raw evidence:
+https://github.com/KAFKA2306/articles/blob/f7368d064d1840a5f66d92563d16deaabb5b3285/benchmarks/verification-stack-v2/results/controlled/workspace.json
 
-ここで「Nxの方が優秀」と結論してはいけない。両コマンドは同じauthority surfaceではないからだ。
-
-Nx公式はaffected計算について、Gitで変更fileを特定し、project graphで所属projectと依存projectを導く、と説明している。
+Nx公式はaffected計算を、Gitで変更fileを特定し、project graphから影響projectを求める仕組みとして説明している。
 
 https://nx.dev/docs/features/ci-features/affected
 
-Nxはproject graphとtask graphを別概念として公開している。`nx show projects --affected` はproject集合を観測するsurfaceである。
-
-https://nx.dev/docs/features/explore-graph
-
-対して今回のTurborepo観測は `run build --affected --dry=json` の**task plan**である。つまり「affected project集合そのもの」と「その変更から実際にbuildするtask集合」を、名前が似ているからといって同じmetricにしてはいけない。
-
-TurborepoのCI documentation:
+一方、今回Turborepoで観測した`turbo run build --affected --dry=json`はbuild task planだった。project集合そのものとtask planを同じaccuracy metricへ押し込むと比較を壊す。
 
 https://turborepo.com/docs/crafting-your-repository/constructing-ci
 
-## 速度比較をheadlineにしなかった理由
+## ここで製品ランキングをしない
 
-同じcontrolled artifactにはelapsed timeも残っている。たとえば `core` 変更の単発観測ではNx commandは約518 ms、Turborepo dry-runは約63 msだった。
+同じartifactにはelapsed timeも残っている。しかし「NxよりTurborepoが何倍速い」のようなheadlineには使わなかった。
 
-しかし、この数字を「TurborepoはNxより8倍速い」とは書けない。
+理由は簡単だ。
 
-理由は3つある。
+- 観測したcommandの責務が違う
+- paired timingではない
+- 正しさを満たしていない候補の速さは意味がない
 
-1. 実行したcommandの責務が違う。
-2. これは同一runnerでのpaired timingではない。
-3. project-set correctnessとtask-plan生成時間を混ぜると、速さがauthorityの正しさを上書きする。
+速度は、**同じ責務を正しく満たしたsurvivor同士**で初めて比較する。
 
-この実験protocolではcorrectnessが速度より先である。速度は、同じ責務を満たしたsurvivor同士で初めて意思決定材料になる。
+## 壊れた導入順序
 
-## 3つの物語を同じ証拠で反証した
+```text
+1. fastest toolを選ぶ
+2. affectedを有効化
+3. CIが短くなったので成功
+```
 
-### 1. 「NxはTurborepoより正確だ」
+この順序では、何を落としてはいけないかが未定義である。
 
-棄却する。
+## 改善した導入順序
 
-今回、Nxではproject affected setを、Turborepoではbuild task planを観測した。異なるauthority surfaceの出力差を製品accuracyへ一般化できない。
+```text
+1. dependency graphから代表変更caseを選ぶ
+2. expected affected setをrepoに固定する
+3. candidate toolの出力を照合する
+4. false negativeがない候補だけ残す
+5. その後に速度・cache・運用costを測る
+```
 
-### 2. 「Turborepoの方が速いからCIにはTurborepoを選ぶ」
+## 読者が最初に区別する5つ
 
-棄却する。
+monorepo高速化では、次を同じものとして扱わない。
 
-単発かつ異なるcommandのelapsed timeであり、same-runner paired timing条件を満たさない。さらに速度はground-truth correctnessの代替にならない。
+- changed files
+- affected projects
+- affected tasks
+- task cache
+- architecture boundaries
 
-### 3. 「affected setを先に契約として固定し、orchestratorの出力をその契約に照合する」
+必要なのがbuild/test taskの絞り込みだけなら、project-level architecture authorityまで追加する必要はない。逆にimpact analysisを人間の判断にも使うなら、project集合を直接観測できるsurfaceが重要になる。
 
-これだけが残る。
+## 最小の再現方法
 
-モノレポtoolを選ぶ前に、repository側が「この変更なら何が影響を受けるべきか」を少数の代表caseで宣言できる。toolはその契約を満たす実装候補であり、tool名そのものがground truthではない。
+自分のrepoで3ケース作ればよい。
 
-## NxとTurborepoのauthorityを分ける
+1. shared/core packageを変更する
+2. leafに近いpackageを変更する
+3. 独立package/docsを変更する
 
-Nx公式はproject graphをworkspace projectと依存関係のgraphとして扱い、affected commandはGit historyとproject graphから影響projectを求める。
+各ケースで「絶対に含む」「絶対に含まない」projectを先に書く。その後でNx、Turborepo、独自scriptなど候補の出力を照合する。
 
-https://nx.dev/docs/features/ci-features/affected
+## 証拠の境界
 
-そのため、**project/affected graphそのものを意思決定に使いたい**場合、Nxには明示的なauthority surfaceがある。
+今回のfixtureだけからNxが一般にTurborepoより正確とも、Turborepoが一般に速いとも言えない。real repositoryで同じ差が再現することも証明していない。
 
-一方、Turborepoを採用する理由は「Nxより軽いから」ではなく、既存JS/TS workspaceで必要なのがtask graph、cache、affected task executionである場合に置くべきだ。project-level architectural boundaryまで必要なら、それは別のcapabilityとして検証する。
+ただし、CI高速化の評価順序は変えられる。
 
-この分離は「全部入りtoolを選べ」という話ではない。逆である。**足りないauthorityだけを追加する**ための分離だ。
+**秒数を測る前に、実行対象集合をrepositoryのcontractとして固定する。**
 
-## 読者が先に決めるべきもの
-
-新しいorchestratorを導入する前に、最低でも次を区別する。
-
-- changed filesを知りたいのか
-- affected projectsを知りたいのか
-- 実行すべきtasksを知りたいのか
-- task結果をcacheしたいのか
-- architecture boundaryを強制したいのか
-
-これらは同じ「monorepo高速化」ではない。
-
-特にCI削減では、`f(change) -> expected projects` を数caseだけでもfixture化すると、速度benchmarkより先にfalse negativeと不要なover-runを検出できる。
-
-## 今回、証明していないこと
-
-このfixtureだけから次は言えない。
-
-- Nxが一般にTurborepoより正確である
-- Turborepoが一般にNxより速い
-- どちらか一方がすべてのmonorepoに適する
-- real repositoryで同じaffected差が再現する
-- task cache hit率やremote cache性能の優劣
-
-real repository観測はexternal validityであり、controlled ground truthの代わりにはしない。
-
-## 何が起きれば判断を反転するか
-
-Turborepo側で、今回と同じ**project affected set**を直接かつ同じ意味論で取得する公式surfaceを固定し、それが3 caseすべてでground truthと一致するなら、「project affected authorityのためにNxが必要」という判断は弱くなる。
-
-逆に、必要なのがbuild/test taskの選択とcacheだけで、project-level impactやarchitecture boundaryを意思決定に使わないrepositoryなら、Nxを追加する理由も弱い。
-
-重要なのはブランドではない。
-
-**CIを速くする前に、「何を実行すべきか」をrepository自身の契約として固定する。orchestratorはその契約に従う側である。**
+CIが速くなったとき、「必要なものを落とさず速くなった」と言えるようにするためだ。

--- a/articles/2026-08-15-hook-runner-is-not-policy.md
+++ b/articles/2026-08-15-hook-runner-is-not-policy.md
@@ -1,5 +1,5 @@
 ---
-title: "Claude Codeにテストを全部任せるなら、先に「合格条件」を固定する"
+title: "Claude Codeにテストを任せるなら、合格条件だけは別に固定する"
 emoji: "🧪"
 type: "tech"
 topics: ["claudecode", "testing", "ai", "ci", "automation"]
@@ -7,334 +7,117 @@ published: true
 published_at: 2026-08-15 09:33
 ---
 
-「実装して。テストも書いて。失敗したら直して。全部通ったらPRまで作って」
+AIに実装もテストも修正も任せられるようになると、最後に残る人間の仕事は「全部を見ること」ではない。
 
-Claude Codeを使っていると、ここまでまとめて任せられる。
+**何を満たせば合格なのかを、実装するagentの外側に固定すること**だ。
 
-Anthropicの現在の公式ドキュメントでも、Claude Codeはコードベースを読み、ファイルを編集し、commandやtestを実行して検証するagentic coding toolとして説明されている。公式のoverviewには、未テストコードへのtest作成、lint errorの修正、さらに「testを書き、実行し、失敗を直す」という利用例まである。
+Claude Codeの公式ドキュメントは、コードを読み、編集し、commandやtestを実行して検証できるagentic coding toolとして説明している。また、Claudeが自分の仕事を検証できるよう、test caseや期待出力のような「照合対象」を与えることを勧めている。
 
-- [Claude Code overview | Claude Code Docs](https://code.claude.com/docs/en/overview)
-- [How Claude Code works | Claude Code Docs](https://code.claude.com/docs/en/how-claude-code-works)
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/how-claude-code-works
 
-では、テスト作成も実行も失敗修正も再実行もClaude Codeに任せられるようになったとき、人間側には何が残るのか。
+ここで実務上の落とし穴がある。同じagentがproduction code、test、fixture、configのすべてを変更できると、greenは「実装を直した」だけでなく「合格条件を弱めた」ことでも作れてしまう。
 
-この記事の答えは1つだ。
+## 問題はAIではなく、oracleまで同じ変更scopeに入ること
 
-> **「何を満たせば合格なのか」を、実行するagentとは別に固定する。**
-
-Claude Codeにテストを任せることが問題なのではない。
-
-むしろ、反復的な実行と修正はagentに積極的に委譲できる。
-
-問題になるのは、**実装する主体・テストを選ぶ主体・合格を宣言する主体が全部同じになったとき、何を根拠に「終わった」と判断するのかが曖昧なままになること**だ。
-
-## 「テストが全部通った」は、何を証明したのか
-
-緑色のtest resultは重要だ。
-
-ただし、それが直接意味するのは、**実行されたテストが、その時点で定義されていた条件を満たした**ということまでである。
-
-たとえば、Claude Codeに次のように頼める。
+たとえば次の依頼は便利だ。
 
 ```text
 この機能を実装して。
-必要なテストを追加して。
-失敗したテストを直して。
-全部通るまで続けて。
+必要なテストも追加して。
+失敗したら直して。
+全部通ったら終わり。
 ```
 
-ここでClaude Codeは、実装、テスト作成、test commandの実行、失敗解析、再修正を1つのloopにまとめられる。
+しかし、この依頼には4つの別問題が混ざっている。
 
-便利である。
+1. 何を作るか
+2. 何を合格とするか
+3. どう直すか
+4. 何を証拠として残すか
 
-ただし、このloopの外側に次の問いが残る。
+3をagentへ強く委譲しても、2までその場の最適化対象にすると完了判定が弱くなる。
+
+## 実務では4層に分ける
 
 ```text
-そもそも何を守るべきか？
-どのテストを必須にするか？
-何を壊してはいけないか？
-どの条件を満たしたらmergeしてよいか？
+Outcome / Contract
+  何を実現し、何を壊してはいけないか
+        ↓
+Policy / Oracle
+  tests / schema / invariants / required checks
+        ↓
+Execution
+  Claude Code / hooks / CI / runner
+        ↓
+Evidence
+  test result / diff / artifact / exact-head CI
 ```
 
-さらに、同じagentがproduction codeだけでなくtest、fixture、configまで自由に変更できるなら、greenは実装修正だけでなく**合格条件側を変えることでも作れてしまう**。
+Claude CodeはExecutionを強くする。だがExecutionが強いこととPolicyが正しいことは別だ。
 
-これはClaude Codeが悪いという話ではない。最適化する主体と、最適化対象を判定するoracleが同じ変更scopeに入っているという設計上の問題だ。
+Claude Code Hooksも、LLMが実行を選ぶことに依存しないdeterministic controlとして公式に説明されている。`TaskCompleted` hookでtest suiteを走らせ、失敗時に完了扱いを止める例もある。
 
-Anthropic自身もClaude Codeの公式ガイドで、Claudeが自分の仕事を検証できるように、test case、期待する出力、screenshotなど「検証対象」を与えることを推奨している。
+- https://code.claude.com/docs/en/hooks-guide
+- https://code.claude.com/docs/en/hooks
 
-- [How Claude Code works: Give Claude something to verify against](https://code.claude.com/docs/en/how-claude-code-works)
+## 何をrepo側へ固定するか
 
-そこで、実行と合格条件を分ける。
+最低限、次はagentのその場の判断から独立させる。
 
-## Claude Code時代の4層
+- 必須test suite
+- acceptance criteria
+- schema / invariant
+- 変更してはいけないartifact
+- testを弱める変更のreview条件
+- mergeをblockする条件
 
-自動化を次の4層に分けると整理しやすい。
+そして可能なら1 commandにまとめる。
 
-```text
-1. Outcome / Contract（目的・契約）
-   何を実現し、何を壊してはいけないか
-
-            ↓
-
-2. Policy / Oracle（合格条件）
-   tests / type checks / schema / invariants / custom checks
-   何をpass・failとするか
-
-            ↓
-
-3. Execution / Trigger（実行）
-   Claude Code / hooks / CI / runner
-   いつ、どのcheckを実行するか
-
-            ↓
-
-4. Evidence（証拠）
-   test result / diff / hash / artifact / CI result
-   何が実際に起きたか
-```
-
-Claude Codeは3層目を非常に強くできる。
-
-実装して、commandを実行し、失敗を読み、直して、もう一度実行するloopを高速化できるからだ。
-
-しかし3層目が強くなったことと、2層目の**「何を合格とするか」**が強くなったことは同じではない。
-
-ここを混ぜないことが重要になる。
-
-## Claude Code自身も「agentの判断」と「必ず実行する仕組み」を分けている
-
-Claude CodeのHooks guideは、hooksをClaude Codeのライフサイクル上の特定地点で自動実行される仕組みとし、LLMが実行を選ぶことに依存しない **deterministic control** と説明している。用途としてproject rulesのenforcementも明記されている。
-
-- [Automate workflows with hooks | Claude Code Docs](https://code.claude.com/docs/en/hooks-guide)
-
-Hooks referenceでは、`TaskCompleted` hookでtest suiteを実行し、失敗時にはtaskをcompleteとして扱わせない公式例も掲載されている。
-
-- [Hooks reference | Claude Code Docs](https://code.claude.com/docs/en/hooks)
-
-つまりClaude Code自身の設計にも、次の区別がある。
-
-```text
-LLMに判断させる
-        ≠
-決定的なcheckを必ず実行する
-```
-
-AI agentを信用するか、しないかという話ではない。
-
-**判断が必要な場所と、決定的に強制したい場所を分ける**という話だ。
-
-## では、Claude Codeには何を任せるのか
-
-テスト自動化をClaude Codeへ委譲するとき、次のように分ける。
-
-| Claude Codeに委譲しやすい | repo側に固定したい |
-|---|---|
-| test commandの反復実行 | 必須test suite |
-| failure logの解析 | acceptance criteria |
-| 実装修正 | invariant |
-| regression testの追加 | testを弱める変更のreview条件 |
-| lint / type checkの実行 | lint / type ruleそのもの |
-| 修正後の再検証 | 許可された変更scope |
-| evidenceの収集 | mergeをblockする条件 |
-
-右側を人間が毎回手作業で実行する必要はない。
-
-**agentのその場の判断から独立し、別の主体でも再実行できる形にしておく**ことが重要だ。
-
-たとえば、
-
-```text
+```bash
 ./scripts/verify
 ```
 
-の1commandに、必須test、lint、type check、schema validation、必要なcustom checkerを集約する。
+Claude CodeにもlocalにもCIにも同じcommandを実行させる。これで「Claudeが大丈夫と言った」ではなく、**同じ合格条件を別主体でも再実行できる**状態になる。
 
-Claude CodeにもCIにも同じcommandを実行させる。
-
-すると「Claudeが大丈夫と言った」ではなく、
+## 壊れた例
 
 ```text
-同じ合格条件を
-Claude Codeでも
-local hookでも
-CIでも
-再実行できる
+agent: 実装
+agent: test追加
+agent: test失敗
+agent: fixtureを簡略化
+agent: green
 ```
 
-状態になる。
+greenは事実でも、最初の期待を満たした証拠とは限らない。
 
-これがagentを安心して働かせるための境界になる。
-
-## 小さな実験で、runnerとpolicyを分離してみた
-
-この考え方を確認するために、Verification Stack v2では `pre-commit` と `prek` を使ったcontrolled fixtureを作った。
-
-これはClaude Codeそのものの比較実験ではない。
-
-**「実行するrunnerを替えたとき、同じpolicyのobservable effectが保存されるか」**を測るための小さな実験だ。
-
-結果を見る前に `HOOK-PATCH-PARITY-001` として、次の4条件を固定した。
-
-1. 同じファイルが変更される
-2. 最終content SHA-256が一致する
-3. diff SHA-256が一致する
-4. 再実行がidempotentである
-
-controlled resultは次の通りだった。
-
-| 観測 | 結果 |
-|---|---|
-| same changed files | true |
-| same content SHA-256 | true |
-| same diff SHA-256 | true |
-| both idempotent | true |
-
-証跡は固定commitに保存している。
-
-- [controlled summary](https://github.com/KAFKA2306/articles/blob/aa33a88e5bf165ac4085c7462e67f23283647926/benchmarks/verification-stack-v2/results/controlled/summary.json)
-- [experiment protocol and artifacts](https://github.com/KAFKA2306/articles/tree/aa33a88e5bf165ac4085c7462e67f23283647926/benchmarks/verification-stack-v2)
-
-このfixtureで観測された範囲では、runnerを `pre-commit` から `prek` に交換しても、hookが作ったpatchのobservable resultは変わらなかった。
-
-つまり、このケースではrunnerの変更を**policy変更ではなくtrigger実装の置換**として扱えた。
-
-全repo・全hookで完全互換だと証明したわけではない。language-specific hook、network依存hook、特殊stage、CI環境差は今回のground truth外である。
-
-しかし、この小さな実験はClaude Code時代にも使える1つの見方を与える。
-
-> **実行主体が変わっただけなら、合格条件が増えたとは限らない。**
-
-## Claude Codeを追加しても、品質ルールが自動的に増えるわけではない
-
-たとえば、既にCIで次を実行しているとする。
+## 改善後
 
 ```text
-Ruff
-Pyright
-test suite
-schema validation
+人間/repo: acceptance criteria固定
+agent: 実装・test追加・修正
+CI: 固定verifyをexact headで再実行
 ```
 
-そこへClaude Codeを追加して、同じcommandを実装中にも実行させる。
+agentは速く回し、人間は毎回すべてを手作業で確認しない。代わりに、**完了条件の所有者を分ける**。
 
-これは大きな価値がある。feedback loopが短くなり、失敗をagent自身が修正できるからだ。
+## 読者向けチェックリスト
 
-ただし、新しく増えたのは主に**実行能力**である。
+Claude Codeへテスト自動化を委譲する前に、次の5問だけ確認すればよい。
 
-Ruff rule、type policy、test oracle、schema invariantが同じなら、合格条件そのものが自動的に増えたわけではない。
+1. 合格条件はコードと同じagentが自由に弱められるか
+2. 必須checkは1 commandで再実行できるか
+3. test/fixture/config変更もdiffでreview対象になるか
+4. CIはexact headで同じ条件を再実行するか
+5. greenが「何を証明したか」を説明できるか
 
-逆に、Claude Codeに新しいregression testを作らせ、そのtestを正準suiteへ追加し、以後の変更をblockできるようにしたなら、そこでrepositoryが検出できるfailure conditionは増える。
+1がyesで、残りがnoなら、委譲範囲より先にoracleを固定した方がよい。
 
-見るべきなのは「Claude Codeを導入したか」ではない。
+## 証拠の境界
 
-**repositoryが昨日より何を検出できるようになったか**である。
+この記事は「Claude Codeがtestを改ざんする」と主張していない。主張しているのは、**最適化する主体と合格条件を変更できる主体を同一scopeに置くと、完了判定の独立性が弱くなる**という設計上の事実だ。
 
-## 「agentに全部任せる」を成立させるのは、強いpromptではなく外部化されたpolicy
+AI coding agentを信用するかどうかではない。速いagentほど、合格条件を外側へ固定した方が委譲できる範囲が広がる。
 
-Claude Codeへ長いpromptを書けば、多くのことを任せられる。
-
-しかし毎回promptの中で、
-
-```text
-必ずtestして
-lintして
-type checkして
-このファイルは触らないで
-この条件を壊さないで
-```
-
-と頼み続けるより、決定的に強制できる条件はrepository側へ外部化した方が再利用しやすい。
-
-Claude Codeを賢くするだけではなく、**Claude Codeが働く環境そのものを賢くする**。
-
-この方が、agentを増やしてもpolicyが散らばりにくい。
-
-## 30秒で確認するなら、この4点だけ
-
-Claude Codeへ大きな仕事を渡す前に、最低限ここだけ確認する。
-
-1. **合格条件はagentのprompt以外にも存在するか**
-2. **同じverificationをCIから再実行できるか**
-3. **test・config・必須artifactを弱める変更をdiffで識別できるか**
-4. **「完了」がagentの自己申告ではなく観測可能な条件になっているか**
-
-この4つがyesなら、実装や修正loopはかなり大胆に委譲できる。
-
-## 最小構成ならこうする
-
-Claude Codeに実装とテストloopをかなり委譲するなら、最小でも次の形にする。
-
-```text
-明示したOutcome / Acceptance Criteria
-             ↓
-正準verification command
-             ↓
-Claude Codeが実装・修正・再実行
-             ↓
-Hooks / CIが同じpolicyを再実行
-             ↓
-Evidenceを残す
-```
-
-終了条件も、
-
-```text
-Claude Codeが「完了」と言った
-```
-
-ではなく、
-
-```text
-正準verification commandがexit 0
-+ 必須artifactが生成された
-+ diffが許可scope内
-```
-
-のような観測可能な条件へ寄せる。
-
-Claude Codeはその条件を満たすために自由に試行できる。
-
-しかし、**完了条件そのものは試行loopの外側に置く**。
-
-この分離があるほど、より大きな仕事をagentへ渡しやすくなる。
-
-人間のレビュー対象も、毎回のcommand実行そのものから、**Outcome・合格条件・policyを変更したdiff**へ寄せられる。
-
-## 誤解しないでほしいこと
-
-この記事は「Claude Codeにテストを任せるな」という話ではない。
-
-逆である。
-
-**もっと任せるために、合格条件をagentの外へ出す。**
-
-反復実行、failure解析、修正、再検証はagentが強い領域だ。
-
-その能力を活かすほど、
-
-```text
-何を合格とするか
-何がblocking conditionか
-何を証拠として残すか
-```
-
-を明示する価値が上がる。
-
-## 持ち帰るべき1文
-
-**Claude Codeにテストを全部任せるなら、テストの実行ではなく「何を合格とするか」を先に固定する。**
-
-agentは何度でも実行できる。
-
-だからこそ、**合格条件は実行loopの外に置く。**
-
-## 一次情報・実験証跡
-
-- [Claude Code overview | Claude Code Docs](https://code.claude.com/docs/en/overview)
-- [How Claude Code works | Claude Code Docs](https://code.claude.com/docs/en/how-claude-code-works)
-- [Automate workflows with hooks | Claude Code Docs](https://code.claude.com/docs/en/hooks-guide)
-- [Hooks reference | Claude Code Docs](https://code.claude.com/docs/en/hooks)
-- [pre-commit documentation](https://pre-commit.com/)
-- [prek compatibility](https://prek.j178.dev/compatibility/)
-- [controlled evidence](https://github.com/KAFKA2306/articles/blob/aa33a88e5bf165ac4085c7462e67f23283647926/benchmarks/verification-stack-v2/results/controlled/summary.json)
-- [experiment protocol and artifacts](https://github.com/KAFKA2306/articles/tree/aa33a88e5bf165ac4085c7462e67f23283647926/benchmarks/verification-stack-v2)
+**AIに多く任せたいなら、人間が多く確認するのではなく、合格条件を先に固定する。**

--- a/articles/2026-08-15-static-types-do-not-validate-external-input.md
+++ b/articles/2026-08-15-static-types-do-not-validate-external-input.md
@@ -1,156 +1,125 @@
 ---
-title: "型チェックが通っても、外部入力は検証されていない"
+title: "型チェックが通っても、外部入力は安全にならない"
 emoji: "🚧"
 type: "tech"
 topics: ["python", "typescript", "pydantic", "zod", "testing"]
 published: false
 ---
 
-型チェッカーをstrictにした。CIもgreenになった。ではAPI、JSON、環境変数、ファイルから来る値も安全になったのか。
+CIで型チェックがgreenでも、API、JSON、環境変数、ファイルから来る値まで安全になったわけではない。
 
-**ならない。少なくとも、今回固定したPython/TypeScriptの2つのruntime-boundary mutantでは、static authorityとruntime authorityは別の仕事だった。**
+今回、PythonとTypeScriptで外部入力のfailureを1件ずつ固定し、static checkとruntime validationを分けて観測した。PydanticとZodは各runtime mutantを拒否し、validationなしのcontrol pathは拒否しなかった。
 
-これは「PydanticやZodを使おう」という製品記事ではない。どのgateに最終判定権を持たせるか、という話だ。
+ここから得た実務上の結論は、製品選びではない。
 
-## 先にground truthを固定した
+> **外部入力は、runtime boundaryで最後に検証する。**
 
-比較後に都合のよい失敗例を選ばないため、Verification Stack v2ではtool実行前にfixtureを凍結した。
+## どこで事故が起きるのか
 
-- `PY-RUNTIME-001`: 外部由来の値がruntime contractに違反する。ただしparse前のコード自体はsyntax/type上受理可能。
-- `TS-RUNTIME-001`: `unknown` の外部payloadがcompileを通るがruntime schemaに違反する。
-- 1 mutant = 1 root fault。
-- raw diagnostic数はdefect数として数えない。
-- runtime validatorをlinterやtype checkerとの「勝敗」には使わない。
+典型例はこれだ。
 
-Protocol: https://github.com/KAFKA2306/articles/blob/4c111d27ea193a72238d5ee97d145770cec2109e/benchmarks/verification-stack-v2/PROTOCOL.md
+```text
+HTTP / JSON / env / file
+        ↓
+アプリ内部の型付きコード
+```
 
-Fixture design: https://github.com/KAFKA2306/articles/blob/4c111d27ea193a72238d5ee97d145770cec2109e/benchmarks/verification-stack-v2/FIXTURE_DESIGN.md
+内部コードが型安全でも、境界から入る値は実行時にしか存在しない。
 
-## 観測結果は2対2だった
-
-controlled resultでは、runtime boundaryだけを見ると次の結果になった。
-
-| mutant | runtime authority | detected | unvalidated control |
-|---|---|---:|---:|
-| `PY-RUNTIME-001` | Pydantic | 1 / 1 | 0 / 1 |
-| `TS-RUNTIME-001` | Zod | 1 / 1 | 0 / 1 |
-
-この数字を「Pydantic/Zodのaccuracy 100%」とは読まない。各言語1 mutantしかないからだ。ここで実証したのはもっと狭い。
-
-**静的に受理可能な外部payloadでも、runtime contractを実行すれば拒否できるfailure classが、PythonとTypeScriptの両fixtureで1件ずつ存在した。**
-
-Raw summary: https://github.com/KAFKA2306/articles/blob/4c111d27ea193a72238d5ee97d145770cec2109e/benchmarks/verification-stack-v2/results/controlled/summary.json
-
-## TypeScriptはruntimeで型を持ち続けない
-
-TypeScript公式Handbookは、compilerがcheckingを終えると型をeraseしてJavaScriptを生成し、型推論によってruntime behaviorを変えないと説明している。
+TypeScript公式は、compile後にtype annotationをeraseしてJavaScriptを生成すると説明している。
 
 https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html
 
-つまり、`unknown` を正しく置くことは重要だが、それだけでは外部payloadをruntimeで検証する処理にはならない。
+つまり`unknown`を正しく扱うことと、その値をruntimeで検証することは別である。
 
-Zodは公式に「TypeScript-first validation library」とされ、schemaでuntrusted dataをparse/validateする例を示している。
+Zodはruntime schema validationを提供する。
 
 https://zod.dev/
 
-したがって責務はこう分かれる。
-
-```text
-external bytes / JSON
-        |
-        v
-runtime schema  <-- 実際に来た値を判定するauthority
-        |
-        v
-validated value
-        |
-        v
-static type checker / compiler <-- コード上の型整合性を判定するauthority
-```
-
-これはどちらか一方を選ぶ競争ではない。
-
-## Pythonでも「Pydanticを理解する型チェッカー」と「Pydanticを実行する」は別
-
-ここは特に混同しやすい。
-
-Pyreflyは現在、Pydantic v2のbuilt-in supportを持ち、`BaseModel`、`Field`、strict/lax modeなどを静的解析へ反映する。公式docs自身も、この機能をstatic type checking / IDE integrationとして説明し、Pydanticにはruntime data validationがあると分けている。
+Pythonでも同じ分離がある。PyreflyはPydantic v2を静的解析できるが、Pydantic自身のruntime validationとは別の責務だ。
 
 https://pyrefly.org/en/docs/pydantic/
-
-一方Pydanticの`validate_call()`は、実際に渡された引数をfunction call前にparse/validateし、失敗時には`ValidationError`を発生させる。
-
 https://docs.pydantic.dev/latest/concepts/validation_decorator/
 
-したがって「type checkerがPydanticを理解するようになったからruntime validationを削除できる」とは、この証拠からは言えない。
+## 固定fixtureで何が起きたか
 
-## 3つの物語を同じ証拠で潰した
+今回のcontrolled fixtureでは次の2ケースだけを扱った。
 
-結果を見たあと、少なくとも次の3命題を競合させた。
+- Python: staticに受理可能だがruntime contractへ違反する外部値
+- TypeScript: compile可能な`unknown` payloadだがruntime schemaへ違反する値
 
-1. **runtime validatorはtype checkerより優秀だ** — 棄却。責務が違い、head-to-headのground truthを置いていない。
-2. **static checkerが強くなればruntime validatorは不要になる** — 今回の2 mutantとTypeScriptのerased-types契約に反する。
-3. **外部入力の最終authorityはruntime boundaryに置く** — 今回の証拠と矛盾せず、実装判断を変える。
+結果は次だった。
 
-残ったのは3だけだった。
+| language | runtime validator | fixed runtime fault | unvalidated control |
+|---|---|---:|---:|
+| Python | Pydantic | reject | accept |
+| TypeScript | Zod | reject | accept |
 
-## gate orderingは「速い順」ではなく「authority順」に考える
+summary:
+https://github.com/KAFKA2306/articles/blob/4c111d27ea193a72238d5ee97d145770cec2109e/benchmarks/verification-stack-v2/results/controlled/summary.json
 
-実務では、source hygiene、static semantics、runtime boundaryを一つの巨大な`quality` gateとして扱うと責務が曖昧になる。
+各言語1件なので「accuracy 100%」とは言わない。実証したのは、**static passでは止まらず、runtime contractで初めて止められるfailure classが両fixtureに存在した**ことだけだ。
 
-今回の結果から言える最小の設計は次だ。
+## 壊れた設計
 
 ```text
-source/lint gate
-    -> static type gate
-        -> runtime boundary validation
-            -> tests / application behavior
+request.json()
+  ↓
+型注釈を付ける
+  ↓
+そのままbusiness logicへ渡す
 ```
 
-これは必ずこの順番でprocessを直列実行せよ、という意味ではない。CIでは並列化できる。重要なのは**失敗を誰の責任として扱うか**だ。
+型注釈は入力値そのものを検証しない。
 
-- Ruff/Biome/Oxlint: source/lint/formatのうち有効化したpolicy。
-- Pyright/Pyrefly/mypy/ty/`tsc`: static semantics/type consistency。
-- Pydantic/Zod: 実行時に到着した外部値のcontract。
-- hook runner: これらを起動するtriggerでありpolicyそのものではない。
+## 改善後
 
-Ruff公式もlinterとformatterを独立して利用できると明記している。
+```text
+external input
+  ↓
+runtime schema / parser
+  ↓
+validated value
+  ↓
+application code + static type checker
+```
 
-https://docs.astral.sh/ruff/faq/
+ここでruntime validatorとtype checkerは競合しない。
 
-Pyrightも`off/basic/standard/strict`というtype-checking rule setを提供するstatic checkerである。
+- static checker: コード上の型整合性
+- runtime validator: 実際に到着した値のcontract
 
-https://github.com/microsoft/pyright/blob/main/docs/configuration.md
+## どこに置くべきか
 
-## 再現する
+外部入力の直後に置く。
 
-この主張を追試するなら、製品を増やす前に1つのboundary mutantを作る。
+対象は最低でも次だ。
 
-1. 外部入力を`unknown`相当として受け取る。
-2. コード自体はstatic checkを通る状態にする。
-3. schemaに違反する値を1つだけ入れる。
-4. static gateとruntime schemaを別々に実行する。
-5. mutantのroot faultを事前に1つへ固定する。
-6. diagnostic件数ではなく、そのroot faultを正しく止めたかだけを記録する。
+- HTTP request body
+- webhook payload
+- environment variables
+- config file
+- CSV / JSON import
+- message queue payload
+- LLM structured output
 
-このrepositoryではfixture、protocol、raw summaryを固定commitで残しているため、そのまま監査できる。
+内部処理の奥深くでvalidationするより、境界直後でunknownをvalidated valueへ変換する方がfailure locationを狭くできる。
 
-https://github.com/KAFKA2306/articles/tree/4c111d27ea193a72238d5ee97d145770cec2109e/benchmarks/verification-stack-v2
+## 読者向けチェックリスト
 
-## 何を測っていないか
+1. 外部から入る値を列挙する
+2. 各入力が最初に`unknown`として扱われる場所を探す
+3. runtime schemaを境界直後に置く
+4. validation後の型だけを内部へ渡す
+5. invalid payloadのtestを1件以上固定する
+6. static checkerがgreenでもruntime boundary testを削除しない
 
-今回のruntime corpusはPython 1件、TypeScript 1件だけである。複雑なnested schema、custom validator、coercion、performance、error UX、schema evolution、API compatibilityは比較していない。PydanticとZodを相互比較もしていない。
+## 証拠の境界
 
-また、real repository stageはground truthが未知なのでrecall証明には使っていない。Protocolでもreal repoはcompatibility、latency、migration frictionなどのexternal validityに限定している。
+この記事は「Pydantic/Zodがすべての入力事故を防ぐ」とは言わない。今回測ったruntime mutantは各言語1件だけで、schema designの完全性も測っていない。
 
-## 何が起きれば結論を反転するか
+言えるのはもっと実務的なことだ。
 
-このrecommendationは永遠の原則ではない。
+**型チェックのgreenを、外部入力のvalidation済みと読み替えない。**
 
-**実際の外部payloadをruntimeで観測し、その値がcontractを満たすかをstatic authorityだけで完全に判定できる実行モデル**が対象systemに存在し、同じpredeclared runtime mutantsを追加validatorなしで拒否できるなら、runtime authorityを別に置く理由は弱くなる。
-
-今回、そのcounterfactualは観測されなかった。
-
-だから現時点の判断は単純だ。
-
-**型チェックがgreenでも、外部入力のgateまでgreenとは限らない。外部値を受け取る場所には、runtime contractを実行する別のauthorityを置く。**
+外から来る値には、実際の値を判定するruntime authorityを置く。

--- a/articles/2026-08-15-two-of-two-is-not-compiler-authority.md
+++ b/articles/2026-08-15-two-of-two-is-not-compiler-authority.md
@@ -1,89 +1,26 @@
 ---
-title: "2/2で通っても、コンパイラはまだ消せない"
+title: "新しいCIツールが同点でも、古いgateを消してはいけないときがある"
 emoji: "🧪"
 type: "tech"
 topics: ["typescript", "oxlint", "ci", "testing", "tooling"]
 published: false
 ---
 
-新しいツールが、既存のコンパイラと同じテストを通った。
+新しいtoolが、既存のcompilerと同じ固定テストを全部通った。
 
-それならCIから古いgateを消してよい――とは限らない。
+それでも、すぐに古いgateを削除してよいとは限らない。
 
-今回の実験では、TypeScriptの型エラーを1つずつ埋め込んだ固定fixtureに対し、TypeScript compilerとOxlintのtype-check機能を同じground truthで検証した。対象となる2つの型mutantでは、どちらも **2/2** を検出した。clean baselineのblocking false positiveも0だった。
+今回、TypeScriptの型failureを1つずつ入れた2つのmutantで、`tsc`とOxlintのtype-check機能はどちらも2/2だった。clean baselineのblocking false positiveも0だった。
 
-それでも、今回の条件では `tsc --noEmit` をdefaultの型authorityから外さない。
+ここまでは置換候補として強い証拠だ。
 
-理由は速度でもブランドでもない。**「このfixtureで正しく動いた」という証拠と、「CIの最終判定者を任せられる」という証拠は別物だからだ。**
+しかし、**「このfixtureで同点」と「CIの最終authorityを移してよい」は別の判断**である。
 
-## まず、何を測ったのか
+## 読者の本当の仕事は「追加」ではなく「安全に削除できるか」
 
-比較前にprotocolを固定した。
+modern toolchainでは1つのbinaryがformatter、linter、type-aware lint、compiler diagnosticsまで持つことがある。
 
-- 1 mutant = 1 root fault
-- raw diagnostic数を欠陥数として数えない
-- clean baselineをblockする候補はdefault authorityから失格
-- correctnessを速度より先に判定する
-- Experimentalなsemantic featureをdefault authorityにする場合は、結論自体をexperimental adoptionに限定する
-
-Protocol:
-https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/PROTOCOL.md
-
-今回のTypeScript corpusには、syntax、lint、type argument、type return、promise misuse、runtime boundaryを別々のroot faultとして入れている。formatter、linter、compiler、runtime validatorを同じ「エラー検出ツール」として合算しないためだ。
-
-Fixture design:
-https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/FIXTURE_DESIGN.md
-
-実行環境のreauditでは、TypeScript 7.0.2、Oxlint 1.76.0を記録した。
-
-Installed versions:
-https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/controlled/installed-versions.json
-
-## 観測結果: 型mutantでは同点だった
-
-controlled summaryでは次の結果になった。
-
-| authority candidate | in-scope type mutants | detected | clean blocking false positives |
-|---|---:|---:|---:|
-| `tsc` | 2 | 2 | 0 |
-| Oxlint `typeCheck` | 2 | 2 | 0 |
-
-`tsc` はsyntax mutantも担当範囲に含めたためsummary全体では3/3、Oxlint `typeCheck` は型mutant2件を担当して2/2である。したがって「3対2だからtscの勝ち」という読み方もしてはいけない。責務の異なる分母を足すと、またraw count比較に戻ってしまう。
-
-Controlled summary:
-https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/controlled/summary.json
-
-この結果だけを見るなら、少なくとも今回の2つの型faultについてOxlint `typeCheck`が見逃した、とは言えない。
-
-ここで重要なのは、**2/2という結果をどこまで昇格させてよいか**である。
-
-## 同じcorrectnessでもauthorityは同じにならない
-
-TypeScript公式は `noEmit` を、JavaScript等を出力せずTypeScriptをsource code type-checkerとして使う設定として説明している。
-
-https://www.typescriptlang.org/tsconfig/noEmit.html
-
-一方、Oxlint公式はtype-aware lintingとtype checkingを分けている。`--type-aware` はTypeScriptの型情報を必要とするlint ruleを有効にする機能で、`--type-check` はTypeScript compiler diagnosticsを併せて報告する機能だ。
-
-https://oxc.rs/docs/guide/usage/linter/type-aware.html
-
-そしてOxlintのconfiguration referenceは、`options.typeCheck` を現在も **experimental type checking** と明記している。
-
-https://oxc.rs/docs/guide/usage/linter/config-file-reference
-
-つまり今回得た証拠はこう分かれる。
-
-- **観測した証拠**: 固定した2つの型mutantでは両者2/2、clean baseline false positive 0
-- **公式仕様の証拠**: `tsc --noEmit` はTypeScriptのsource type-checkerとして使える
-- **公式statusの証拠**: Oxlint `typeCheck` はexperimental
-
-最初の証拠が良好でも、3番目は消えない。
-
-## 「動いた」と「default authority」は別のgateにする
-
-CIのtool migrationで危険なのは、parity testをそのままreplacement authorizationにしてしまうことだ。
-
-例えば次の移行を考える。
+すると移行はこう見える。
 
 ```text
 before
@@ -94,131 +31,114 @@ after
   oxlint --type-aware --type-check
 ```
 
-コマンドが1本減る。今回の2 mutantも検出できた。魅力的に見える。
+commandが減る。管理対象も減る。だが、古いgateを消すには「新しいtoolが動く」以上の証拠が必要だ。
 
-しかし、この変更には少なくとも2つの別判定がある。
+## 今回、correctness gateは通った
 
-1. **correctness gate**: 事前に固定したfaultを落とさないか
-2. **authority gate**: その機能のstatus・互換範囲・運用条件を含め、defaultのblocking authorityを任せる条件を満たすか
+固定したTypeScript type mutantでは次だった。
 
-今回、1は通った。2は通していない。
+| candidate | in-scope type mutants | detected | clean blocking FP |
+|---|---:|---:|---:|
+| `tsc` | 2 | 2 | 0 |
+| Oxlint `typeCheck` | 2 | 2 | 0 |
 
-これはOxlintを否定する判断ではない。むしろ逆で、**experimental challengerとして比較対象に残せるだけのcorrectness evidenceは得られた**。ただし「試す価値がある」と「既存authorityを削除してよい」の間にgateを置く。
+controlled summary:
+https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/controlled/summary.json
 
-## 壊れた判断例: 2/2だから置換する
+2件だけなのでTypeScript全体のaccuracyを示さない。それでも「この2 faultをOxlintが見逃した」とは言えなくなった。
 
-次の推論は成立しない。
+## それでも削除しなかった理由
 
-```text
-Oxlint typeCheck: 2/2
-TypeScript compiler: 2/2
-        ↓
-同等
-        ↓
-tscを削除
-```
+TypeScript公式は`noEmit`を、出力せずsourceをtype-checkする用途として説明している。
 
-2件のmutantは完全なTypeScript compiler conformance suiteではない。また、今回のreal-repository probeでは `investor2` の `tsc` と通常の `oxlint` は実行したが、Oxlint `--type-check` のexternal-validity probeは記録していない。
+https://www.typescriptlang.org/tsconfig/noEmit.html
 
-External-validity summary:
+Oxlint公式は`--type-aware`と`--type-check`を別surfaceとして扱い、configuration referenceでは`options.typeCheck`をexperimentalとしている。
+
+https://oxc.rs/docs/guide/usage/linter/type-aware.html
+https://oxc.rs/docs/guide/usage/linter/config-file-reference
+
+さらに今回のfrozen real-repo probeでは`tsc`と通常の`oxlint`は実行したが、Oxlintの`--type-check`自体はexternal-validity未検証だった。
+
 https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/external/summary.json
 
-そこでは `tsc` はexit 0、通常の`oxlint`はexit 1だったが、real repoには完全なdefect ground truthがない。したがって、このexit codeや出力行数をaccuracy比較には使えない。まして通常lintの結果を`--type-check`の実証に読み替えることもできない。
+つまり、correctnessの小さなground truthでは通ったが、**default authorityを置き換えるための運用証拠はまだ揃っていなかった**。
 
-**external `--type-check` は未検証**。ここは空欄のまま残すのが正しい。
-
-## 改善後: replacementを3段階に分ける
-
-実務では、置換を次の3段階に分けると判断が崩れにくい。
+## migrationを3段階に分ける
 
 ### 1. Candidate
 
-公式に責務を持つかを確認する。
+公式にその責務を持つか確認する。
 
-Oxlintの場合、type-aware lintとtype-checkは別surfaceである。単に「型が分かるlinter」だからcompiler replacement候補、と推測しない。
+「型情報を使えるlinter」だからcompiler replacement候補、と推測しない。実際にcompiler diagnosticsを担当する公式surfaceを確認する。
 
 ### 2. Evidence-qualified challenger
 
-自分のrepoで重要なfailure classをfixture化し、clean baselineとmutantを固定して比較する。
+自分のrepoで絶対に落としたくないfailure classを固定し、clean baselineとmutantの両方で比較する。
 
 今回の2/2はここまでを支持する。
 
 ### 3. Default authority
 
-correctnessに加えて、機能status、対応するcompiler/config surface、real-repo compatibility、upgrade時の回帰gateまで満たした時だけ既存authorityを削除する。
+ここで初めて旧gate削除を検討する。
 
-この段階では「新しいtoolを追加できるか」ではなく、**古いauthorityを安全に削除できるか**を問う。
+最低限見るのは次だ。
 
-## 他のtoolにも同じauthority modelを使う
+- stability status
+- 必要なfailure corpus
+- real-repo compatibility
+- config/compiler surfaceの欠落
+- upgrade時のregression gate
+- superseded authorityを削除できるか
 
-この考え方はTypeScript type checkingだけの話ではない。
+## 壊れた判断
 
-Ruff公式はlinterの入口を `ruff check`、formatterの入口を `ruff format` と分け、formatterはimport sortingを行わないと明記している。Biomeもformatter、linter、assistを別surfaceとして設定する。prekは既存の`.pre-commit-config.yaml`を実行できるhook managerであり、hook内部のpolicyそのものではない。
-
-- Ruff linter: https://docs.astral.sh/ruff/linter/
-- Ruff formatter: https://docs.astral.sh/ruff/formatter/
-- Biome configuration: https://biomejs.dev/reference/configuration/
-- prek compatibility: https://prek.j178.dev/compatibility/
-
-workspaceでも同様だ。Turborepoはtask execution/cacheを提供し、`--affected`でGit履歴から対象packageを絞れる。一方、Boundaries/Tagsは公式support policy上experimentalである。Nxはaffected calculationにGit historyとproject graphを使い、JavaScript/TypeScriptのboundary enforcementには`@nx/enforce-module-boundaries`という別surfaceを持つ。
-
-- Turborepo caching: https://turborepo.dev/docs/crafting-your-repository/caching
-- Turborepo `--affected`: https://turborepo.dev/docs/reference/run#--affected
-- Turborepo support policy: https://turborepo.dev/docs/support-policy
-- Nx affected: https://nx.dev/docs/features/ci-features/affected
-- Nx module boundaries: https://nx.dev/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries
-
-**1つのbinaryに機能が増えたことと、1つのauthorityに統合してよいことは同義ではない。**
-
-## 再現する
-
-この結果はrepositoryに固定してある。
-
-```bash
-git clone https://github.com/KAFKA2306/articles.git
-cd articles
-git checkout 81848adca34e077835735a1f8586c6e8cd8cd511
-
-cat benchmarks/verification-stack-v2/PROTOCOL.md
-cat benchmarks/verification-stack-v2/results/controlled/summary.json
-cat benchmarks/verification-stack-v2/results/controlled/installed-versions.json
-cat benchmarks/verification-stack-v2/results/external/summary.json
+```text
+new tool: 2/2
+old tool: 2/2
+↓
+同等
+↓
+old gate削除
 ```
 
-raw artifactまで追う場合は `benchmarks/verification-stack-v2/results/controlled/source-runtime.json` を確認する。diagnostic行数ではなく、mutant IDとexpected authorityに対するdetected booleanを見る。
+この推論は、2件のmutantをcompiler conformance全体へ外挿している。
 
-## 何を測っていないか
+## 改善した判断
 
-今回の結論には明確な境界がある。
+```text
+fixed correctness corpus PASS
+        ↓
+real-repo / config / statusを確認
+        ↓
+replacement contract PASS
+        ↓
+old gateを削除
+```
 
-- 型mutantは2件であり、TypeScript全仕様のconformanceを測っていない
-- Oxlint `--type-check` のreal-repository external-validity runを実施していない
-- editor/LSP体験を比較していない
-- upgrade間の互換性を長期観測していない
-- vendorの速度倍率を自分たちの性能結果として使っていない
+重要なのは「新しいtoolを足せるか」ではなく、**古いauthorityを安全に消せるか**である。
 
-したがって「Oxlint typeCheckは不正確」とは結論していない。今回言えるのは、**観測したcorrectness parityだけではdefault authorityへの昇格条件を満たさない**、ということだけだ。
+## 読者向けの削除チェックリスト
 
-## 何が起きれば判断を反転するか
+既存CI gateを1本消す前に、次の6問を確認する。
 
-recommendationを固定観念にしないため、反転条件も決めておく。
+1. 新toolの公式責務は旧gateと同じか
+2. repo固有の重要failureをclean baseline付きで通したか
+3. real repoで新しいsurfaceそのものを実行したか
+4. 必要なconfig/diagnostic surfaceに欠落はないか
+5. feature statusはdefault blocking authorityに適するか
+6. 移行後、二重authorityを恒久化せず旧gateを削除できるか
 
-少なくとも次が揃えば、`tsc --noEmit`を削除する再評価に進める。
+1〜4が未確認ならreplacement以前。5がexperimentalなら、採用判断もexperimental adoptionとして限定する。
 
-1. Oxlintのtype checkingが公式にdefault-authority用途へ十分なstability statusになる
-2. repoで重要な型failure corpusをclean baseline付きで継続的に通す
-3. frozen real repoで`--type-check`自体のcompatibilityを確認する
-4. 必要なTypeScript configuration/compiler diagnostic surfaceに欠落がないことを確認する
-5. 置換後にsuperseded gateを削除し、二重authorityを恒久化しない
+## 証拠の境界
 
-逆に、このどれかが欠ける間は、Oxlintをlint authorityとして使うことと、compiler authorityまで移譲することを別の意思決定として扱う。
+この記事はOxlintのtype checkingが不正確だとは主張しない。今回の2 mutantではむしろ2/2だった。
 
-## 結論
+主張はもっと狭い。
 
-modern toolchainの統合で見るべきなのは「何本のcommandを1本にできるか」ではない。
+**correctness parityは、replacement authorizationの必要条件になり得ても十分条件ではない。**
 
-見るべきなのは、**その1本にどの判定権限まで移してよい証拠があるか**だ。
+commandを1本減らすことより、判定権限をどこまで移してよい証拠があるかを見る。
 
-今回、Oxlint `typeCheck` は固定した型mutantで2/2を検出した。それは有力なchallengerである証拠にはなる。しかし、公式にexperimentalで、external `--type-check`も未検証の状態では、`tsc --noEmit`をdefault authorityから外す証拠にはならない。
-
-correctness parityは、移行の入口であって出口ではない。
+新しいtoolが同点だったときこそ、次に問うべきは「勝ったか」ではなく、**古いgateを消しても同じ安全性を説明できるか**である。

--- a/articles/2026-08-15-type-checker-config-is-authority.md
+++ b/articles/2026-08-15-type-checker-config-is-authority.md
@@ -1,172 +1,126 @@
 ---
-title: "同じ型チェッカーでも、設定で2/5が5/5になる"
+title: "型チェッカー比較で先に固定すべきなのは、製品名ではなく設定"
 emoji: "🧪"
 type: "tech"
 topics: ["python", "typechecking", "ci", "testing", "developerexperience"]
 published: false
 ---
 
-同じ型チェッカー、同じversion、同じ5つのfaultでも、設定だけで結果が **2/5から5/5へ変わった**。
+型チェッカーを比較して「Aは5件中2件、Bは5件中5件だった」と出たら、製品差だと思いたくなる。
 
-これは「どの型チェッカーが強いか」という話ではない。もっと手前の話だ。
+今回、それを誤った。
 
-**設定を固定していない型チェッカー比較は、製品差ではなくpreset差を測っている可能性がある。**
+同じPyrefly 1.2.0、同じ5つのroot faultでも、`basic` presetでは2/5、`default` presetでは5/5だった。つまり最初に見えていた差の一部は、**製品差ではなく実行設定の差**だった。
 
-今回、その失敗を実際に踏んだ。最初のcontrolled resultではPyrefly 1.2.0を5 mutant中2件検出と解釈した。その後、post-merge evidence integrity re-auditで同一candidateをpreset別に再計測すると、`basic`では2/5、`default`では5/5だった。旧記事の「stableのPyreflyが2/5」という製品差の物語は撤回する。
+この失敗から得た実務上の結論は単純だ。
 
-## 先に結論を決めない
+> 型チェッカーを比較する前に、version・preset・config・scope・severityを固定する。
 
-この実験系では、tool名より先にground truthを固定した。
+## なぜこの失敗は起きるのか
 
-Python static type authorityに対するin-scope faultは5つだけである。
+CIではbinary名だけが記録されがちだ。
 
-- `PY-SYNTAX-001`: syntax failure
-- `PY-TYPE-ARG-001`: incompatible argument type
-- `PY-TYPE-RETURN-001`: incompatible declared return type
-- `PY-NAME-001`: undefined name
-- `PY-ASYNC-001`: async misuse
+```text
+pyrefly
+pyright
+mypy
+```
 
-1 mutant = 1 root faultとし、raw diagnostic数をdefect数として足さない。さらにv2.5で、**clean baselineもblockするcandidateにはmutant検出creditを与えない**というintegrity ruleを明示した。
-
-Protocolとamendment:
-
-- https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/PROTOCOL.md
-- https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/AMENDMENT-v2.5-post-merge-evidence-integrity.md
-
-ここで重要なのは、v2.5が結果をよく見せるための後付け評価軸ではないことだ。旧summaryにrepaired harnessの結果が反映されていないことが判明したため、旧記事の結論を停止し、同じcandidate versions・mutants・real-repo sampleを維持したままevidenceを再生成するためのamendmentである。
-
-## 同じPyrefly 1.2.0で結果が変わった
-
-preset calibrationでは、Pyrefly 1.2.0に対して同じ5 mutantを `no_config`、`basic`、`default` の3条件で実行した。各mutantでclean baselineも同じ条件に通している。
-
-観測結果の要点はこうなる。
-
-| mode | syntax | arg type | return type | undefined name | async misuse |
-|---|---:|---:|---:|---:|---:|
-| no config → basic | detect | miss | miss | detect | miss |
-| `basic` | detect | miss | miss | detect | miss |
-| `default` | detect | detect | detect | detect | detect |
-
-Raw calibration:
-https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/pyrefly-preset-calibration.json
-
-Pyrefly公式ドキュメントとも整合する。設定のないprojectでは`basic` presetを合成し、これはsyntax errorやmissing importなど高confidenceのerror kindに絞る。一方、`default`は通常のdefault severityを使い、`strict`はさらにerror kindを追加する。
-
-https://pyrefly.org/en/docs/configuration/
-
-つまり2/5は「Pyrefly 1.2.0の検出能力」ではなかった。**Pyrefly 1.2.0をbasic presetで走らせたときの、この5 faultに対する観測**だった。
-
-## 修復後、製品ランキングは消えた
-
-baseline-qualifiedなcontrolled summaryを再生成すると、Python static type checkerの5 mutantについて次になった。
-
-| checker / tested configuration | detected | clean blocking false positives |
-|---|---:|---:|
-| mypy 2.3.0 | 5/5 | 0 |
-| Pyright 1.1.411 | 5/5 | 0 |
-| ty 0.0.71 | 5/5 | 0 |
-| Pyrefly 1.2.0 | 5/5 | 0 |
-
-Repaired summary:
-https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/summary.json
-
-ここから「4製品は同等」とも言えない。5 mutantしかなく、typing全体のrecall、diagnostic quality、third-party typing、incremental behavior、editor behaviorは測っていない。
-
-言えるのはもっと限定的だ。**このground truthでは、以前の記事を支えていた2/5対5/5の製品差は、configurationを揃え直すと残らなかった。**
-
-## authorityはbinary名ではなく実行契約に付く
-
-CIでblocking authorityを決めるとき、`pyrefly`や`pyright`というbinary名だけを記録しても足りない。
-
-少なくとも次を1つの実行契約として固定する必要がある。
+しかし実際にblocking authorityとして動くのはbinary名ではなく、次の組み合わせである。
 
 ```text
 authority =
   tool version
   + preset / mode
-  + config file
+  + config
   + project scope
-  + Python version / environment
+  + runtime environment
   + blocking severity policy
 ```
 
-Pyrightも公式に`off` / `basic` / `standard` / `strict`の`typeCheckingMode`を持ち、strictでは多くのruleが追加で有効になる。
+Pyrefly公式は、設定のないprojectでは`basic` presetを合成し、`default`や`strict`とはdiagnostic surfaceが異なると説明している。
+
+https://pyrefly.org/en/docs/configuration/
+
+Pyrightも`off` / `basic` / `standard` / `strict`の`typeCheckingMode`を持つ。
 
 https://github.com/microsoft/pyright/blob/main/docs/configuration.md
 
-したがって「Pyrefly vs Pyright」を測るなら、まず双方で何をblocking errorとして有効化したかを固定しなければならない。presetの違いを製品差としてheadlineにしてはいけない。
+製品名だけ揃えても、比較条件は揃っていない。
 
-## gate orderingも変わる
+## 実際に何が変わったか
 
-この結果から、型チェッカー導入gateは次の順序にする。
+固定fixtureでは次の5 failure classを1件ずつ用意した。
 
-1. **environment/config discovery**: 実際に読まれたconfigとpresetを記録する。
-2. **clean baseline**: 正常fixtureをblockしないことを確認する。
-3. **ground-truth mutants**: 1 root faultずつ必要なfailure classを検出するか測る。
-4. **diagnostic quality**: root causeを直接指すかを見る。件数はdefect数にしない。
-5. **same-runner timing**: correctness survivorだけを同一runnerでcold/warm計測する。
-6. **real repo**: frozen repositoryでoperational frictionを見る。ground truth不明なのでrecallには使わない。
+- syntax failure
+- incompatible argument type
+- incompatible return type
+- undefined name
+- async misuse
 
-速度を先に置かない。clean baselineを通らないcandidateの「検出数」も数えない。そしてpresetを記録していないrunを製品比較へ昇格させない。
+同じPyrefly 1.2.0で観測した結果はこうだった。
 
-## real repoは答え合わせではない
+| tested mode | detected |
+|---|---:|
+| no config → basic | 2/5 |
+| `basic` | 2/5 |
+| `default` | 5/5 |
 
-外部妥当性用のPython repositoryは結果を見る前にfreezeした。
+raw calibration:
+https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/pyrefly-preset-calibration.json
+
+修復後の同じ5 mutantでは、mypy / Pyright / ty / Pyreflyのtested configurationはいずれも5/5だった。
+
+summary:
+https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/summary.json
+
+ここから「4製品は同等」とは言えない。5 mutantしか測っていないからだ。言えるのは、**旧2/5対5/5を製品固有のcoverage差として扱えなかった**ことだけである。
+
+## 壊れた比較
 
 ```text
-KAFKA2306/2511youtuber
-95a0f6b4f5270d1463c15f301a2bd4f0d709c109
+A: 2/5
+B: 5/5
+↓
+Bの方が強い
 ```
 
-ここでは複数checkerが実行可能であることを確認したが、diagnostic数をrecall rankingには使っていない。実repositoryには完全なdefect ground truthがなく、dependency、stub、configuration、実際のtype defectが混在するからだ。
+この推論には、AとBが同じpolicy surfaceで走ったという確認が抜けている。
 
-Frozen sample:
-https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/real-repo-sample.json
+## 改善した比較
 
-controlled fixtureが「何を検出したか」を測り、real repoは「その実行契約を現実のrepositoryへ持ち込めるか」を見る。この2層を混ぜない。
+比較を次の順序に変える。
 
-## 3つの物語を同じ証拠で潰した
+1. repoで絶対にblockしたいfailure classをfixture化する
+2. clean baselineを保存する
+3. version / preset / config / scopeをpinする
+4. cleanとmutantを同じexecution contractで走らせる
+5. `clean=pass && mutant=block` のときだけcreditを与える
+6. correctness survivorだけを速度やmigration costへ進める
 
-結果を見てから都合のよいheadlineを選ばないため、同じevidenceから競合する命題を作った。
+これなら「設定が強いだけ」を「製品が強い」と誤読しにくい。
 
-### 1. Stableはsemantic correctnessを証明しない
+## 読者が持ち帰るべきもの
 
-一般論としては正しいが、今回の旧headlineを支えた「stable 2/5 vs Beta 5/5」というcontrastは修復後に消えた。この記事の中心命題には採用しない。
+型チェッカー導入時に比較表を作る前に、CI logへ次を残す。
 
-### 2. Pyreflyは他checkerよりcoverageが低い
+```text
+checker: pyrefly 1.2.0
+preset: default
+config: pyproject.toml
+scope: src + tests
+python: 3.12
+blocking severity: error
+```
 
-棄却する。同じversionが`default`では5/5になったため、旧2/5を製品固有coverageとして扱えない。
+この記録がないbenchmarkは、後から再現できても「何を比較したのか」が曖昧になる。
 
-### 3. 型チェッカー比較ではpresetもauthority contractの一部である
+## 証拠の境界
 
-これだけが残った。同一binary・同一version・同一ground truthでpreset変更だけが2/5→5/5を生み、公式仕様もpresetごとのdiagnostic surface差を明示している。
+今回の5 mutantはtyping全体のaccuracy benchmarkではない。editor behavior、third-party stubs、incremental analysis、large-repo behaviorも測っていない。
 
-## 何が出ればこの結論を変えるか
+それでも、設定を固定しない比較が危険だという判断には十分だった。なぜなら、**同一binary・同一version・同一fixtureでpresetだけを変えたとき、結果が2/5から5/5へ変わった**からだ。
 
-同じfrozen corpusで`basic`と`default`が同じ5/5になっていた、あるいは旧2/5がpresetではなく再現可能なchecker defectによるものだったなら、このheadlineは成立しない。
+製品比較は最後でいい。
 
-また、この実験は「defaultが最適」「strictを使うべき」とは証明していない。必要なfailure classと許容false positiveはrepositoryごとに違う。strict/default/basicのどれをauthorityにするかは、repository固有ground truthで決めるべきである。
-
-## 再現方法
-
-最小の再現手順は次でよい。
-
-1. repositoryで絶対にblockしたいtype failureを1 root faultずつfixture化する。
-2. 各mutantに対応するclean baselineを保存する。
-3. tool versionだけでなくpreset/mode/configをpinする。
-4. cleanとmutantを同じexecution contractで実行する。
-5. `clean=pass && mutant=block` のときだけ検出creditを与える。
-6. presetを変える場合は同じcorpusで再実行し、製品差と設定差を分離する。
-7. survivorだけを速度やmigration costへ進める。
-
-## 結論
-
-型チェッカーの名前はauthorityではない。**versionと設定を含む実行契約がauthorityである。**
-
-今回、Pyrefly 1.2.0はbasic presetで2/5、default presetで5/5だった。この差を無視して「Pyreflyは2/5だった」と書けば、設定差を製品差に変換してしまう。
-
-新しい型チェッカーを評価するとき、最初に比較表を作る必要はない。
-
-まず、何をblockする権限を与えたいかをground truthにする。その次に、実際にその権限を行使する**設定込みのexecution contract**を固定する。
-
-製品比較は、その後でいい。
+最初に固定すべきなのは、**その製品に実際どの判定権限を与えたのか**である。


### PR DESCRIPTION
## Outcome
直近5記事を `AGENTS.md` の `Broad door -> Original insight -> Concrete proof -> Useful exit` に合わせて全面改稿する。

## Rewrites
- Claude Code: AI一般論ではなく「合格条件をagentの外側に固定する」という読者jobへ集中
- type checker config: 製品比較ではなく「設定差を製品差と誤認しない」再現可能な失敗へ集中
- runtime validation: authority taxonomyより「外部入力をどこで止めるか」という実装判断へ集中
- affected set: monorepo tool比較より「CI高速化で必要なtestを落とさない」という損失回避へ集中
- compiler replacement: 2/2比較より「古いCI gateをいつ安全に削除できるか」というmigration判断へ集中

既にsupersedeされた `stable-is-not-correctness-proof` はmain上で削除済みのため再作成しない。

既存のpublication stateは変更しない。Claude Code記事の `published: true` / `published_at` は維持し、他4記事は `published: false` のまま。