### PR TITLE
rewrite: 直近5記事をreader job中心へ再整理

### DIFF
--- a/articles/2026-08-15-affected-set-is-a-contract.md
+++ b/articles/2026-08-15-affected-set-is-a-contract.md
@@ -6,47 +6,43 @@ topics: ["monorepo", "ci", "nx", "turborepo", "testing"]
 published: false
 ---
 
-CI短縮で最初に見るべきなのは秒数ではない。
+CIを30秒短くしても、必要なtestを1つ落としたら改善ではない。
 
-**変更したとき、本当に実行すべきprojectを落としていないか**である。
+ところがaffected executionでは、対象を減らすほど時間は短くなる。誤判定まで「高速化」に見えるのが怖い。
 
-affected executionは強力だが、対象集合を間違えると「速くなった」のではなく「必要な検証を飛ばした」だけでもgreenになる。
-
-今回、toolを選ぶ前にrepository側の期待affected setを固定した。
+そこでtoolを選ぶ前に、repository側で「この変更なら、何を必ず実行するか」を3ケースだけ固定した。
 
 - `core`変更 → `core`, `ui`, `web`, `api`
 - `ui`変更 → `ui`, `web`
 - `docs`変更 → `docs`
 
-この3ケースをground truthとして、orchestratorの出力を照合した。
+Nxのproject-level affected setは、この3/3でground truthと一致した。
 
-## 速さより先に集合を固定する理由
+この記事の結論はNx推奨ではない。**CI時間を測る前に、落としてはいけない実行対象をfixture化する**という導入順序だ。
 
-CI時間は観測しやすい。一方、false negativeは見えにくい。
+## なぜ秒数を最初に見ると危ないのか
 
 ```text
 変更
   ↓
 affected判定を誤る
   ↓
-必要なtest/buildを実行しない
+必要なtest/buildを飛ばす
   ↓
-CIは速くgreenになる
+CI時間は短くなる
+  ↓
+greenなので成功に見える
 ```
 
-最悪なのは、性能改善として成功に見えることだ。
+速度だけでは、正しく省略したのか、誤って省略したのかを区別できない。
 
-だから先に次のcontractを作る。
+だから先に次をrepository contractにする。
 
 ```text
 f(change) -> expected projects
 ```
 
-代表caseが3件でも、速度benchmarkより先に「落としてはいけない対象」を検証できる。
-
-## 今回の観測
-
-Nxの`nx show projects --affected`は、固定した3 caseでproject-level ground truthと一致した。
+## 今回の3ケース
 
 | change | expected | Nx observed |
 |---|---|---|
@@ -57,49 +53,17 @@ Nxの`nx show projects --affected`は、固定した3 caseでproject-level groun
 raw evidence:
 https://github.com/KAFKA2306/articles/blob/f7368d064d1840a5f66d92563d16deaabb5b3285/benchmarks/verification-stack-v2/results/controlled/workspace.json
 
-Nx公式はaffected計算を、Gitで変更fileを特定し、project graphから影響projectを求める仕組みとして説明している。
+Nx公式も、affectedはGitでchanged filesを求め、project graphから所属projectとdependent projectを導くと説明している。
 
 https://nx.dev/docs/features/ci-features/affected
 
-一方、今回Turborepoで観測した`turbo run build --affected --dry=json`はbuild task planだった。project集合そのものとtask planを同じaccuracy metricへ押し込むと比較を壊す。
+## Turborepoと勝敗を付けなかった理由
+
+同じ実験ではTurborepoの`turbo run build --affected --dry=json`も観測した。ただしこちらはbuild task planで、Nxで見たproject集合と同じ出力surfaceではなかった。
 
 https://turborepo.com/docs/crafting-your-repository/constructing-ci
 
-## ここで製品ランキングをしない
-
-同じartifactにはelapsed timeも残っている。しかし「NxよりTurborepoが何倍速い」のようなheadlineには使わなかった。
-
-理由は簡単だ。
-
-- 観測したcommandの責務が違う
-- paired timingではない
-- 正しさを満たしていない候補の速さは意味がない
-
-速度は、**同じ責務を正しく満たしたsurvivor同士**で初めて比較する。
-
-## 壊れた導入順序
-
-```text
-1. fastest toolを選ぶ
-2. affectedを有効化
-3. CIが短くなったので成功
-```
-
-この順序では、何を落としてはいけないかが未定義である。
-
-## 改善した導入順序
-
-```text
-1. dependency graphから代表変更caseを選ぶ
-2. expected affected setをrepoに固定する
-3. candidate toolの出力を照合する
-4. false negativeがない候補だけ残す
-5. その後に速度・cache・運用costを測る
-```
-
-## 読者が最初に区別する5つ
-
-monorepo高速化では、次を同じものとして扱わない。
+同じ「affected」という言葉でも、次は別物だ。
 
 - changed files
 - affected projects
@@ -107,24 +71,57 @@ monorepo高速化では、次を同じものとして扱わない。
 - task cache
 - architecture boundaries
 
-必要なのがbuild/test taskの絞り込みだけなら、project-level architecture authorityまで追加する必要はない。逆にimpact analysisを人間の判断にも使うなら、project集合を直接観測できるsurfaceが重要になる。
+違う対象を同じaccuracy表へ押し込むと、製品ランキングは作れても意思決定は弱くなる。
 
-## 最小の再現方法
+## 導入順序を逆にする
 
-自分のrepoで3ケース作ればよい。
+壊れやすい順序:
 
-1. shared/core packageを変更する
-2. leafに近いpackageを変更する
-3. 独立package/docsを変更する
+```text
+1. 速そうなtoolを選ぶ
+2. affectedを有効化
+3. CIが短くなったので成功
+```
 
