### PR TITLE
research: external AIDev study of vocabulary reuse and context cost

### DIFF
--- a/.github/workflows/aidev-vocabulary-study.yml
+++ b/.github/workflows/aidev-vocabulary-study.yml
@@ -1,0 +1,33 @@
+name: AIDev vocabulary study
+
+on:
+  push:
+    branches:
+      - research/aidev-vocabulary-study
+    paths:
+      - "research/aidev-vocabulary-study/**"
+      - ".github/workflows/aidev-vocabulary-study.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install analysis dependencies
+        run: python -m pip install --disable-pip-version-check pandas pyarrow scipy numpy
+      - name: Run external-only AIDev analysis
+        run: python research/aidev-vocabulary-study/analyze.py
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: aidev-vocabulary-results
+          path: research/aidev-vocabulary-study/results/
+          if-no-files-found: error

--- a/.github/workflows/aidev-vocabulary-study.yml
+++ b/.github/workflows/aidev-vocabulary-study.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - research/aidev-vocabulary-study
     paths:
-      - "research/aidev-vocabulary-study/**"
+      - "research/aidev-vocabulary-study/analyze.py"
+      - "research/aidev-vocabulary-study/analyze_task_matched.py"
       - ".github/workflows/aidev-vocabulary-study.yml"
   workflow_dispatch:
 
@@ -23,8 +24,10 @@ jobs:
           python-version: "3.12"
       - name: Install analysis dependencies
         run: python -m pip install --disable-pip-version-check pandas pyarrow scipy numpy
-      - name: Run external-only AIDev analysis
+      - name: Run repository-matched AIDev analysis
         run: python research/aidev-vocabulary-study/analyze.py
+      - name: Run repository-and-task-type matched robustness analysis
+        run: python research/aidev-vocabulary-study/analyze_task_matched.py
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/aidev-vocabulary-study.yml
+++ b/.github/workflows/aidev-vocabulary-study.yml
@@ -1,3 +1,4 @@
+# Reproduce the external-only AIDev analyses on the exact research branch head.
 name: AIDev vocabulary study
 
 on:

--- a/research/aidev-vocabulary-study/CONTROLLED_EXPERIMENT.md
+++ b/research/aidev-vocabulary-study/CONTROLLED_EXPERIMENT.md
@@ -1,0 +1,151 @@
+# Controlled experiment: wording in repository context and coding-agent retrieval cost
+
+Status: protocol drafted after the observational AIDev analysis and before running this experiment.
+
+The observational study did not robustly show higher multiword-expression reuse in agent-authored PR titles. This experiment therefore tests the causal question directly instead of searching for another observational proxy.
+
+## Research question
+
+Holding the software task and behavioral requirements constant, does introducing repository-specific names or abbreviations into agent instructions change coding-agent context retrieval, task success, or inference cost?
+
+## Benchmark
+
+Use ContextBench because it supplies issue-resolution tasks with human-annotated gold repository context and an evaluator for agent trajectories.
+
+Primary sources:
+
+- Paper: https://arxiv.org/abs/2602.05892
+- Code: https://github.com/EuniAI/ContextBench
+- Project site: https://contextbench.github.io/
+
+ContextBench reports 1,136 tasks from 66 repositories across eight programming languages and evaluates retrieved context against human-annotated gold context at file, block, and line granularity.
+
+For comparison with existing repository-context research, also retain the published AGENTBench implementation and paper as methodological references:
+
+- Paper: https://arxiv.org/abs/2602.11988
+- Code: https://github.com/eth-sri/agentbench
+
+The AGENTS.md study reports that repository context files can increase exploration and inference cost while not consistently improving task success. The present experiment isolates wording while keeping requirements unchanged.
+
+## Intervention
+
+Every benchmark task is run from the same frozen repository snapshot under three instruction variants. The software requirements, required checks, and stopping condition are identical across variants.
+
+### Plain wording
+
+Instructions use ordinary software-engineering language without assigning new names to the rules.
+
+Example semantic content:
+
+- inspect existing work before creating duplicate work;
+- make the smallest change required by the issue;
+- run the relevant existing checks;
+- stop after the requested outcome is verified.
+
+### New multiword labels
+
+The same requirements are expressed with newly introduced multiword names. The name is defined when first used and then used later in place of the ordinary phrase.
+
+The exact label vocabulary must be generated before the confirmatory runs and stored in the experiment manifest. Multiple label sets are used and counterbalanced across tasks so that results cannot depend on one particular coined phrase.
+
+### New abbreviations
+
+The same requirements and multiword names are used, but subsequent references use newly introduced abbreviations. Each abbreviation is defined once before use.
+
+## Two estimands
+
+Two separate comparisons are necessary because real repository terminology can increase both lexical opacity and instruction length.
+
+1. **Realistic package effect**: preserve the natural extra text required to define new labels and abbreviations. This estimates the total effect of introducing the terminology as it would normally appear in a repository context file.
+2. **Length-controlled wording effect**: construct semantically equivalent variants with approximately equal tokenizer length and the same number of requirements. This estimates the effect of lexical naming with instruction length held as constant as practicable.
+
+The two estimands must not be collapsed into one result.
+
+## Exposure
+
+The treatment is supplied through the repository-context mechanism used by the evaluated agent. The experiment harness must confirm before inclusion that each agent actually receives the context file or equivalent repository instruction surface.
+
+A manipulation check records whether the introduced labels or abbreviations occur later in the agent trajectory. Failure to repeat a label is not an exclusion criterion; it is evidence that the treatment was ignored.
+
+Each run starts from a clean benchmark snapshot. Treatment vocabulary from one run must never persist into another run.
+
+## Sampling and power
+
+Do not choose a favorable subset after observing treatment outcomes.
+
+1. Draw an initial pilot sample of 30 ContextBench tasks using a fixed pseudorandom seed, stratified by repository and language where possible. Pilot tasks are used only to verify treatment delivery, estimate runtime/variance, and calculate the confirmatory sample size; they are excluded from confirmatory effect estimates.
+2. Before confirmatory runs, freeze the task IDs, model versions, agent versions, instruction variants, tokenizer-length checks, time/token limits, and statistical analysis in a machine-readable manifest.
+3. Determine the confirmatory task count from the pilot variance using 80% power and two-sided alpha 0.05 for the declared smallest effects of interest. If the computed count exceeds the available benchmark, use the full eligible ContextBench corpus and report the resulting detectable effect rather than reducing the target post hoc.
+
+The initial smallest effects of interest must be set before pilot outcome analysis. Suggested values to justify or revise before running are a 5 percentage-point absolute change in task resolution and a 10% relative change in retrieval-efficiency or token-cost measures.
+
+## Randomization
+
+Use a within-task design: every included task is evaluated under every wording condition for each selected model/agent configuration.
+
+For stochastic agents, repeat each task-condition combination with independent runs. Condition order is randomized independently within each task/model/agent block using a recorded seed.
+
+Repository snapshot, issue text, agent scaffold, model version, tool availability, maximum turns, token budget, and execution timeout remain fixed within each block.
+
+## Outcomes
+
+### Primary process outcome
+
+Use ContextBench's existing retrieval-efficiency metric at the published granularity selected before confirmatory runs. Do not create a new composite score.
+
+### Primary end-to-end outcome
+
+Task resolution using the benchmark's existing pass/fail evaluation.
+
+### Secondary outcomes
+
+Use existing observable quantities where available:
+
+- context recall;
+- context precision;
+- context F1;
+- time or trajectory step at which the first gold-context file is retrieved;
+- number of files inspected;
+- number of non-gold files inspected;
+- input tokens;
+- output tokens;
+- total model tokens/cost when reported by the runner;
+- tool calls;
+- elapsed runtime;
+- patch size;
+- introduced-label or abbreviation occurrences in the trajectory.
+
+Do not infer cognitive state from tokens or tool calls. These are process measurements only.
+
+## Statistical analysis
+
+The primary comparison is paired within task.
+
+- For continuous retrieval/cost outcomes, report the paired mean and median treatment differences with task-clustered bootstrap 95% confidence intervals.
+- For binary task resolution, report paired absolute percentage-point differences with a confidence interval and a paired binary test such as McNemar's test.
+- Report model/agent-specific estimates in addition to the pooled estimate; do not assume one effect applies to all coding agents.
+- Use task as the resampling cluster so repeated runs of one task do not become independent observations.
+- Correct confirmatory p-values for the two primary treatment comparisons (`new labels` vs `plain`, `new abbreviations` vs `plain`). Secondary outcomes are exploratory and are reported as effect estimates with intervals rather than used to rescue a null primary result.
+
+The confirmatory analysis script must be written and committed before confirmatory trajectories are generated.
+
+## Exclusions
+
+Exclude a task-run only for a predeclared execution failure unrelated to treatment, such as a corrupted benchmark snapshot or provider outage affecting the whole comparison block. Do not exclude runs because the model ignored the terminology, failed the task, used many tokens, or produced an extreme trajectory.
+
+If one condition in a paired block is lost to infrastructure failure, rerun the entire affected block under the same recorded configuration rather than retaining an unpaired subset.
+
+## Threats to validity
+
+- ContextBench gold context represents expert-annotated sufficient/relevant code context, not human cognitive effort.
+- Different agent frameworks may consume repository context files differently; exposure must be verified per agent.
+- Coined experimental labels may be more artificial than naturally evolved repository terminology.
+- Equalizing tokenizer length can itself require unnatural wording; therefore the realistic and length-controlled estimands are both reported.
+- Model/provider updates can invalidate replication unless exact versions are pinned.
+- Repeated runs on hosted models may remain nondeterministic even with identical prompts.
+
+## Falsification criterion
+
+The hypothesis that repository-specific naming creates measurable coding-agent decision cost is not supported if the confirmatory experiment shows no practically meaningful degradation in the predefined primary outcomes across the label and abbreviation treatments, with confidence intervals narrow enough to exclude the declared smallest effects of interest.
+
+A null result must be retained. The study must not switch after the fact to a different lexical metric, task subset, or outcome to preserve the original hypothesis.