-各ケースで「絶対に含む」「絶対に含まない」projectを先に書く。その後でNx、Turborepo、独自scriptなど候補の出力を照合する。
+改善後:
+
+```text
+1. shared/core変更の期待集合を書く
+2. leaf変更の期待集合を書く
+3. 独立docs/package変更の期待集合を書く
+4. candidateの出力を照合する
+5. false negativeがない候補だけ残す
+6. その後に速度・cache・運用costを測る
+```
+
+## 同等なら、最後は小さい構成を選ぶ
+
+correctness、必要機能、運用性、UI/UXが同等まで揃った候補なら、次は少ない方がよい。
+
+- CI command数
+- config file数
+- dependency数
+- custom scriptのLOC / file数
+- 二重に存在する判定authority
+
+ただし、これは最後のtie-breakerだ。必要なtestを落として作った「小さいCI」は最適化ではない。
+
+## 自分のrepoで10分で試す
+
+代表変更を3つ選び、各ケースで次を1行ずつ書く。
+
+```text
+change: packages/core/**
+must_include: core, ui, web, api
+must_exclude: docs
+```
+
+その後、Nx、Turborepo、独自scriptなど実際に使いたいsurfaceを実行し、期待集合との差を見る。速度計測は一致した候補だけで行う。
 
 ## 証拠の境界
 
-今回のfixtureだけからNxが一般にTurborepoより正確とも、Turborepoが一般に速いとも言えない。real repositoryで同じ差が再現することも証明していない。
+今回の3ケースから、Nxが一般にTurborepoより正確とも、Turborepoが一般に速いとも言えない。real repositoryで同じ差が出ることも証明していない。
 
-ただし、CI高速化の評価順序は変えられる。
+変えられるのは評価順序だ。
 
-**秒数を測る前に、実行対象集合をrepositoryのcontractとして固定する。**
-
-CIが速くなったとき、「必要なものを落とさず速くなった」と言えるようにするためだ。
+**CI高速化では、秒数より先に「何を落としてはいけないか」を固定する。速さは、その契約を守った候補同士で比べる。**

--- a/articles/2026-08-15-hook-runner-is-not-policy.md
+++ b/articles/2026-08-15-hook-runner-is-not-policy.md
@@ -1,5 +1,5 @@
 ---
-title: "Claude Codeにテストを全部任せるなら、先に「合格条件」を固定する"
+title: "AIにテストまで任せるなら、合格条件だけは外に置く"
 emoji: "🧪"
 type: "tech"
 topics: ["claudecode", "testing", "ai", "ci", "automation"]
@@ -7,117 +7,87 @@ published: true
 published_at: 2026-08-15 09:33
 ---
 
-AIに実装もテストも修正も任せられるようになると、最後に残る人間の仕事は「全部を見ること」ではない。
+Claude Codeに実装、テスト追加、失敗修正まで任せると、レビュー時間は減らせる。そこで最後まで人間が全部を見る設計に戻すと、自動化の価値が消える。
 
-**何を満たせば合格なのかを、実装するagentの外側に固定すること**だ。
+必要なのは監視を増やすことではない。**何を満たせば合格かを、実装するagentとは別に再実行できる形で固定すること**だ。
 
-Claude Codeの公式ドキュメントは、コードを読み、編集し、commandやtestを実行して検証できるagentic coding toolとして説明している。また、Claudeが自分の仕事を検証できるよう、test caseや期待出力のような「照合対象」を与えることを勧めている。
-
-- https://code.claude.com/docs/en/overview
-- https://code.claude.com/docs/en/how-claude-code-works
-
-ここで実務上の落とし穴がある。同じagentがproduction code、test、fixture、configのすべてを変更できると、greenは「実装を直した」だけでなく「合格条件を弱めた」ことでも作れてしまう。
-
-## 問題はAIではなく、oracleまで同じ変更scopeに入ること
-
-たとえば次の依頼は便利だ。
-
-```text
-この機能を実装して。
-必要なテストも追加して。
-失敗したら直して。
-全部通ったら終わり。
-```
-
-しかし、この依頼には4つの別問題が混ざっている。
-
-1. 何を作るか
-2. 何を合格とするか
-3. どう直すか
-4. 何を証拠として残すか
-
-3をagentへ強く委譲しても、2までその場の最適化対象にすると完了判定が弱くなる。
-
-## 実務では4層に分ける
-
-```text
-Outcome / Contract
-  何を実現し、何を壊してはいけないか
-        ↓
-Policy / Oracle
-  tests / schema / invariants / required checks
-        ↓
-Execution
-  Claude Code / hooks / CI / runner
-        ↓
-Evidence
-  test result / diff / artifact / exact-head CI
-```
-
-Claude CodeはExecutionを強くする。だがExecutionが強いこととPolicyが正しいことは別だ。
-
-Claude Code Hooksも、LLMが実行を選ぶことに依存しないdeterministic controlとして公式に説明されている。`TaskCompleted` hookでtest suiteを走らせ、失敗時に完了扱いを止める例もある。
+Anthropic公式も、Claude Code Hooksを「LLMが実行を選ぶことに依存しないdeterministic control」と説明し、project rulesの強制やテスト実行に使えるとしている。
 
 - https://code.claude.com/docs/en/hooks-guide
 - https://code.claude.com/docs/en/hooks
 
-## 何をrepo側へ固定するか
+## 私が変えたのは、agentではなく合格条件の置き場所だった
 
-最低限、次はagentのその場の判断から独立させる。
-
-- 必須test suite
-- acceptance criteria
-- schema / invariant
-- 変更してはいけないartifact
-- testを弱める変更のreview条件
-- mergeをblockする条件
-
-そして可能なら1 commandにまとめる。
-
-```bash
-./scripts/verify
-```
-
-Claude CodeにもlocalにもCIにも同じcommandを実行させる。これで「Claudeが大丈夫と言った」ではなく、**同じ合格条件を別主体でも再実行できる**状態になる。
-
-## 壊れた例
+危ないのはAIそのものではない。production code、test、fixture、config、完了判定を同じ変更ループへ全部入れることだ。
 
 ```text
 agent: 実装
 agent: test追加
 agent: test失敗
-agent: fixtureを簡略化
+agent: fixture/configも変更
 agent: green
 ```
 
-greenは事実でも、最初の期待を満たした証拠とは限らない。
+このgreenだけでは、「実装が要件へ近づいた」のか「要件側が動いた」のかを区別しにくい。
 
-## 改善後
+そこで作業を3つに分ける。
 
 ```text
-人間/repo: acceptance criteria固定
-agent: 実装・test追加・修正
-CI: 固定verifyをexact headで再実行
+1. Contract
+   何を実現し、何を壊してはいけないか
+
+2. Verifier
+   tests / schema / invariant / required checks
+
+3. Worker
+   Claude Codeが実装・修正・反復実行する
 ```
 
-agentは速く回し、人間は毎回すべてを手作業で確認しない。代わりに、**完了条件の所有者を分ける**。
+Workerは何度でも変えてよい。ContractとVerifierは、変更するならその変更自体をレビュー対象にする。
 
-## 読者向けチェックリスト
+## 実運用では、同じverifyをagentとCIの両方から呼ぶ
 
-Claude Codeへテスト自動化を委譲する前に、次の5問だけ確認すればよい。
+この`articles` repositoryでも、PRのArticle Pipeline CIはcompile、contract tests、publication transition guard、Zenn render、privacy audit、clean checkoutをrepository側に固定している。
 
-1. 合格条件はコードと同じagentが自由に弱められるか
-2. 必須checkは1 commandで再実行できるか
-3. test/fixture/config変更もdiffでreview対象になるか
-4. CIはexact headで同じ条件を再実行するか
-5. greenが「何を証明したか」を説明できるか
+https://github.com/KAFKA2306/articles/blob/main/.github/workflows/article-pipeline-ci.yml
 
-1がyesで、残りがnoなら、委譲範囲より先にoracleを固定した方がよい。
+Claude Codeが何を実装したかに関係なく、CIは同じ条件をもう一度実行する。この構造なら「Claudeが大丈夫と言った」ではなく、**別主体が同じ合格条件を再実行した**と言える。
 
-## 証拠の境界
+自分のrepoでも、入口を1 commandへ寄せると扱いやすい。
 
-この記事は「Claude Codeがtestを改ざんする」と主張していない。主張しているのは、**最適化する主体と合格条件を変更できる主体を同一scopeに置くと、完了判定の独立性が弱くなる**という設計上の事実だ。
+```bash
+./scripts/verify
+```
 
-AI coding agentを信用するかどうかではない。速いagentほど、合格条件を外側へ固定した方が委譲できる範囲が広がる。
+中身はprojectごとに違ってよい。重要なのは、Claude Code、ローカル、CIで同じ判定を呼べることだ。
 
-**AIに多く任せたいなら、人間が多く確認するのではなく、合格条件を先に固定する。**
+## 何をagentの外へ残すか
+
+最低限、次の4つは明文化する。
+
+1. **acceptance criteria** — 何ができれば完了か
+2. **must-pass checks** — 必ず通すtest/schema/invariant
+3. **protected assumptions** — fixtureや期待値を変えるならreviewが必要なもの
+4. **merge condition** — どの結果をもって終了とするか
+
+これらを固定したうえで、実装・テスト追加・failure解析・再修正は積極的にagentへ渡す。
+
+## 5分でできる導入チェック
+
+Claude Codeへ「全部通るまで直して」と頼む前に、次だけ確認する。
+
+- 必須checkを1 commandで再実行できる
+- test/fixture/configの変更もdiffに出る
+- acceptance criteriaがpromptだけでなくrepoにも残る
+- CIがPRのexact headで同じverifyを実行する
+- greenが何を証明したか1文で説明できる
+
+この5つが揃えば、人間は全diffを逐語監視するのではなく、**合格条件の変更と最終証拠に集中できる**。
+
+## この記事が言っていないこと
+
+Claude Codeがtestを勝手に弱める、と主張しているわけではない。またHooksだけで品質が保証されるとも言っていない。
+
+言いたいのは、実装主体が高速になるほど、完了条件を独立して再実行できる設計の価値が上がるということだ。
+
+**AIにもっと任せたいなら、人間の監視量を増やすのではなく、合格条件を先に外へ出す。**

--- a/articles/2026-08-15-runtime-validation-boundary.md
+++ b/articles/2026-08-15-runtime-validation-boundary.md
@@ -1,125 +1,112 @@
 ---
-title: "型チェックが通っても、外部入力は安全にならない"
+title: "型チェックが通っても、APIの入力はまだ信用できない"
 emoji: "🚧"
 type: "tech"
 topics: ["python", "typescript", "pydantic", "zod", "testing"]
 published: false
 ---
 
-CIで型チェックがgreenでも、API、JSON、環境変数、ファイルから来る値まで安全になったわけではない。
+API、JSON、環境変数、ファイル入力を扱うコードで型チェックがgreenになると、入力まで安全になったように感じる。
 
-今回、PythonとTypeScriptで外部入力のfailureを1件ずつ固定し、static checkとruntime validationを分けて観測した。PydanticとZodは各runtime mutantを拒否し、validationなしのcontrol pathは拒否しなかった。
+しかし外から届く値は、実行時に初めて存在する。
 