--- a/research/aidev-vocabulary-study/FINDINGS.md
+++ b/research/aidev-vocabulary-study/FINDINGS.md
@@ -1,0 +1,105 @@
+# Observed results from the AIDev matched-corpus study
+
+Date: 2026-08-16
+
+This file records the observed results. The study corpus contains no KAFKA2306 repository data and no repositories selected from prior chat context.
+
+## Data and reproducibility
+
+Upstream data:
+
+- AIDev paper: https://arxiv.org/abs/2602.09185
+- AIDev dataset revision: https://huggingface.co/datasets/hao-li/AIDev/tree/6200a09fc80606189a50056eb10a50da157bde13
+- AIDev schema: https://huggingface.co/datasets/hao-li/AIDev/blob/6200a09fc80606189a50056eb10a50da157bde13/data_table.md
+
+Pinned inputs:
+
+- `pull_request.parquet`: SHA-256 `08f520b5ef36b6281f82090db09ac14aefc3534ee113886e7bc85131fd8d214c`
+- `human_pull_request.parquet`: SHA-256 `910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248`
+- `pr_task_type.parquet`: SHA-256 `f32a97a45ac944f4ea473327e62d8f41361502c2b6b3778e76fb64c2b8896476`
+- `human_pr_task_type.parquet`: SHA-256 `5527d52bfd9605a25d1ed1ef03bce0e1cc217f6ffed936e2be1b80a04123e658`
+
+Raw rows read successfully: 33,596 Agentic-PRs and 6,618 Human-PRs.
+
+GitHub Actions run: https://github.com/KAFKA2306/articles/actions/runs/31943122727
+
+The run completed both the repository-matched analysis and the repository + task-type matched robustness analysis successfully. The result artifact ID is `9262565185`; its ZIP SHA-256 is `2b55ad4cd660cd178cc8766f9f0aa30b9e96d0cd2a70a559c969cdec0145cec6`.
+
+## Result 1: agent-authored PR titles are longer
+
+This is the most stable observed difference.
+
+After matching by repository and AIDev task type, the mean paired difference in repository-level median PR-title length was:
+
+| Minimum matched PRs per class | Repositories | Agent − human tokens | Bootstrap 95% CI |
+| ---: | ---: | ---: | ---: |
+| 2 | 318 | +0.469 | +0.209 to +0.725 |
+| 5 | 157 | +0.640 | +0.360 to +0.917 |
+| 10 | 93 | +0.726 | +0.376 to +1.075 |
+| 20 | 47 | +1.096 | +0.660 to +1.532 |
+
+The direction remains positive at every predefined minimum-document threshold.
+
+This measures text length only. It does not establish comprehension cost.
+
+## Result 2: title-only phrase reuse does not provide robust evidence of stronger agent lexical propagation
+
+The cleanest low-template scope is PR titles only. Multiword reuse was measured using contiguous 2–4-token expressions that appeared in at least two PR titles in the same repository.
+
+After matching by repository and task type, the mean paired difference in the share of unique expressions that were reused was:
+
+| Minimum matched PRs per class | Repositories | Agent − human | Bootstrap 95% CI |
+| ---: | ---: | ---: | ---: |
+| 2 | 318 | +0.0118 | +0.0026 to +0.0228 |
+| 5 | 157 | +0.0083 | −0.0028 to +0.0215 |
+| 10 | 93 | +0.0020 | −0.0092 to +0.0127 |
+| 20 | 47 | +0.0113 | −0.0022 to +0.0243 |
+
+The corresponding document–phrase event-share differences were:
+
+| Minimum matched PRs per class | Agent − human | Bootstrap 95% CI |
+| ---: | ---: | ---: |
+| 2 | +0.0152 | +0.0029 to +0.0289 |
+| 5 | +0.0121 | −0.0055 to +0.0304 |
+| 10 | +0.0042 | −0.0160 to +0.0236 |
+| 20 | +0.0227 | −0.0023 to +0.0474 |
+
+Only the most permissive threshold has a bootstrap interval entirely above zero. The effect is not stable across the predefined 5/10/20-document sensitivity checks.
+
+Therefore this observational analysis does **not** support a robust claim that agent-authored PR titles propagate repeated multiword expressions more strongly than human-authored PR titles.
+
+## Result 3: adding PR bodies changes the result substantially
+
+When cleaned PR bodies are included, human-authored PR text has higher mean repeated-expression shares in the larger matched subsets even after matching by repository and task type.
+
+For example:
+
+- minimum 5 PRs/class, 158 repositories: repeated-expression event share difference = −0.0776 (agent − human), bootstrap 95% CI −0.1198 to −0.0373;
+- minimum 10 PRs/class, 95 repositories: −0.0941, CI −0.1447 to −0.0452;
+- minimum 20 PRs/class, 47 repositories: −0.1476, CI −0.2208 to −0.0748.
+
+For the share of unique expressions reused:
+
+- minimum 5: −0.0360, CI −0.0582 to −0.0152;
+- minimum 10: −0.0337, CI −0.0563 to −0.0131;
+- minimum 20: −0.0328, CI −0.0605 to −0.0065.
+
+The title-only and title+body analyses therefore answer different questions. PR bodies can contain contribution templates, checklists, boilerplate, copied issue descriptions, standard project language, and other repeated structures. The current analysis does not identify which mechanism produces the body-level difference.
+
+It would be invalid to interpret the body result as evidence that human developers have more or less repository-specific jargon.
+
+## What the observational study falsified
+
+A simple proxy was tested: if coding agents strongly self-propagate repository-local vocabulary, agent-authored PR text might exhibit systematically higher cross-document multiword-expression reuse after matching exposure within repositories.
+
+That prediction is not robustly supported in the cleaner title-only analysis.
+
+This is a useful negative result because it rules out using generic n-gram repetition in PR text as sufficient evidence for the original mechanism.
+
+## Remaining causal question
+
+The original question is narrower and causal:
+
+> Holding task requirements and meaning constant, does replacing ordinary software-engineering language with newly introduced repository-specific terms or abbreviations change how efficiently humans or coding agents find relevant context, make changes, and verify them?
+
+The AIDev analysis cannot answer that question because wording was not randomized. The next study therefore uses controlled wording interventions on a repository-level benchmark rather than searching for another favorable observational proxy.

--- a/research/aidev-vocabulary-study/README.md
+++ b/research/aidev-vocabulary-study/README.md
@@ -1,0 +1,67 @@
+# AIDev vocabulary study
+
+This study uses only the public AIDev dataset as research data. KAFKA2306 repositories, prior chat examples, and hand-picked repository samples are excluded from the study corpus.
+
+## Question
+
+Do agent-authored pull requests exhibit different cross-document reuse of multiword expressions than human-authored pull requests from the same repositories when the number of documents is balanced within each repository?
+
+This is an observational question. It does not by itself establish that an agent invented a term, that a repeated phrase is jargon, or that repeated language increases maintenance cost.
+
+## Upstream data
+
+Primary sources:
+
+- AIDev paper: https://arxiv.org/abs/2602.09185
+- AIDev replication package: https://github.com/SAILResearch/AI_Teammates_in_SE3
+- AIDev dataset: https://huggingface.co/datasets/hao-li/AIDev
+
+The analysis downloads these two published files and verifies their SHA-256 hashes before use:
+
+- `pull_request.parquet` — SHA-256 `08f520b5ef36b6281f82090db09ac14aefc3534ee113886e7bc85131fd8d214c`
+- `human_pull_request.parquet` — SHA-256 `910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248`
+
+AIDev states that Human-PRs were sampled from the same repositories as Agentic-PRs, restricted to repositories with more than 500 GitHub stars. The analysis therefore uses only repository IDs present in both files.
+
+## Predefined analysis
+
+1. Concatenate PR title and body.
+2. Remove URLs, fenced code, and inline code.
+3. Tokenize ASCII word-like tokens and lowercase them.
+4. Extract contiguous 2-, 3-, and 4-token expressions.
+5. Intersect repository IDs between Agentic-PR and Human-PR data.
+6. Require at least two usable PR documents in each class for a repository because cross-document reuse is undefined with one document.
+7. Within every eligible repository, set `n = min(agent documents, human documents)` and select exactly `n` documents from each class using a deterministic SHA-256 ordering with a fixed seed.
+8. For each repository and class, measure:
+   - median token count per PR;
+   - fraction of unique 2–4-grams appearing in at least two PRs;
+   - fraction of document–phrase events attributable to expressions appearing in at least two PRs.
+9. Compare Agentic-PR and Human-PR values within the same repository.
+10. Report the mean and median paired difference, a 10,000-resample bootstrap 95% confidence interval for the mean paired difference, and a two-sided Wilcoxon signed-rank test.
+
+No phrase is manually labeled as "AI jargon". Repeated expressions are descriptive lexical observations only.
+
+## Run
+
+```bash
+python -m pip install pandas pyarrow scipy numpy
+python research/aidev-vocabulary-study/analyze.py
+```
+
+Outputs:
+
+- `results/summary.json`
+- `results/repository_metrics.csv`
+- `results/top_reused_phrases.csv`
+
+The raw downloaded Parquet files are stored under `.data/` and are not intended for version control.
+
+## Threats to validity
+
+- AIDev's human comparison set is sampled and restricted to popular repositories; it is not a census of all human PRs.
+- PR title/body language is not the same thing as persistent repository instructions such as `AGENTS.md`.
+- Multiword-expression reuse can reflect legitimate project/domain terminology, templates, contribution conventions, or duplicated text.
+- Balancing document counts controls exposure opportunity but changes the analyzed sample when class sizes differ.
+- A statistical difference in reuse does not establish higher comprehension or maintenance cost.
+
+A causal follow-up must hold task semantics constant and randomize wording in controlled agent and human experiments.