-ここから得た実務上の結論は、製品選びではない。
+今回、PythonとTypeScriptでruntime-boundary faultを1件ずつ固定したところ、validationなしのcontrol pathは両方とも通過し、Pydantic/Zodを置いたpathだけが不正値を拒否した。
 
-> **外部入力は、runtime boundaryで最後に検証する。**
+読者が持ち帰る判断は1つでよい。
 
-## どこで事故が起きるのか
+**外部値は、business logicへ渡す直前ではなく、入ってきた境界で`unknown → validated value`へ変換する。**
 
-典型例はこれだ。
+## 何が実際に起きたか
 
-```text
-HTTP / JSON / env / file
-        ↓
-アプリ内部の型付きコード
-```
+固定fixtureでは次の2ケースだけを測った。
 
-内部コードが型安全でも、境界から入る値は実行時にしか存在しない。
-
-TypeScript公式は、compile後にtype annotationをeraseしてJavaScriptを生成すると説明している。
-
-https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html
-
-つまり`unknown`を正しく扱うことと、その値をruntimeで検証することは別である。
-
-Zodはruntime schema validationを提供する。
-
-https://zod.dev/
-
-Pythonでも同じ分離がある。PyreflyはPydantic v2を静的解析できるが、Pydantic自身のruntime validationとは別の責務だ。
-
-https://pyrefly.org/en/docs/pydantic/
-https://docs.pydantic.dev/latest/concepts/validation_decorator/
-
-## 固定fixtureで何が起きたか
-
-今回のcontrolled fixtureでは次の2ケースだけを扱った。
-
-- Python: staticに受理可能だがruntime contractへ違反する外部値
-- TypeScript: compile可能な`unknown` payloadだがruntime schemaへ違反する値
-
-結果は次だった。
-
-| language | runtime validator | fixed runtime fault | unvalidated control |
-|---|---|---:|---:|
+| language | runtime validator | invalid input | validationなし |
+|---|---|---|---|
 | Python | Pydantic | reject | accept |
 | TypeScript | Zod | reject | accept |
 
-summary:
+raw summary:
 https://github.com/KAFKA2306/articles/blob/4c111d27ea193a72238d5ee97d145770cec2109e/benchmarks/verification-stack-v2/results/controlled/summary.json
 
-各言語1件なので「accuracy 100%」とは言わない。実証したのは、**static passでは止まらず、runtime contractで初めて止められるfailure classが両fixtureに存在した**ことだけだ。
+各言語1件なので、Pydantic/Zodのaccuracyを100%と呼ぶ証拠ではない。確認できたのは、**static checkだけでは止まらずruntime validationで初めて止まるfailure classが両fixtureにあった**ことだ。
 
-## 壊れた設計
+## なぜ型注釈だけでは足りないのか
+
+TypeScript公式は、compile後に型をeraseしてJavaScriptを生成し、型によってruntime behaviorを変えないと説明している。
+
+https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html
+
+Zodは`parse` / `safeParse`で実際の値をschemaへ照合する。
+
+https://zod.dev/basics
+
+PythonでもPydanticの`validate_call()`は、function call前に実際の引数をparse/validateする。
+
+https://docs.pydantic.dev/latest/concepts/validation_decorator/
+
+つまり、static checkerとruntime validatorは代替関係ではない。
+
+```text
+external value
+    ↓
+runtime validation
+    ↓
+validated value
+    ↓
+typed application code
+```
+
+## 置く場所を迷ったら「最初の信用境界」を探す
+
+runtime validationを置く候補は、外部世界から値が入る場所だ。
+
+- HTTP request / webhook
+- environment variables
+- JSON / CSV / config file
+- message queue
+- LLM structured output
+
+内部の深い関数で毎回validateする必要はない。**境界で1回、明示的に信用できる値へ変える**方が、失敗箇所と責務を狭くできる。
+
+## 壊れた形と改善後
+
+壊れやすい形:
 
 ```text
 request.json()
   ↓
 型注釈を付ける
   ↓
-そのままbusiness logicへ渡す
+business logic
 ```
 
-型注釈は入力値そのものを検証しない。
-
-## 改善後
+改善後:
 
 ```text
-external input
+request.json()
   ↓
-runtime schema / parser
+schema.parse / model validation
   ↓
 validated value
   ↓
-application code + static type checker
+business logic
 ```
 
-ここでruntime validatorとtype checkerは競合しない。
+## 導入するときの6問
 
-- static checker: コード上の型整合性
-- runtime validator: 実際に到着した値のcontract
+1. 外部から値が入る入口はどこか
+2. 入口では値を`unknown`相当として扱っているか
+3. schema/modelは境界直後にあるか
+4. validation後の値だけを内部へ渡しているか
+5. invalid payloadのregression testが最低1件あるか
+6. static checkerがgreenでも、そのruntime testを削除していないか
 
-## どこに置くべきか
-
-外部入力の直後に置く。
-
-対象は最低でも次だ。
-
-- HTTP request body
-- webhook payload
-- environment variables
-- config file
-- CSV / JSON import
-- message queue payload
-- LLM structured output
-
-内部処理の奥深くでvalidationするより、境界直後でunknownをvalidated valueへ変換する方がfailure locationを狭くできる。
-
-## 読者向けチェックリスト
-
-1. 外部から入る値を列挙する
-2. 各入力が最初に`unknown`として扱われる場所を探す
-3. runtime schemaを境界直後に置く
-4. validation後の型だけを内部へ渡す
-5. invalid payloadのtestを1件以上固定する
-6. static checkerがgreenでもruntime boundary testを削除しない
+この6問で、型チェックと入力検証を同じ「型安全」という言葉に潰さずに済む。
 
 ## 証拠の境界
 