--- a/research/aidev-vocabulary-study/README.md
+++ b/research/aidev-vocabulary-study/README.md
@@ -16,30 +16,35 @@ Primary sources:
 - AIDev replication package: https://github.com/SAILResearch/AI_Teammates_in_SE3
 - AIDev dataset: https://huggingface.co/datasets/hao-li/AIDev
 
-The analysis downloads these two published files and verifies their SHA-256 hashes before use:
+The study pins AIDev revision `6200a09fc80606189a50056eb10a50da157bde13` and verifies SHA-256 before reading either file:
 
 - `pull_request.parquet` — SHA-256 `08f520b5ef36b6281f82090db09ac14aefc3534ee113886e7bc85131fd8d214c`
 - `human_pull_request.parquet` — SHA-256 `910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248`
 
-AIDev states that Human-PRs were sampled from the same repositories as Agentic-PRs, restricted to repositories with more than 500 GitHub stars. The analysis therefore uses only repository IDs present in both files.
+AIDev states that Human-PRs were sampled from the same repositories as Agentic-PRs and restricted to repositories with more than 500 GitHub stars. Repository identity is therefore derived from published GitHub repository/PR URLs and only repositories present in both classes are compared.
 
-## Predefined analysis
+## Analysis
 
-1. Concatenate PR title and body.
-2. Remove URLs, fenced code, and inline code.
-3. Tokenize ASCII word-like tokens and lowercase them.
-4. Extract contiguous 2-, 3-, and 4-token expressions.
-5. Intersect repository IDs between Agentic-PR and Human-PR data.
-6. Require at least two usable PR documents in each class for a repository because cross-document reuse is undefined with one document.
-7. Within every eligible repository, set `n = min(agent documents, human documents)` and select exactly `n` documents from each class using a deterministic SHA-256 ordering with a fixed seed.
-8. For each repository and class, measure:
+Two text scopes are reported separately:
+
+- `title`: PR title only, to reduce PR-template contamination;
+- `title_body`: cleaned title plus body, to measure the broader collaboration text.
+
+For each scope:
+
+1. Remove URLs, fenced code, and inline code.
+2. Tokenize ASCII word-like tokens and lowercase them.
+3. Extract contiguous 2-, 3-, and 4-token expressions.
+4. Intersect repository identities between Agentic-PR and Human-PR data.
+5. Within every repository, set `n = min(agent documents, human documents)` and select exactly `n` documents from each class using deterministic SHA-256 ordering with a fixed seed.
+6. Measure, per repository and class:
    - median token count per PR;
    - fraction of unique 2–4-grams appearing in at least two PRs;
    - fraction of document–phrase events attributable to expressions appearing in at least two PRs.
-9. Compare Agentic-PR and Human-PR values within the same repository.
-10. Report the mean and median paired difference, a 10,000-resample bootstrap 95% confidence interval for the mean paired difference, and a two-sided Wilcoxon signed-rank test.
+7. Repeat the paired comparison for repositories with at least 2, 5, 10, and 20 documents in each class. Reporting all four thresholds exposes instability caused by small repositories rather than selecting a favorable cutoff after seeing results.
+8. Report mean and median paired differences, positive/negative/zero difference counts, a 10,000-resample bootstrap 95% confidence interval for the mean paired difference, a two-sided Wilcoxon signed-rank test, and a two-sided sign test.
 
-No phrase is manually labeled as "AI jargon". Repeated expressions are descriptive lexical observations only.
+No phrase is manually labeled as "AI jargon". Repeated expressions are descriptive lexical observations only. Raw phrases are not published by this analysis because AIDev states that source-repository content remains governed by each source repository's original license.
 
 ## Run
 
@@ -52,16 +57,17 @@ Outputs:
 
 - `results/summary.json`
 - `results/repository_metrics.csv`
-- `results/top_reused_phrases.csv`
 
 The raw downloaded Parquet files are stored under `.data/` and are not intended for version control.
 
 ## Threats to validity
 
 - AIDev's human comparison set is sampled and restricted to popular repositories; it is not a census of all human PRs.
-- PR title/body language is not the same thing as persistent repository instructions such as `AGENTS.md`.
-- Multiword-expression reuse can reflect legitimate project/domain terminology, templates, contribution conventions, or duplicated text.
-- Balancing document counts controls exposure opportunity but changes the analyzed sample when class sizes differ.
-- A statistical difference in reuse does not establish higher comprehension or maintenance cost.
+- PR language is not the same thing as persistent repository instructions such as `AGENTS.md`.
+- Multiword-expression reuse can reflect legitimate project/domain terminology, contribution conventions, or duplicated text.
+- PR bodies can contain templates; the title-only scope is included specifically to expose this confound rather than assuming it away.
+- Balancing document counts controls opportunity for reuse but changes the analyzed sample when class sizes differ.
+- Statistical differences in reuse do not establish higher comprehension or maintenance cost.
+- This observational stage cannot identify whether an AI agent caused a phrase to enter a repository.
 
 A causal follow-up must hold task semantics constant and randomize wording in controlled agent and human experiments.

--- a/research/aidev-vocabulary-study/README.md
+++ b/research/aidev-vocabulary-study/README.md
@@ -1,12 +1,20 @@
 # AIDev vocabulary study
 
-This study uses only the public AIDev dataset as research data. KAFKA2306 repositories, prior chat examples, and hand-picked repository samples are excluded from the study corpus.
+This study uses only public external research datasets as study data. KAFKA2306 repositories, prior chat examples, and hand-picked repository samples are excluded from the study corpus.
 
-## Question
+## Current status
 
-Do agent-authored pull requests exhibit different cross-document reuse of multiword expressions than human-authored pull requests from the same repositories when the number of documents is balanced within each repository?
+The external AIDev observational analysis has been executed. Its main result is negative with respect to the original lexical-propagation hypothesis: title-only multiword-expression reuse is not consistently higher for Agentic-PRs across the predefined sample-size sensitivity checks after matching by repository and AIDev task type.
 
-This is an observational question. It does not by itself establish that an agent invented a term, that a repeated phrase is jargon, or that repeated language increases maintenance cost.
+The observed numbers and interpretation boundary are recorded in [`FINDINGS.md`](./FINDINGS.md).
+
+Because the observational proxy is insufficient to establish decision or comprehension cost, the causal follow-up is specified separately in [`CONTROLLED_EXPERIMENT.md`](./CONTROLLED_EXPERIMENT.md). It uses ContextBench's existing gold-context and trajectory metrics rather than redefining success around a favorable lexical proxy.
+
+## Observational question
+
+Do agent-authored pull requests exhibit different cross-document reuse of multiword expressions than human-authored pull requests from the same repositories when exposure opportunity is balanced?
+
+This is observational. It does not establish that an agent invented a term, that a repeated phrase is jargon, or that repeated language increases maintenance cost.
 
 ## Upstream data
 
@@ -15,59 +23,69 @@ Primary sources:
 - AIDev paper: https://arxiv.org/abs/2602.09185
 - AIDev replication package: https://github.com/SAILResearch/AI_Teammates_in_SE3
 - AIDev dataset: https://huggingface.co/datasets/hao-li/AIDev
+- AIDev schema at the pinned revision: https://huggingface.co/datasets/hao-li/AIDev/blob/6200a09fc80606189a50056eb10a50da157bde13/data_table.md
 
-The study pins AIDev revision `6200a09fc80606189a50056eb10a50da157bde13` and verifies SHA-256 before reading either file:
+The study pins AIDev revision `6200a09fc80606189a50056eb10a50da157bde13` and verifies SHA-256 before reading inputs:
 