-この記事は「Pydantic/Zodがすべての入力事故を防ぐ」とは言わない。今回測ったruntime mutantは各言語1件だけで、schema designの完全性も測っていない。
+この記事は、Pydantic/Zodがすべての入力事故を防ぐとは主張しない。schema自体が間違っていればvalidationも間違うし、今回測ったfaultは各言語1件だけだ。
 
-言えるのはもっと実務的なことだ。
+それでも運用判断は変えられる。
 
-**型チェックのgreenを、外部入力のvalidation済みと読み替えない。**
-
-外から来る値には、実際の値を判定するruntime authorityを置く。
+**型チェックのgreenを「外部入力も検証済み」と読み替えない。外から来る値は、最初の信用境界で実際の値を検証する。**

--- a/articles/2026-08-15-two-of-two-is-not-compiler-authority.md
+++ b/articles/2026-08-15-two-of-two-is-not-compiler-authority.md
@@ -1,34 +1,14 @@
 ---
-title: "公式が『tscを置き換えられる』と言っても、CI gateはまだ消せない"
+title: "CIを1コマンドに減らす前に、古いgateの削除条件を書く"
 emoji: "🧪"
 type: "tech"
 topics: ["typescript", "oxlint", "ci", "testing", "tooling"]
 published: false
 ---
 
-CIのtoolを統合するとき、難しいのは新しいcommandを足すことではない。**古いgateを安全に消せるか判断すること**だ。
+同じ機能、同じ品質、同じ運用性なら、CI commandもconfigもdependencyも少ない方がよい。
 
-2026年8月15日時点のOxlint公式ドキュメントには、`--type-aware --type-check`について、独立した`tsc --noEmit` stepを置き換えられると書かれている。
-
-https://oxc.rs/docs/guide/usage/linter/type-aware
-
-ところが同じ公式ドキュメント群は、`options.typeCheck`を**experimental type checking**とも明記している。
-
-https://oxc.rs/docs/guide/usage/linter/config-file-reference
-
-では、既存の`tsc --noEmit`をいつ削除してよいのか。
-
-私は先に固定したTypeScriptの型failure 2件で、`tsc`とOxlint `typeCheck`を同じground truthへ当てた。結果は両方2/2、clean baselineのblocking false positiveも0だった。
-
-それでも`tsc`削除を結論にしなかった。
-
-この小さな実験で見えたのは、**correctness parityはreplacement authorizationではない**ということだった。
-
-## 最初の予想は「同点なら統合候補」だった
-
-modern toolchainでは、1つのbinaryがlint、type-aware lint、compiler diagnosticsまで持つようになっている。Oxlintも現在、通常lintとは別に`--type-aware`と`--type-check`を提供している。
-
-移行案は自然にこう見える。
+だから、
 
 ```text
 before
@@ -39,162 +19,98 @@ after
   oxlint --type-aware --type-check
 ```
 
-commandが1本減り、CI設定も単純になる。
+のように **2 command → 1 command（-50%）** へ減らせるなら魅力がある。
 
-だから最初に確認したのは「新しいsurfaceが、既存compiler gateで止めていた既知failureを止められるか」だった。
-
-## 2つのroot faultでは、両方2/2だった
-
-比較前にmutantを固定し、1 mutant = 1 root faultとして数えた。raw diagnostic数はdefect数として合算していない。
-
-| candidate | in-scope type mutants | detected | clean blocking FP |
-|---|---:|---:|---:|
-| `tsc` | 2 | 2 | 0 |
-| Oxlint `typeCheck` | 2 | 2 | 0 |
-
-controlled summary:
-https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/controlled/summary.json
-
-protocol:
-https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/PROTOCOL.md
-
-この結果から言えるのは狭い。
-
-- 固定した2つの型failureは両方が検出した
-- clean baselineでは両方ともblocking false positiveが0だった
-- 少なくともこのcorpusではOxlint `typeCheck`を「型failureを検出できない」とは言えない
-
-逆に、**TypeScript compiler conformance全体が同等**とは言えない。2 mutantを全言語機能へ外挿する証拠はない。
-
-## ここで公式仕様が判断を難しくする
-
-TypeScriptの`noEmit`は、JavaScript等を出力せずにtype checkingを行う用途を公式に持つ。
-
-https://www.typescriptlang.org/tsconfig/noEmit.html
-
-Oxlintの現行公式ドキュメントは、type-aware lintingとtype checkingを分けている。`--type-aware`は型情報を必要とするlint ruleを有効にし、`--type-check`はTypeScript compiler diagnosticsを追加する。
+Oxlint公式も現在、`--type-aware --type-check`で独立した`tsc --noEmit` stepを置換できる例を示している。
 
 https://oxc.rs/docs/guide/usage/linter/type-aware
 
-そして同じページは、`--type-aware --type-check`によって独立した`tsc --noEmit` stepを置き換える例を示す。一方、configuration referenceとCLI referenceでは`--type-check` / `options.typeCheck`をexperimentalと明記している。
+ただし、私は今回`tsc`を消さなかった。
 
-https://oxc.rs/docs/guide/usage/linter/config-file-reference
-https://oxc.rs/docs/guide/usage/linter/cli.html
+固定した型failure 2件では両者とも **2/2**、clean blocking false positiveも **0** だった一方、frozen real repoではOxlint `--type-check`そのものが **NOT_RUN** だったからだ。
 
-これは矛盾として処理する必要はない。
+**小さくするのは正しい。ただし「同等」を確認してから削る。**
 
-「置換できる」はcapabilityの説明であり、「自分のrepositoryでdefault blocking authorityとして今すぐ置換してよい」はadoption decisionだからだ。
+## controlled fixtureでは同点だった
 
-## real repoで未実行なら、2/2を削除許可へ昇格しない
+| candidate | fixed type faults | detected | clean blocking FP |
+|---|---:|---:|---:|
+| `tsc` | 2 | 2/2 | 0 |
+| Oxlint `typeCheck` | 2 | 2/2 | 0 |
 
-このbenchmarkにはfrozen real-repository probeもある。ただしreal repoは完全なdefect ground truthがないため、recallやfalse-positive rateの証明には使っていない。見るのはexecution compatibility、diagnosticの実用性、latency、migration frictionなどである。
+controlled evidence:
+https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/controlled/summary.json
 
-external summary:
+この2件については、Oxlint `typeCheck`を「検出できないから残せない」とは言えない。
+
+一方で、2件はTypeScript全体のconformanceではない。correctness parityの小さな証拠を、そのままreplacement authorizationへ昇格させることもできない。
+
+## 公式の「置換できる」と、自分のrepoで「消してよい」は別
+
+Oxlint公式はtype checkingを提供し、独立した`tsc --noEmit`を置換できる例を示す。一方、CLI/config referenceでは`--type-check` / `options.typeCheck`を**experimental type checking**と明記している。
+
+- https://oxc.rs/docs/guide/usage/linter/type-aware
+- https://oxc.rs/docs/guide/usage/linter/cli.html
+- https://oxc.rs/docs/guide/usage/linter/config-file-reference
+
+TypeScript側では`noEmit`が、出力せずtype checkingする公式surfaceとして存在する。
+
+https://www.typescriptlang.org/tsconfig/noEmit.html
+
+つまりcapabilityは確認できても、自分のrepoのrequired surfaceまで同等かは別に確認する必要がある。
+
+## 今回止めたのはreal-repoの空欄だった
+
+frozen real-repository evidenceでは、`tsc`と通常のOxlintは観測済みだったが、replacementで使いたいOxlint `--type-check`自体は **NOT_RUN** だった。
+
 https://github.com/KAFKA2306/articles/blob/81848adca34e077835735a1f8586c6e8cd8cd511/benchmarks/verification-stack-v2/results/external/summary.json
 
-ここで重要なのは、frozen probeでは`tsc`と通常の`oxlint`は実行したが、**Oxlint `--type-check`そのものはexternal-validity未検証**だったことだ。
-
-したがって証拠はこう分かれる。
-
 ```text
-controlled correctness
-  Oxlint typeCheck: 2/2
+controlled fixture
   tsc:              2/2
+  Oxlint typeCheck: 2/2
 
-real-repo compatibility
+real repo / same surface
   tsc:              observed
   Oxlint typeCheck: NOT_RUN
 ```
 
-`NOT_RUN`をPASSへ読み替えない限り、ここから`tsc`削除までは進めない。
+この状態で2→1へ削ると、「同等だから簡素化した」ではなく「未確認のsurfaceへauthorityを移した」になる。
 
-## 同じ証拠から3つの物語を潰す
+## 削除条件を先に6つ書く
 
-### 1. 「Oxlint typeCheckは不正確だからtscを残す」
+新toolを追加する前に、旧gateを削除できる条件を決めておく。
 
-棄却した。
+1. **同じ責務** — 旧gateが担うfailure classを公式に持つ
+2. **fixed correctness** — repoで重要なfaultをclean baseline付きで通す
+3. **real-repo parity** — replacementに使う同じsurfaceを実repoで走らせる
+4. **config coverage** — 必要なtsconfig / diagnostic surfaceの欠落がない
+5. **stability acceptance** — feature statusをblocking authorityとして受け入れられる
+6. **actual deletion** — 条件達成後は旧gateを消し、二重authorityを常設しない
 
-今回の固定2 mutantでは2/2だった。不正確さを示す観測ではない。
+6まで行って初めて、tool consolidationがtool accumulationではなくなる。
 
-### 2. 「公式がreplacement例を出していて2/2だからtscを消す」
+## 同等になった後のtie-breaker
 
-棄却した。
+機能、correctness、UI/UX、運用性が同等なら、私は次を小さい方へ寄せる。
 
-2件はcompiler conformance全体ではなく、real repoでは`--type-check`自体がNOT_RUNで、公式statusもexperimentalである。capability確認とdefault-authority移行を混同している。
+| metric | prefer |
+|---|---|
+| CI commands | fewer |
+| config files | fewer |
+| dependencies | fewer |
+| custom LOC | fewer |
+| files | fewer |
+| duplicate authorities | fewer |
 
-### 3. 「旧gate削除には、parityとは別のreplacement contractが要る」
+今回の候補ならcommand数は **2 → 1** にできる可能性がある。しかしreal-repo `--type-check`が **NOT_RUN → NOT_RUN** のままなので、削減はまだ実行しない。
 
-これだけが残る。
+小ささは重要な設計品質だ。ただし、小さくするために未確認をPASSへ変換しない。
 
-この命題なら、今回の2/2、external-validityの空欄、現行公式statusを同時に説明できる。
+## この記事が言っていないこと
 
-## migrationは「追加」ではなく「削除条件」を先に書く
+Oxlint `typeCheck`が不正確だとは言っていない。今回の2 faultでは2/2だった。また、将来もexperimentalのままだとも言っていない。
 
-新tool導入時にありがちな順序はこうだ。
+反転条件は明確だ。real repoで同じsurfaceを実行し、必要なconfig/diagnostic coverageとstability条件を満たせば、`tsc --noEmit`削除を再評価できる。
 