-- `pull_request.parquet` — SHA-256 `08f520b5ef36b6281f82090db09ac14aefc3534ee113886e7bc85131fd8d214c`
-- `human_pull_request.parquet` — SHA-256 `910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248`
+- `pull_request.parquet` — `08f520b5ef36b6281f82090db09ac14aefc3534ee113886e7bc85131fd8d214c`
+- `human_pull_request.parquet` — `910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248`
+- `pr_task_type.parquet` — `f32a97a45ac944f4ea473327e62d8f41361502c2b6b3778e76fb64c2b8896476`
+- `human_pr_task_type.parquet` — `5527d52bfd9605a25d1ed1ef03bce0e1cc217f6ffed936e2be1b80a04123e658`
 
-AIDev states that Human-PRs were sampled from the same repositories as Agentic-PRs and restricted to repositories with more than 500 GitHub stars. Repository identity is therefore derived from published GitHub repository/PR URLs and only repositories present in both classes are compared.
+AIDev states that Human-PRs were sampled from the same repositories as Agentic-PRs and restricted to repositories with more than 500 GitHub stars. AIDev also publishes task-purpose classifications using Conventional Commit-style categories, derived by LLM classification of PR titles and commit messages.
 
-## Analysis
+## Analyses
 
 Two text scopes are reported separately:
 
-- `title`: PR title only, to reduce PR-template contamination;
-- `title_body`: cleaned title plus body, to measure the broader collaboration text.
+- `title`: PR title only, reducing PR-body template contamination;
+- `title_body`: cleaned title plus body.
 
-For each scope:
+The repository-matched analysis:
 
-1. Remove URLs, fenced code, and inline code.
-2. Tokenize ASCII word-like tokens and lowercase them.
-3. Extract contiguous 2-, 3-, and 4-token expressions.
-4. Intersect repository identities between Agentic-PR and Human-PR data.
-5. Within every repository, set `n = min(agent documents, human documents)` and select exactly `n` documents from each class using deterministic SHA-256 ordering with a fixed seed.
-6. Measure, per repository and class:
-   - median token count per PR;
-   - fraction of unique 2–4-grams appearing in at least two PRs;
-   - fraction of document–phrase events attributable to expressions appearing in at least two PRs.
-7. Repeat the paired comparison for repositories with at least 2, 5, 10, and 20 documents in each class. Reporting all four thresholds exposes instability caused by small repositories rather than selecting a favorable cutoff after seeing results.
-8. Report mean and median paired differences, positive/negative/zero difference counts, a 10,000-resample bootstrap 95% confidence interval for the mean paired difference, a two-sided Wilcoxon signed-rank test, and a two-sided sign test.
+1. removes URLs, fenced code, and inline code;
+2. tokenizes word-like tokens and lowercases them;
+3. extracts contiguous 2-, 3-, and 4-token expressions;
+4. intersects repository identities between Agentic-PR and Human-PR data;
+5. within every repository, selects the same number of documents from each class using deterministic SHA-256 ordering with a fixed seed;
+6. measures median token count, the share of unique expressions reused in at least two PRs, and the share of document–phrase events attributable to reused expressions;
+7. repeats paired comparisons at minimum document counts 2, 5, 10, and 20;
+8. reports paired effect estimates, 10,000-resample bootstrap 95% confidence intervals, Wilcoxon signed-rank tests, and sign tests.
 
-No phrase is manually labeled as "AI jargon". Repeated expressions are descriptive lexical observations only. Raw phrases are not published by this analysis because AIDev states that source-repository content remains governed by each source repository's original license.
+The post-specified robustness analysis in `analyze_task_matched.py` additionally balances Agentic-PR and Human-PR documents within the same repository **and the same AIDev task type** before computing repository-level outcomes. This controls the observed task-category mixture but does not make the study causal because the task labels are themselves model classifications and unobserved confounding remains possible.
+
+No phrase is manually labeled as "AI jargon". Repeated expressions are descriptive lexical observations only. Raw phrases are not republished because AIDev states that content originating in source repositories remains governed by each source repository's original license.
 
 ## Run
 
 ```bash
 python -m pip install pandas pyarrow scipy numpy
 python research/aidev-vocabulary-study/analyze.py
+python research/aidev-vocabulary-study/analyze_task_matched.py
 ```
 
-Outputs:
+Generated outputs:
 
 - `results/summary.json`
 - `results/repository_metrics.csv`
+- `results/task_matched_summary.json`
+- `results/task_matched_repository_metrics.csv`
 
-The raw downloaded Parquet files are stored under `.data/` and are not intended for version control.
+Verified GitHub Actions run:
+
+- https://github.com/KAFKA2306/articles/actions/runs/31943122727
+
+The run completed both analyses and uploaded artifact `9262565185`; artifact ZIP SHA-256: `2b55ad4cd660cd178cc8766f9f0aa30b9e96d0cd2a70a559c969cdec0145cec6`.
 
 ## Threats to validity
 
 - AIDev's human comparison set is sampled and restricted to popular repositories; it is not a census of all human PRs.
 - PR language is not the same thing as persistent repository instructions such as `AGENTS.md`.
-- Multiword-expression reuse can reflect legitimate project/domain terminology, contribution conventions, or duplicated text.
-- PR bodies can contain templates; the title-only scope is included specifically to expose this confound rather than assuming it away.
-- Balancing document counts controls opportunity for reuse but changes the analyzed sample when class sizes differ.
-- Statistical differences in reuse do not establish higher comprehension or maintenance cost.
+- Multiword-expression reuse can reflect legitimate project/domain terminology, contribution conventions, templates, or duplicated text.
+- PR bodies can contain repeated structures; title-only results are therefore reported separately.
+- Balancing document counts controls exposure opportunity but changes the analyzed sample when class sizes differ.
+- Task-type matching controls only the published classification, not all differences between human and agent work.
+- Statistical differences in wording do not establish comprehension or decision cost.
 - This observational stage cannot identify whether an AI agent caused a phrase to enter a repository.
 
-A causal follow-up must hold task semantics constant and randomize wording in controlled agent and human experiments.
+The controlled follow-up holds task semantics constant and randomizes wording instead of selecting another observational proxy after seeing these results.

--- a/research/aidev-vocabulary-study/analyze.py
+++ b/research/aidev-vocabulary-study/analyze.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Compare repeated multiword expressions in matched Agentic-PR and Human-PR corpora.
 