-```text
-1. new toolを追加
-2. CIがgreen
-3. しばらく二重実行
-4. いつ消せるか分からず両方残る
-```
-
-これではtool consolidationがtool accumulationになる。
-
-先にreplacement contractを書く。
-
-```text
-1. 旧gateが所有するfailure classを列挙
-2. clean baseline + 固定mutantでchallengerを照合
-3. real repoでchallengerの同じsurfaceを実行
-4. 必要なconfig / diagnostic surfaceを照合
-5. stability boundaryを受け入れられるか決める
-6. 全条件PASSなら旧gateを削除
-```
-
-ポイントは、**新toolを採用できる条件ではなく、旧toolを削除できる条件**を定義することだ。
-
-## 6問だけ持ち帰ればよい
-
-既存CI gateを消す前に、次を確認する。
-
-1. 新toolの公式責務は旧gateと本当に同じか
-2. repo固有の重要failureをclean baseline付きで通したか
-3. real repoでreplacementに使う**同じsurface**を実行したか
-4. 必要なconfig / diagnostic / language surfaceに欠落はないか
-5. feature statusはdefault blocking authorityとして受け入れられるか
-6. 条件を満たしたら二重authorityを残さず旧gateを削除できるか
-
-この6問はOxlint固有ではない。formatter、linter、type checker、hook runner、workspace orchestratorを統合するときにも使える。
-
-たとえばRuffはformatterとlinterを同じCLIに持つが、公式にも両者は独立して利用でき、formatterはimport sortingを行わない。binaryが同じでもauthority surfaceは同じではない。
-
-https://docs.astral.sh/ruff/formatter/
-https://docs.astral.sh/ruff/linter/
-
-同様に、TypeScriptの型はcompile後にeraseされ、runtime behaviorを型によって変えない。compiler gateを統合しても、外部入力のruntime validationまで消えるわけではない。
-
-https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html
-https://zod.dev/
-
-## 何を測っていないか
-
-この記事は次を証明していない。
-
-- Oxlint `typeCheck`と`tsc`の一般的なaccuracy parity
-- 全`tsconfig` option / TypeScript language featureのcompatibility
-- Oxlint `typeCheck`のreal-repo compatibility
-- repo-local cold/warm timingの優劣
-- Oxlintが将来もexperimentalであること
-
-特に最後は変わり得る。Oxlint公式がtype checkingをstableなdefault-authority候補へ昇格し、重要failure corpusとreal-repo probeで同じsurfaceが通れば、この記事の「今は`tsc`を消さない」という判断は反転する。
-
-## 結論
-
-今回、Oxlint `typeCheck`は固定2 mutantで`tsc`と同じ2/2だった。だから「新しいtoolだから信用しない」という結論にはしない。
-
-一方、公式がreplacement例を示していても、experimental statusとreal-repo NOT_RUNを無視して旧gateを削除する根拠にもならない。
-
-**parityはchallengerになる条件であって、authorityを移す許可ではない。**
-
-CIを統合するときは「何を追加するか」より先に、「何が確認できたら古いgateを消すか」を契約にする。そうすれば、toolchainを安全に減らせる。
+**同じ価値を出せるなら、コードも設定もcommandも少ない方がよい。そのために必要なのは、新toolの採用条件ではなく、古いgateを安全に削除できる条件である。**

--- a/articles/2026-08-15-type-checker-config-is-authority.md
+++ b/articles/2026-08-15-type-checker-config-is-authority.md
@@ -1,56 +1,24 @@
 ---
-title: "型チェッカー比較で先に固定すべきなのは、製品名ではなく設定"
+title: "型チェッカーを変える前に、設定差を製品差から消す"
 emoji: "🧪"
 type: "tech"
 topics: ["python", "typechecking", "ci", "testing", "developerexperience"]
 published: false
 ---
 
-型チェッカーを比較して「Aは5件中2件、Bは5件中5件だった」と出たら、製品差だと思いたくなる。
+新しい型チェッカーを試して「Aは2/5、Bは5/5」と出たら、Bへ移行したくなる。
 
-今回、それを誤った。
+私はそこで一度、結論を間違えた。
 
-同じPyrefly 1.2.0、同じ5つのroot faultでも、`basic` presetでは2/5、`default` presetでは5/5だった。つまり最初に見えていた差の一部は、**製品差ではなく実行設定の差**だった。
+同じPyrefly 1.2.0、同じ5つのroot faultでも、`basic` presetでは **2/5**、`default` presetでは **5/5** だった。製品を変えなくても、設定だけで結果が3件動いた。
 
-この失敗から得た実務上の結論は単純だ。
+だから比較表を作る前にやることがある。
 
-> 型チェッカーを比較する前に、version・preset・config・scope・severityを固定する。
+**version・preset・config・scope・blocking severityを固定し、設定差を製品差から先に取り除く。**
 
-## なぜこの失敗は起きるのか
+## 2/5から5/5へ動いた
 
-CIではbinary名だけが記録されがちだ。
-
-```text
-pyrefly
-pyright
-mypy
-```
-
-しかし実際にblocking authorityとして動くのはbinary名ではなく、次の組み合わせである。
-
-```text
-authority =
-  tool version
-  + preset / mode
-  + config
-  + project scope
-  + runtime environment
-  + blocking severity policy
-```
-
-Pyrefly公式は、設定のないprojectでは`basic` presetを合成し、`default`や`strict`とはdiagnostic surfaceが異なると説明している。
-
-https://pyrefly.org/en/docs/configuration/
-
-Pyrightも`off` / `basic` / `standard` / `strict`の`typeCheckingMode`を持つ。
-
-https://github.com/microsoft/pyright/blob/main/docs/configuration.md
-
-製品名だけ揃えても、比較条件は揃っていない。
-
-## 実際に何が変わったか
-
-固定fixtureでは次の5 failure classを1件ずつ用意した。
+固定fixtureは5 failure classだけに絞った。
 
 - syntax failure
 - incompatible argument type