-The input is the public AIDev dataset only. No KAFKA2306 repository content is
-used as study data. Inputs are pinned by SHA-256. The analysis balances the two
-classes within each repository before computing document-frequency measures.
+Study data come only from a pinned public AIDev revision. No KAFKA2306
+repository content is used as research data. Results are reported for PR titles
+alone and for cleaned title+body text, with several minimum-document thresholds
+to expose sensitivity to small repositories and PR-body templates.
 """
 
 from __future__ import annotations
@@ -20,10 +21,11 @@ from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
-from scipy.stats import wilcoxon
+from scipy.stats import binomtest, wilcoxon
 
 SEED = "2026-08-16-aidev-vocabulary"
-BASE = "https://huggingface.co/datasets/hao-li/AIDev/resolve/main"
+AIDEV_REVISION = "6200a09fc80606189a50056eb10a50da157bde13"
+BASE = f"https://huggingface.co/datasets/hao-li/AIDev/resolve/{AIDEV_REVISION}"
 INPUTS = {
     "agent": (
         f"{BASE}/pull_request.parquet",
@@ -34,6 +36,8 @@ INPUTS = {
         "910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248",
     ),
 }
+MINIMUM_DOCUMENTS = (2, 5, 10, 20)
+SCOPES = ("title", "title_body")
 TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_+.-]*")
 URL_RE = re.compile(r"https?://\S+|www\.\S+", re.I)
 CODE_FENCE_RE = re.compile(r"```.*?```", re.S)
@@ -59,19 +63,21 @@ def download(name: str, out_dir: Path) -> Path:
     return path
 
 
-def normalize_text(title: object, body: object) -> list[str]:
-    text = f"{'' if pd.isna(title) else title}\n{'' if pd.isna(body) else body}"
+def clean_text(value: object) -> str:
+    text = "" if pd.isna(value) else str(value)
     text = CODE_FENCE_RE.sub(" ", text)
     text = INLINE_CODE_RE.sub(" ", text)
-    text = URL_RE.sub(" ", text)
+    return URL_RE.sub(" ", text)
+
+
+def tokenize(text: str) -> list[str]:
     return [m.group(0).lower() for m in TOKEN_RE.finditer(text)]
 
 
 def ngrams(tokens: list[str], n_min: int = 2, n_max: int = 4) -> set[str]:
     result: set[str] = set()
     for n in range(n_min, n_max + 1):
-        if len(tokens) >= n:
-            result.update(" ".join(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+        result.update(" ".join(tokens[i : i + n]) for i in range(max(0, len(tokens) - n + 1)))
     return result
 
 
@@ -111,11 +117,10 @@ def add_repository_key(df: pd.DataFrame, group: str) -> pd.DataFrame:
 
 
 def stable_key(group: str, repo_key: object, pr_id: object) -> str:
-    raw = f"{SEED}|{group}|{repo_key}|{pr_id}".encode()
-    return hashlib.sha256(raw).hexdigest()
+    return hashlib.sha256(f"{SEED}|{group}|{repo_key}|{pr_id}".encode()).hexdigest()
 
 
-def prepare(df: pd.DataFrame, group: str) -> pd.DataFrame:
+def prepare(df: pd.DataFrame, group: str, scope: str) -> pd.DataFrame:
     required = {"id", "title", "body"}
     missing = required - set(df.columns)
     if missing:
@@ -124,8 +129,14 @@ def prepare(df: pd.DataFrame, group: str) -> pd.DataFrame:
     keep = [c for c in ["id", "repo_key", "title", "body", "created_at"] if c in df.columns]
     out = df.loc[:, keep].copy().dropna(subset=["repo_key", "id"])
     out["group"] = group
-    out["tokens"] = [normalize_text(t, b) for t, b in zip(out["title"], out["body"])]
-    out = out[out["tokens"].map(len) > 0].copy()
+    if scope == "title":
+        texts = [clean_text(t) for t in out["title"]]
+    elif scope == "title_body":
+        texts = [f"{clean_text(t)}\n{clean_text(b)}" for t, b in zip(out["title"], out["body"])]
+    else:
+        raise ValueError(scope)
+    out["tokens"] = [tokenize(x) for x in texts]
+    out = out[out["tokens"].map(len) >= 2].copy()
     out["ngrams"] = out["tokens"].map(ngrams)
     return out
 
@@ -134,15 +145,12 @@ def balance(agent: pd.DataFrame, human: pd.DataFrame) -> tuple[pd.DataFrame, pd.
     shared = sorted(set(agent.repo_key) & set(human.repo_key), key=str)
     a_parts: list[pd.DataFrame] = []
     h_parts: list[pd.DataFrame] = []
-    eligible = 0
     for repo_key in shared:
         a = agent[agent.repo_key == repo_key].copy()
         h = human[human.repo_key == repo_key].copy()
         n = min(len(a), len(h))
-        # At least two documents per class are needed to measure cross-document reuse.
         if n < 2:
             continue
-        eligible += 1
         a["_key"] = [stable_key("agent", repo_key, x) for x in a.id]
         h["_key"] = [stable_key("human", repo_key, x) for x in h.id]
         a_parts.append(a.sort_values("_key").head(n).drop(columns="_key"))
@@ -156,7 +164,7 @@ def balance(agent: pd.DataFrame, human: pd.DataFrame) -> tuple[pd.DataFrame, pd.
     h_bal = pd.concat(h_parts, ignore_index=True)
     return a_bal, h_bal, {
         "shared_repositories_before_minimum": len(shared),
-        "matched_repositories": eligible,
+        "matched_repositories_at_least_2": len(a_parts),
         "balanced_agent_prs": len(a_bal),
         "balanced_human_prs": len(h_bal),
     }
@@ -171,7 +179,7 @@ def repo_metrics(df: pd.DataFrame) -> dict[str, float]:
         document_ngram_events += len(row.ngrams)
         word_counts.append(len(row.tokens))
     unique = len(doc_freq)
-    reused = sum(1 for v in doc_freq.values() if v >= 2)
+    reused = sum(v >= 2 for v in doc_freq.values())
     reused_events = sum(v for v in doc_freq.values() if v >= 2)
     return {
         "documents": float(len(df)),
@@ -182,11 +190,18 @@ def repo_metrics(df: pd.DataFrame) -> dict[str, float]:
     }
 
 
-def paired_summary(metrics: pd.DataFrame, metric: str) -> dict[str, float | int | None]:
+def paired_summary(metrics: pd.DataFrame, metric: str, minimum_documents: int) -> dict[str, float | int | None]:
     wide = metrics.pivot(index="repo_key", columns="group", values=metric).dropna()
+    docs = metrics.pivot(index="repo_key", columns="group", values="documents").dropna()
+    keep = (docs["agent"] >= minimum_documents) & (docs["human"] >= minimum_documents)
+    wide = wide.loc[keep]
     delta = wide["agent"] - wide["human"]
-    stat = wilcoxon(wide["agent"], wide["human"], zero_method="wilcox", alternative="two-sided") if (delta != 0).any() else None
-    rng = np.random.default_rng(20260816)
+    if len(delta) == 0:
+        return {"repositories": 0}
+    nonzero = delta[delta != 0]
+    signed = binomtest(int((nonzero > 0).sum()), n=len(nonzero), p=0.5, alternative="two-sided") if len(nonzero) else None
+    rank = wilcoxon(wide["agent"], wide["human"], zero_method="wilcox", alternative="two-sided") if len(nonzero) else None
+    rng = np.random.default_rng(20260816 + minimum_documents)
     values = delta.to_numpy(dtype=float)
     boot = np.array([rng.choice(values, size=len(values), replace=True).mean() for _ in range(10_000)])
     return {
@@ -195,18 +210,38 @@ def paired_summary(metrics: pd.DataFrame, metric: str) -> dict[str, float | int 
         "human_mean": float(wide["human"].mean()),
         "mean_paired_difference_agent_minus_human": float(delta.mean()),
         "median_paired_difference_agent_minus_human": float(delta.median()),
+        "positive_differences": int((delta > 0).sum()),
+        "negative_differences": int((delta < 0).sum()),
+        "zero_differences": int((delta == 0).sum()),
         "bootstrap_95pct_ci_mean_difference_low": float(np.quantile(boot, 0.025)),
         "bootstrap_95pct_ci_mean_difference_high": float(np.quantile(boot, 0.975)),
-        "wilcoxon_statistic": float(stat.statistic) if stat else None,
-        "wilcoxon_p_value": float(stat.pvalue) if stat else None,
+        "wilcoxon_p_value": float(rank.pvalue) if rank else None,
+        "sign_test_p_value": float(signed.pvalue) if signed else None,
     }
 
 
-def global_reused_phrases(df: pd.DataFrame, minimum_documents: int = 3) -> Counter[str]:
-    counts: Counter[str] = Counter()
-    for phrases in df.ngrams:
-        counts.update(phrases)
-    return Counter({k: v for k, v in counts.items() if v >= minimum_documents})
+def analyze_scope(raw_agent: pd.DataFrame, raw_human: pd.DataFrame, scope: str) -> tuple[pd.DataFrame, dict[str, object]]:
+    agent = prepare(raw_agent, "agent", scope)
+    human = prepare(raw_human, "human", scope)
+    a_bal, h_bal, matching = balance(agent, human)
+    balanced = pd.concat([a_bal, h_bal], ignore_index=True)
+    rows: list[dict[str, object]] = []
+    for (repo_key, group), part in balanced.groupby(["repo_key", "group"], sort=True):
+        rows.append({"scope": scope, "repo_key": repo_key, "group": group, **repo_metrics(part)})
+    metrics = pd.DataFrame(rows)
+    sensitivity: dict[str, object] = {}
+    for minimum in MINIMUM_DOCUMENTS:
+        sensitivity[str(minimum)] = {
+            metric: paired_summary(metrics, metric, minimum)
+            for metric in ["median_words", "reused_unique_share", "reused_event_share"]
+        }
+    summary = {
+        "usable_rows": {"agent": int(len(agent)), "human": int(len(human))},
+        "repository_keys": {"agent": int(agent.repo_key.nunique()), "human": int(human.repo_key.nunique())},
+        "matching": matching,
+        "minimum_documents_sensitivity": sensitivity,
+    }
+    return metrics, summary
 
 
 def main() -> None:
@@ -218,44 +253,31 @@ def main() -> None:
 
     raw_agent = pd.read_parquet(download("agent", data_dir))
     raw_human = pd.read_parquet(download("human", data_dir))
-    agent = prepare(raw_agent, "agent")
-    human = prepare(raw_human, "human")
-    a_bal, h_bal, counts = balance(agent, human)
-    balanced = pd.concat([a_bal, h_bal], ignore_index=True)
 
-    rows: list[dict[str, object]] = []
-    for (repo_key, group), part in balanced.groupby(["repo_key", "group"], sort=True):
-        rows.append({"repo_key": repo_key, "group": group, **repo_metrics(part)})
-    metrics = pd.DataFrame(rows)
-    metrics.to_csv(out_dir / "repository_metrics.csv", index=False)
-
-    summaries = {
-        metric: paired_summary(metrics, metric)
-        for metric in ["median_words", "reused_unique_share", "reused_event_share"]
-    }
-
-    top_rows: list[dict[str, object]] = []
-    for group, part in [("agent", a_bal), ("human", h_bal)]:
-        for phrase, docs in global_reused_phrases(part).most_common(500):
-            top_rows.append({"group": group, "phrase": phrase, "documents": docs})
-    pd.DataFrame(top_rows).to_csv(out_dir / "top_reused_phrases.csv", index=False)
+    all_metrics: list[pd.DataFrame] = []
+    scopes: dict[str, object] = {}
+    for scope in SCOPES:
+        metrics, scope_summary = analyze_scope(raw_agent, raw_human, scope)
+        all_metrics.append(metrics)
+        scopes[scope] = scope_summary
+    pd.concat(all_metrics, ignore_index=True).to_csv(out_dir / "repository_metrics.csv", index=False)
 
     result = {
         "study_input": {
             "dataset": "hao-li/AIDev",
+            "revision": AIDEV_REVISION,
             "agent_file": "pull_request.parquet",
             "human_file": "human_pull_request.parquet",
             "input_sha256": {k: v[1] for k, v in INPUTS.items()},
             "no_kafka2306_repositories_used_as_data": True,
         },
         "raw_rows": {"agent": int(len(raw_agent)), "human": int(len(raw_human))},
-        "nonempty_text_rows": {"agent": int(len(agent)), "human": int(len(human))},
-        "repository_keys": {"agent": int(agent.repo_key.nunique()), "human": int(human.repo_key.nunique())},
-        "matching": counts,
-        "analysis": summaries,
+        "scopes": scopes,
         "interpretation_boundary": (
             "These are descriptive paired comparisons in AIDev's sampled popular-repository corpus. "
-            "They do not identify whether an AI agent caused any phrase, and reused n-grams are not automatically jargon."
+            "Repeated n-grams are not automatically repository-specific terminology or jargon. "
+            "PR-body templates can create repeated text, so title-only results are reported separately. "
+            "No causal claim about AI-generated terminology follows from this observational analysis."
         ),
     }
     (out_dir / "summary.json").write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")

--- a/research/aidev-vocabulary-study/analyze.py
+++ b/research/aidev-vocabulary-study/analyze.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Compare repeated multiword expressions in matched Agentic-PR and Human-PR corpora.
+
+The input is the public AIDev dataset only. No KAFKA2306 repository content is
+used as study data. Inputs are pinned by SHA-256. The analysis balances the two
+classes within each repository before computing document-frequency measures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sys
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.stats import wilcoxon
+
+SEED = "2026-08-16-aidev-vocabulary"
+BASE = "https://huggingface.co/datasets/hao-li/AIDev/resolve/main"
+INPUTS = {
+    "agent": (
+        f"{BASE}/pull_request.parquet",
+        "08f520b5ef36b6281f82090db09ac14aefc3534ee113886e7bc85131fd8d214c",
+    ),
+    "human": (
+        f"{BASE}/human_pull_request.parquet",
+        "910238f8fe5deb544ae82be343232ff6838f271f3de4b4e4787a515336a91248",
+    ),
+}
+TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_+.-]*")
+URL_RE = re.compile(r"https?://\S+|www\.\S+", re.I)
+CODE_FENCE_RE = re.compile(r"```.*?```", re.S)
+INLINE_CODE_RE = re.compile(r"`[^`]+`")
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download(name: str, out_dir: Path) -> Path:
+    url, expected = INPUTS[name]
+    path = out_dir / f"{name}.parquet"
+    if not path.exists() or sha256(path) != expected:
+        urllib.request.urlretrieve(url, path)
+    actual = sha256(path)
+    if actual != expected:
+        raise RuntimeError(f"{name}: SHA-256 mismatch: {actual} != {expected}")
+    return path
+
+
+def normalize_text(title: object, body: object) -> list[str]:
+    text = f"{'' if pd.isna(title) else title}\n{'' if pd.isna(body) else body}"
+    text = CODE_FENCE_RE.sub(" ", text)
+    text = INLINE_CODE_RE.sub(" ", text)
+    text = URL_RE.sub(" ", text)
+    return [m.group(0).lower() for m in TOKEN_RE.finditer(text)]
+
+
+def ngrams(tokens: list[str], n_min: int = 2, n_max: int = 4) -> set[str]:
+    result: set[str] = set()
+    for n in range(n_min, n_max + 1):
+        if len(tokens) >= n:
+            result.update(" ".join(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+    return result
+
+
+def stable_key(group: str, repo_id: object, pr_id: object) -> str:
+    raw = f"{SEED}|{group}|{repo_id}|{pr_id}".encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def prepare(df: pd.DataFrame, group: str) -> pd.DataFrame:
+    required = {"id", "repo_id", "title", "body"}
+    missing = required - set(df.columns)
+    if missing:
+        raise RuntimeError(f"{group}: missing required columns: {sorted(missing)}")
+    out = df.loc[:, [c for c in ["id", "repo_id", "title", "body", "created_at"] if c in df.columns]].copy()
+    out = out.dropna(subset=["repo_id", "id"])
+    out["group"] = group
+    out["tokens"] = [normalize_text(t, b) for t, b in zip(out["title"], out["body"])]
+    out = out[out["tokens"].map(len) > 0].copy()
+    out["ngrams"] = out["tokens"].map(ngrams)
+    return out
+
+
+def balance(agent: pd.DataFrame, human: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, int]]:
+    shared = sorted(set(agent.repo_id) & set(human.repo_id), key=str)
+    a_parts: list[pd.DataFrame] = []
+    h_parts: list[pd.DataFrame] = []
+    eligible = 0
+    for repo_id in shared:
+        a = agent[agent.repo_id == repo_id].copy()
+        h = human[human.repo_id == repo_id].copy()
+        n = min(len(a), len(h))
+        # At least two documents per class are needed to measure cross-document reuse.
+        if n < 2:
+            continue
+        eligible += 1
+        a["_key"] = [stable_key("agent", repo_id, x) for x in a.id]
+        h["_key"] = [stable_key("human", repo_id, x) for x in h.id]
+        a_parts.append(a.sort_values("_key").head(n).drop(columns="_key"))
+        h_parts.append(h.sort_values("_key").head(n).drop(columns="_key"))
+    if not a_parts:
+        raise RuntimeError("No matched repositories with at least two PRs per class")
+    a_bal = pd.concat(a_parts, ignore_index=True)
+    h_bal = pd.concat(h_parts, ignore_index=True)
+    return a_bal, h_bal, {
+        "shared_repositories_before_minimum": len(shared),
+        "matched_repositories": eligible,
+        "balanced_agent_prs": len(a_bal),
+        "balanced_human_prs": len(h_bal),
+    }
+
+
+def repo_metrics(df: pd.DataFrame) -> dict[str, float]:
+    doc_freq: Counter[str] = Counter()
+    document_ngram_events = 0
+    word_counts: list[int] = []
+    for row in df.itertuples(index=False):
+        doc_freq.update(row.ngrams)
+        document_ngram_events += len(row.ngrams)
+        word_counts.append(len(row.tokens))
+    unique = len(doc_freq)
+    reused = sum(1 for v in doc_freq.values() if v >= 2)
+    reused_events = sum(v for v in doc_freq.values() if v >= 2)
+    return {
+        "documents": float(len(df)),
+        "median_words": float(np.median(word_counts)),
+        "unique_ngrams": float(unique),
+        "reused_unique_share": float(reused / unique) if unique else math.nan,
+        "reused_event_share": float(reused_events / document_ngram_events) if document_ngram_events else math.nan,
+    }
+
+
+def paired_summary(metrics: pd.DataFrame, metric: str) -> dict[str, float | int | None]:
+    wide = metrics.pivot(index="repo_id", columns="group", values=metric).dropna()
+    delta = wide["agent"] - wide["human"]
+    stat = wilcoxon(wide["agent"], wide["human"], zero_method="wilcox", alternative="two-sided") if (delta != 0).any() else None
+    rng = np.random.default_rng(20260816)
+    values = delta.to_numpy(dtype=float)
+    boot = np.array([
+        rng.choice(values, size=len(values), replace=True).mean() for _ in range(10_000)
+    ])
+    return {
+        "repositories": int(len(wide)),
+        "agent_mean": float(wide["agent"].mean()),
+        "human_mean": float(wide["human"].mean()),
+        "mean_paired_difference_agent_minus_human": float(delta.mean()),
+        "median_paired_difference_agent_minus_human": float(delta.median()),
+        "bootstrap_95pct_ci_mean_difference_low": float(np.quantile(boot, 0.025)),
+        "bootstrap_95pct_ci_mean_difference_high": float(np.quantile(boot, 0.975)),
+        "wilcoxon_statistic": float(stat.statistic) if stat else None,
+        "wilcoxon_p_value": float(stat.pvalue) if stat else None,
+    }
+
+
+def global_reused_phrases(df: pd.DataFrame, minimum_documents: int = 3) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for phrases in df.ngrams:
+        counts.update(phrases)
+    return Counter({k: v for k, v in counts.items() if v >= minimum_documents})
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    data_dir = root / ".data"
+    out_dir = root / "results"
+    data_dir.mkdir(exist_ok=True)
+    out_dir.mkdir(exist_ok=True)
+
+    raw_agent = pd.read_parquet(download("agent", data_dir))
+    raw_human = pd.read_parquet(download("human", data_dir))
+    agent = prepare(raw_agent, "agent")
+    human = prepare(raw_human, "human")
+    a_bal, h_bal, counts = balance(agent, human)
+    balanced = pd.concat([a_bal, h_bal], ignore_index=True)
+
+    rows: list[dict[str, object]] = []
+    for (repo_id, group), part in balanced.groupby(["repo_id", "group"], sort=True):
+        rows.append({"repo_id": repo_id, "group": group, **repo_metrics(part)})
+    metrics = pd.DataFrame(rows)
+    metrics.to_csv(out_dir / "repository_metrics.csv", index=False)
+
+    summaries = {
+        metric: paired_summary(metrics, metric)
+        for metric in ["median_words", "reused_unique_share", "reused_event_share"]
+    }
+
+    top_rows: list[dict[str, object]] = []
+    for group, part in [("agent", a_bal), ("human", h_bal)]:
+        for phrase, docs in global_reused_phrases(part).most_common(500):
+            top_rows.append({"group": group, "phrase": phrase, "documents": docs})
+    pd.DataFrame(top_rows).to_csv(out_dir / "top_reused_phrases.csv", index=False)
+
+    result = {
+        "study_input": {
+            "dataset": "hao-li/AIDev",
+            "agent_file": "pull_request.parquet",
+            "human_file": "human_pull_request.parquet",
+            "input_sha256": {k: v[1] for k, v in INPUTS.items()},
+            "no_kafka2306_repositories_used_as_data": True,
+        },
+        "raw_rows": {"agent": int(len(raw_agent)), "human": int(len(raw_human))},
+        "nonempty_text_rows": {"agent": int(len(agent)), "human": int(len(human))},
+        "matching": counts,
+        "analysis": summaries,
+        "interpretation_boundary": (
+            "These are descriptive paired comparisons in AIDev's sampled popular-repository corpus. "
+            "They do not identify whether an AI agent caused any phrase, and reused n-grams are not automatically jargon."
+        ),
+    }
+    (out_dir / "summary.json").write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise

--- a/research/aidev-vocabulary-study/analyze.py
+++ b/research/aidev-vocabulary-study/analyze.py
@@ -16,6 +16,7 @@ import sys
 import urllib.request
 from collections import Counter
 from pathlib import Path
+from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -74,18 +75,54 @@ def ngrams(tokens: list[str], n_min: int = 2, n_max: int = 4) -> set[str]:
     return result
 
 
-def stable_key(group: str, repo_id: object, pr_id: object) -> str:
-    raw = f"{SEED}|{group}|{repo_id}|{pr_id}".encode()
+def repo_from_url(value: object) -> str | None:
+    if pd.isna(value):
+        return None
+    try:
+        parsed = urlparse(str(value))
+    except ValueError:
+        return None
+    parts = [p for p in parsed.path.split("/") if p]
+    if parsed.netloc == "api.github.com" and len(parts) >= 3 and parts[0] == "repos":
+        return f"{parts[1]}/{parts[2]}".lower()
+    if parsed.netloc in {"github.com", "www.github.com"} and len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}".lower()
+    return None
+
+
+def add_repository_key(df: pd.DataFrame, group: str) -> pd.DataFrame:
+    url_columns = [c for c in ["repo_url", "repository_url", "html_url", "url"] if c in df.columns]
+    keys: list[str | None] = []
+    for row in df.itertuples(index=False):
+        key = None
+        for column in url_columns:
+            key = repo_from_url(getattr(row, column))
+            if key:
+                break
+        if key is None and "repo_id" in df.columns:
+            value = getattr(row, "repo_id")
+            key = None if pd.isna(value) else f"id:{value}"
+        keys.append(key)
+    out = df.copy()
+    out["repo_key"] = keys
+    if out["repo_key"].notna().sum() == 0:
+        raise RuntimeError(f"{group}: cannot derive repository identity; columns={sorted(df.columns)}")
+    return out
+
+
+def stable_key(group: str, repo_key: object, pr_id: object) -> str:
+    raw = f"{SEED}|{group}|{repo_key}|{pr_id}".encode()
     return hashlib.sha256(raw).hexdigest()
 
 
 def prepare(df: pd.DataFrame, group: str) -> pd.DataFrame:
-    required = {"id", "repo_id", "title", "body"}
+    required = {"id", "title", "body"}
     missing = required - set(df.columns)
     if missing:
-        raise RuntimeError(f"{group}: missing required columns: {sorted(missing)}")
-    out = df.loc[:, [c for c in ["id", "repo_id", "title", "body", "created_at"] if c in df.columns]].copy()
-    out = out.dropna(subset=["repo_id", "id"])
+        raise RuntimeError(f"{group}: missing required columns: {sorted(missing)}; columns={sorted(df.columns)}")
+    df = add_repository_key(df, group)
+    keep = [c for c in ["id", "repo_key", "title", "body", "created_at"] if c in df.columns]
+    out = df.loc[:, keep].copy().dropna(subset=["repo_key", "id"])
     out["group"] = group
     out["tokens"] = [normalize_text(t, b) for t, b in zip(out["title"], out["body"])]
     out = out[out["tokens"].map(len) > 0].copy()
@@ -94,24 +131,27 @@ def prepare(df: pd.DataFrame, group: str) -> pd.DataFrame:
 
 
 def balance(agent: pd.DataFrame, human: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, int]]:
-    shared = sorted(set(agent.repo_id) & set(human.repo_id), key=str)
+    shared = sorted(set(agent.repo_key) & set(human.repo_key), key=str)
     a_parts: list[pd.DataFrame] = []
     h_parts: list[pd.DataFrame] = []
     eligible = 0
-    for repo_id in shared:
-        a = agent[agent.repo_id == repo_id].copy()
-        h = human[human.repo_id == repo_id].copy()
+    for repo_key in shared:
+        a = agent[agent.repo_key == repo_key].copy()
+        h = human[human.repo_key == repo_key].copy()
         n = min(len(a), len(h))
         # At least two documents per class are needed to measure cross-document reuse.
         if n < 2:
             continue
         eligible += 1
-        a["_key"] = [stable_key("agent", repo_id, x) for x in a.id]
-        h["_key"] = [stable_key("human", repo_id, x) for x in h.id]
+        a["_key"] = [stable_key("agent", repo_key, x) for x in a.id]
+        h["_key"] = [stable_key("human", repo_key, x) for x in h.id]
         a_parts.append(a.sort_values("_key").head(n).drop(columns="_key"))
         h_parts.append(h.sort_values("_key").head(n).drop(columns="_key"))
     if not a_parts:
-        raise RuntimeError("No matched repositories with at least two PRs per class")
+        raise RuntimeError(
+            "No matched repositories with at least two PRs per class; "
+            f"agent_keys={agent.repo_key.nunique()}, human_keys={human.repo_key.nunique()}, shared={len(shared)}"
+        )
     a_bal = pd.concat(a_parts, ignore_index=True)
     h_bal = pd.concat(h_parts, ignore_index=True)
     return a_bal, h_bal, {
@@ -143,14 +183,12 @@ def repo_metrics(df: pd.DataFrame) -> dict[str, float]:
 
 
 def paired_summary(metrics: pd.DataFrame, metric: str) -> dict[str, float | int | None]:
-    wide = metrics.pivot(index="repo_id", columns="group", values=metric).dropna()
+    wide = metrics.pivot(index="repo_key", columns="group", values=metric).dropna()
     delta = wide["agent"] - wide["human"]
     stat = wilcoxon(wide["agent"], wide["human"], zero_method="wilcox", alternative="two-sided") if (delta != 0).any() else None
     rng = np.random.default_rng(20260816)
     values = delta.to_numpy(dtype=float)
-    boot = np.array([
-        rng.choice(values, size=len(values), replace=True).mean() for _ in range(10_000)
-    ])
+    boot = np.array([rng.choice(values, size=len(values), replace=True).mean() for _ in range(10_000)])
     return {
         "repositories": int(len(wide)),
         "agent_mean": float(wide["agent"].mean()),
@@ -186,8 +224,8 @@ def main() -> None:
     balanced = pd.concat([a_bal, h_bal], ignore_index=True)
 
     rows: list[dict[str, object]] = []
-    for (repo_id, group), part in balanced.groupby(["repo_id", "group"], sort=True):
-        rows.append({"repo_id": repo_id, "group": group, **repo_metrics(part)})
+    for (repo_key, group), part in balanced.groupby(["repo_key", "group"], sort=True):
+        rows.append({"repo_key": repo_key, "group": group, **repo_metrics(part)})
     metrics = pd.DataFrame(rows)
     metrics.to_csv(out_dir / "repository_metrics.csv", index=False)
 
@@ -212,6 +250,7 @@ def main() -> None:
         },
         "raw_rows": {"agent": int(len(raw_agent)), "human": int(len(raw_human))},
         "nonempty_text_rows": {"agent": int(len(agent)), "human": int(len(human))},
+        "repository_keys": {"agent": int(agent.repo_key.nunique()), "human": int(human.repo_key.nunique())},
         "matching": counts,
         "analysis": summaries,
         "interpretation_boundary": (

--- a/research/aidev-vocabulary-study/analyze_task_matched.py
+++ b/research/aidev-vocabulary-study/analyze_task_matched.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Robustness analysis matching Agentic-PR and Human-PR by repository and task type.
+
+This is a post-specified robustness analysis motivated by task-mix confounding in
+the repository-only comparison. Task labels come from AIDev's published
+`pr_task_type` and `human_pr_task_type` tables. The labels are themselves LLM
+classifications, so this analysis does not treat them as ground truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from pathlib import Path
+
+import pandas as pd
+
+import analyze as base
+
+TASK_INPUTS = {
+    "agent_task": (
+        f"{base.BASE}/pr_task_type.parquet",
+        "f32a97a45ac944f4ea473327e62d8f41361502c2b6b3778e76fb64c2b8896476",
+    ),
+    "human_task": (
+        f"{base.BASE}/human_pr_task_type.parquet",
+        "5527d52bfd9605a25d1ed1ef03bce0e1cc217f6ffed936e2be1b80a04123e658",
+    ),
+}
+
+
+def download_task(name: str, out_dir: Path) -> Path:
+    url, expected = TASK_INPUTS[name]
+    path = out_dir / f"{name}.parquet"
+    if not path.exists() or base.sha256(path) != expected:
+        urllib.request.urlretrieve(url, path)
+    actual = base.sha256(path)
+    if actual != expected:
+        raise RuntimeError(f"{name}: SHA-256 mismatch: {actual} != {expected}")
+    return path
+
+
+def unambiguous_task_labels(df: pd.DataFrame, group: str) -> tuple[pd.DataFrame, dict[str, int]]:
+    required = {"id", "type"}
+    missing = required - set(df.columns)
+    if missing:
+        raise RuntimeError(f"{group}: task table missing {sorted(missing)}; columns={sorted(df.columns)}")
+
+    labels = df.loc[:, ["id", "type"]].dropna().copy()
+    labels["task_type"] = labels["type"].astype(str).str.strip().str.lower()
+    labels = labels[labels["task_type"] != ""].drop(columns="type")
+
+    # Exclude PR IDs with conflicting labels rather than selecting one arbitrarily.
+    unique_counts = labels.groupby("id")["task_type"].nunique()
+    conflicting_ids = set(unique_counts[unique_counts > 1].index)
+    if conflicting_ids:
+        labels = labels[~labels["id"].isin(conflicting_ids)]
+    labels = labels.drop_duplicates(subset=["id", "task_type"]).drop_duplicates(subset=["id"])
+
+    return labels, {
+        "task_table_rows": int(len(df)),
+        "labeled_unique_prs": int(labels["id"].nunique()),
+        "conflicting_pr_ids_excluded": int(len(conflicting_ids)),
+        "task_types": int(labels["task_type"].nunique()),
+    }
+
+
+def stable_stratum_key(group: str, repo_key: str, task_type: str, pr_id: object) -> str:
+    raw = f"{base.SEED}|task-matched|{group}|{repo_key}|{task_type}|{pr_id}".encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def balance_by_repository_and_task(
+    agent: pd.DataFrame, human: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, int]]:
+    agent_keys = set(zip(agent["repo_key"], agent["task_type"]))
+    human_keys = set(zip(human["repo_key"], human["task_type"]))
+    shared = sorted(agent_keys & human_keys, key=lambda x: (str(x[0]), str(x[1])))
+
+    a_parts: list[pd.DataFrame] = []
+    h_parts: list[pd.DataFrame] = []
+    retained_strata = 0
+    for repo_key, task_type in shared:
+        a = agent[(agent.repo_key == repo_key) & (agent.task_type == task_type)].copy()
+        h = human[(human.repo_key == repo_key) & (human.task_type == task_type)].copy()
+        n = min(len(a), len(h))
+        if n == 0:
+            continue
+        retained_strata += 1
+        a["_key"] = [stable_stratum_key("agent", repo_key, task_type, x) for x in a.id]
+        h["_key"] = [stable_stratum_key("human", repo_key, task_type, x) for x in h.id]
+        a_parts.append(a.sort_values("_key").head(n).drop(columns="_key"))
+        h_parts.append(h.sort_values("_key").head(n).drop(columns="_key"))
+
+    if not a_parts:
+        raise RuntimeError("No shared repository/task-type strata")
+
+    a_bal = pd.concat(a_parts, ignore_index=True)
+    h_bal = pd.concat(h_parts, ignore_index=True)
+    return a_bal, h_bal, {
+        "shared_repository_task_strata": int(len(shared)),
+        "retained_repository_task_strata": int(retained_strata),
+        "retained_repositories": int(len(set(a_bal.repo_key) & set(h_bal.repo_key))),
+        "balanced_agent_prs": int(len(a_bal)),
+        "balanced_human_prs": int(len(h_bal)),
+    }
+
+
+def analyze_scope(
+    raw_agent: pd.DataFrame,
+    raw_human: pd.DataFrame,
+    agent_labels: pd.DataFrame,
+    human_labels: pd.DataFrame,
+    scope: str,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    agent = base.prepare(raw_agent, "agent", scope).merge(agent_labels, on="id", how="inner", validate="many_to_one")
+    human = base.prepare(raw_human, "human", scope).merge(human_labels, on="id", how="inner", validate="many_to_one")
+    a_bal, h_bal, matching = balance_by_repository_and_task(agent, human)
+    balanced = pd.concat([a_bal, h_bal], ignore_index=True)
+
+    rows: list[dict[str, object]] = []
+    for (repo_key, group), part in balanced.groupby(["repo_key", "group"], sort=True):
+        rows.append({"scope": scope, "repo_key": repo_key, "group": group, **base.repo_metrics(part)})
+    metrics = pd.DataFrame(rows)
+
+    sensitivity: dict[str, object] = {}
+    for minimum in base.MINIMUM_DOCUMENTS:
+        sensitivity[str(minimum)] = {
+            metric: base.paired_summary(metrics, metric, minimum)
+            for metric in ["median_words", "reused_unique_share", "reused_event_share"]
+        }
+
+    return metrics, {
+        "labeled_usable_rows": {"agent": int(len(agent)), "human": int(len(human))},
+        "matching": matching,
+        "minimum_documents_sensitivity": sensitivity,
+    }
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    data_dir = root / ".data"
+    out_dir = root / "results"
+    data_dir.mkdir(exist_ok=True)
+    out_dir.mkdir(exist_ok=True)
+
+    raw_agent = pd.read_parquet(base.download("agent", data_dir))
+    raw_human = pd.read_parquet(base.download("human", data_dir))
+    raw_agent_task = pd.read_parquet(download_task("agent_task", data_dir))
+    raw_human_task = pd.read_parquet(download_task("human_task", data_dir))
+
+    agent_labels, agent_label_stats = unambiguous_task_labels(raw_agent_task, "agent")
+    human_labels, human_label_stats = unambiguous_task_labels(raw_human_task, "human")
+
+    scopes: dict[str, object] = {}
+    metric_frames: list[pd.DataFrame] = []
+    for scope in base.SCOPES:
+        metrics, summary = analyze_scope(raw_agent, raw_human, agent_labels, human_labels, scope)
+        scopes[scope] = summary
+        metric_frames.append(metrics)
+    pd.concat(metric_frames, ignore_index=True).to_csv(out_dir / "task_matched_repository_metrics.csv", index=False)
+
+    result = {
+        "study_input": {
+            "dataset": "hao-li/AIDev",
+            "revision": base.AIDEV_REVISION,
+            "task_input_sha256": {k: v[1] for k, v in TASK_INPUTS.items()},
+            "no_kafka2306_repositories_used_as_data": True,
+        },
+        "task_labels": {"agent": agent_label_stats, "human": human_label_stats},
+        "scopes": scopes,
+        "analysis_status": "post-specified robustness analysis",
+        "interpretation_boundary": (
+            "This analysis controls the observed AIDev task-category mix within each repository. "
+            "AIDev task types are LLM classifications of PR titles and commit messages, so they may contain measurement error. "
+            "Matching on task type does not make the observational comparison causal."
+        ),
+    }
+    (out_dir / "task_matched_summary.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope

Replace the abandoned hand-picked repository pilot with an external-only empirical study.

Study data are pinned public AIDev files only; no KAFKA2306 repository content or prior-chat repository sample is used as research data.

## What is included

- reproducible repository-matched Agentic-PR vs Human-PR analysis;
- post-specified robustness analysis matching both repository and AIDev task type;
- title-only and title+body scopes;
- predefined minimum-document sensitivity checks at 2/5/10/20;
- SHA-256-pinned upstream inputs;
- observed findings including the negative result;
- a separate controlled-experiment protocol using ContextBench for causal testing of repository-specific names/abbreviations.

## Observed result

The cleaner title-only analysis does **not** provide robust evidence that agent-authored PRs have higher cross-document multiword-expression reuse. After repository + task-type matching, a positive difference appears at the permissive 2-document threshold, but bootstrap 95% intervals cross zero at the predefined 5/10/20 thresholds.

Agent-authored PR titles are consistently longer in the matched corpus. Including PR bodies substantially changes reuse estimates, showing that broad PR-text repetition is not a valid stand-in for repository-specific jargon without further decomposition.

The causal claim is therefore not made from AIDev. `CONTROLLED_EXPERIMENT.md` specifies a randomized ContextBench follow-up that holds task semantics constant and measures existing context-retrieval and task-success outcomes.

## Verification

Final head: `b4a07370540e2539bb8df0373e07528cdbafdd92`

Exact-head GitHub Actions run: https://github.com/KAFKA2306/articles/actions/runs/31943369057

Both analyses and artifact upload passed on that head.