@@ -58,51 +26,54 @@ https://github.com/microsoft/pyright/blob/main/docs/configuration.md
 - undefined name
 - async misuse
 
-同じPyrefly 1.2.0で観測した結果はこうだった。
+同じPyrefly 1.2.0の結果はこうだった。
 
-| tested mode | detected |
+| configuration | detected |
 |---|---:|
-| no config → basic | 2/5 |
+| no config → `basic` | 2/5 |
 | `basic` | 2/5 |
 | `default` | 5/5 |
 
-raw calibration:
+raw evidence:
 https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/pyrefly-preset-calibration.json
 
-修復後の同じ5 mutantでは、mypy / Pyright / ty / Pyreflyのtested configurationはいずれも5/5だった。
+Pyrefly公式も、設定のないprojectでは`basic`を使い、高confidenceなdiagnosticへ絞ると説明している。`default`や`strict`は別のdiagnostic surfaceを持つ。
 
-summary:
-https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/summary.json
+https://pyrefly.org/en/docs/configuration/
 
-ここから「4製品は同等」とは言えない。5 mutantしか測っていないからだ。言えるのは、**旧2/5対5/5を製品固有のcoverage差として扱えなかった**ことだけである。
+つまり「Pyreflyは2/5だった」という書き方では情報が欠ける。正しくは、**Pyrefly 1.2.0をbasic presetで、この5 faultへ当てたとき2/5だった**だ。
 
-## 壊れた比較
+## 私が捨てた比較方法
 
 ```text
-A: 2/5
-B: 5/5
+pyrefly: 2/5
+pyright: 5/5
 ↓
-Bの方が強い
+pyrightの方が強い
 ```
 
-この推論には、AとBが同じpolicy surfaceで走ったという確認が抜けている。
+この比較は、両者へ何をblockさせたかが揃っていないと製品比較にならない。
 
-## 改善した比較
+修復後、同じ5 mutantに対するtested configurationでは、mypy / Pyright / ty / Pyreflyはいずれも5/5だった。
 
-比較を次の順序に変える。
+https://github.com/KAFKA2306/articles/blob/822be109de61e5915799fcf7d79e6345dff4f6b1/benchmarks/verification-stack-v2/results/controlled/summary.json
 
-1. repoで絶対にblockしたいfailure classをfixture化する
-2. clean baselineを保存する
-3. version / preset / config / scopeをpinする
-4. cleanとmutantを同じexecution contractで走らせる
-5. `clean=pass && mutant=block` のときだけcreditを与える
-6. correctness survivorだけを速度やmigration costへ進める
+ここから「4製品は同等」とも言えない。5件しか測っていない。消えたのは、旧2/5対5/5を**製品固有の差だとする根拠**だけだ。
 
-これなら「設定が強いだけ」を「製品が強い」と誤読しにくい。
+## 比較を6段階にする
 
-## 読者が持ち帰るべきもの
+型チェッカーを移行するときは次の順で十分だった。
 
-型チェッカー導入時に比較表を作る前に、CI logへ次を残す。
+1. repoで絶対にblockしたいfailureを1 root faultずつfixture化する
+2. clean baselineを用意する
+3. tool versionを固定する
+4. preset / mode / config / scope / severityを固定する
+5. `clean=pass && fault=block`だけを成功として数える
+6. correctnessを満たした候補だけ速度・導入コスト・保守量を比べる
+
+最後の段階で機能と運用性が同等なら、**LOC、設定ファイル、dependency、CI commandが少ない方を選ぶ**。複雑性は有効なtie-breakerだが、設定の違う候補を無理に同点扱いするためには使わない。
+
+## benchmark結果と一緒に残す最小メモ
 
 ```text
 checker: pyrefly 1.2.0
@@ -113,14 +84,12 @@ python: 3.12
 blocking severity: error
 ```
 
-この記録がないbenchmarkは、後から再現できても「何を比較したのか」が曖昧になる。
+この6項目があれば、半年後でも「製品を比較したのか、設定を比較したのか」を追いやすい。
 
 ## 証拠の境界
 
-今回の5 mutantはtyping全体のaccuracy benchmarkではない。editor behavior、third-party stubs、incremental analysis、large-repo behaviorも測っていない。
+今回の5 mutantはtyping全体のaccuracyを証明しない。editor behavior、third-party stubs、incremental analysis、大規模repoも未評価だ。
 
-それでも、設定を固定しない比較が危険だという判断には十分だった。なぜなら、**同一binary・同一version・同一fixtureでpresetだけを変えたとき、結果が2/5から5/5へ変わった**からだ。
+それでも比較手順を変える理由にはなった。**同一binary・同一version・同一fixtureで、presetだけを変えると2/5→5/5になった**からだ。
 
-製品比較は最後でいい。
-
-最初に固定すべきなのは、**その製品に実際どの判定権限を与えたのか**である。
+型チェッカーを選ぶ前に、まず比較対象から設定差を消す。それから初めて、製品差と複雑性を比べる。


### PR DESCRIPTION
README.md / AGENTS.md に合わせ、直近5記事を再度reader-value中心へ整理する。

- Claude Code: 監視ではなく合格条件をagent外へ固定する
- type checker: 2/5→5/5の観測を、設定差を製品差にしない判断へ集中
- runtime validation: API/JSON等を最初の信用境界で検証する
- affected set: CI高速化で必要なtestを落とさない評価順序へ集中
- compiler replacement: 同等後はcommand/config/dependency/LOC/filesを減らす。ただしNOT_RUNをPASSにしない

publication stateは変更しない。Claude Code記事のpublished:true/published_atを維持し、他4記事はpublished:falseを維持する。