### PR TITLE
Simplify Zenn publication flow

### DIFF
--- a/.github/workflows/zenn-manual-release.yml
+++ b/.github/workflows/zenn-manual-release.yml
@@ -66,7 +66,7 @@ jobs:
           cd _zenn_release
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "articles/${SLUG}.md" "images/${SLUG}" 2>/dev/null || true
+          git add -A
 
           if git diff --cached --quiet; then
             echo "zenn-release already contains this exact article snapshot"

--- a/.github/workflows/zenn-manual-release.yml
+++ b/.github/workflows/zenn-manual-release.yml
@@ -57,26 +57,23 @@ jobs:
           git worktree add _zenn_release origin/zenn-release
 
           cp "articles/${SLUG}.md" "_zenn_release/articles/${SLUG}.md"
-
+          rm -rf "_zenn_release/images/${SLUG}"
           if [[ -d "images/${SLUG}" ]]; then
             mkdir -p "_zenn_release/images"
-            rm -rf "_zenn_release/images/${SLUG}"
             cp -R "images/${SLUG}" "_zenn_release/images/${SLUG}"
           fi
 
           cd _zenn_release
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "articles/${SLUG}.md"
-          if [[ -d "images/${SLUG}" ]]; then
-            git add "images/${SLUG}"
-          fi
+          git add "articles/${SLUG}.md" "images/${SLUG}" 2>/dev/null || true
 
           if git diff --cached --quiet; then
-            git commit --allow-empty -m "deploy: retry ${SLUG}"
-          else
-            git commit -m "deploy: publish ${SLUG}"
+            echo "zenn-release already contains this exact article snapshot"
+            exit 0
           fi
+
+          git commit -m "deploy: publish ${SLUG}"
           git push origin HEAD:zenn-release
 
       - name: Verify Zenn production

--- a/.github/workflows/zenn-manual-release.yml
+++ b/.github/workflows/zenn-manual-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       slug:
-        description: "Release or reconcile exactly one approved article slug"
+        description: "Publish exactly one approved article"
         required: true
         type: string
 
@@ -20,131 +20,71 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout Zenn deployment branch
+      - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
 
-      - name: Preflight contracts
+      - name: Validate approved article
+        shell: bash
         env:
           SLUG: ${{ inputs.slug }}
         run: |
-          python -m unittest tests.test_zenn_slug tests.test_publication_diff tests.test_zenn_production -v
-          python -m pipeline.zenn_slug
+          set -euo pipefail
           python -m pipeline.zenn_slug --slug "$SLUG"
+          test -f "articles/${SLUG}.md"
+          grep -q '^published: true$' "articles/${SLUG}.md"
+          grep -q '^published_at:' "articles/${SLUG}.md"
+          python -m pipeline.audit
+          bash scripts/zenn-render-check.sh
 
-      - name: Resolve desired publication state
-        id: state
+      - name: Copy one article to zenn-release
         shell: bash
         env:
           SLUG: ${{ inputs.slug }}
         run: |
           set -euo pipefail
-          python - <<'PY'
-          import os
-          from datetime import datetime
-          from pathlib import Path
-          from zoneinfo import ZoneInfo
+          git fetch origin zenn-release
+          git worktree add _zenn_release origin/zenn-release
 
-          slug = os.environ["SLUG"]
-          path = Path("articles") / f"{slug}.md"
-          if not path.is_file():
-              raise SystemExit(f"unknown article: {slug}")
-          text = path.read_text(encoding="utf-8")
-          parts = text.split("---\n", 2)
-          if len(parts) != 3:
-              raise SystemExit(f"invalid front matter: {path}")
-          front = parts[1]
-          body = parts[2]
-          if front.count("published: false") == 1 and "published: true" not in front:
-              front = front.replace("published: false", "published: true", 1)
-              if "published_at:" not in front:
-                  stamp = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d %H:%M")
-                  front = front.replace("published: true\n", f"published: true\npublished_at: {stamp}\n", 1)
-              path.write_text(f"---\n{front}---\n{body}", encoding="utf-8")
-              main_changed = "true"
-          elif front.count("published: true") == 1 and "published: false" not in front:
-              main_changed = "false"
-          else:
-              raise SystemExit(f"ambiguous publication state: {path}")
+          cp "articles/${SLUG}.md" "_zenn_release/articles/${SLUG}.md"
 
-          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
-              handle.write(f"main_changed={main_changed}\n")
-          print(f"slug={slug} main_changed={main_changed}")
-          PY
-
-      - name: Validate and publish on main
-        shell: bash
-        env:
-          SLUG: ${{ inputs.slug }}
-          MAIN_CHANGED: ${{ steps.state.outputs.main_changed }}
-        run: |
-          set -euo pipefail
-          python -m pipeline.zenn_slug
-          git diff --check
-
-          if [[ "$MAIN_CHANGED" == "true" ]]; then
-            changed="$(git diff --name-only)"
-            test "$changed" = "articles/${SLUG}.md" || {
-              echo "unexpected release diff: $changed"
-              exit 1
-            }
-
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add "articles/${SLUG}.md"
-            git commit -m "publish: approve ${SLUG}"
-
-            pushed=0
-            for attempt in 1 2 3; do
-              git fetch origin main
-              git rebase origin/main
-              python -m pipeline.zenn_slug
-              python -m pipeline.publication_diff --base HEAD^ --head HEAD
-              python -m pipeline.audit
-              bash scripts/zenn-render-check.sh
-              if git push origin HEAD:main; then
-                pushed=1
-                break
-              fi
-            done
-            test "$pushed" = "1" || {
-              echo "main moved too quickly; release aborted without force push"
-              exit 1
-            }
-          else
-            git diff --exit-code
-            git fetch origin main
-            git reset --hard origin/main
-            python -m pipeline.zenn_slug
-            python -m pipeline.audit
-            bash scripts/zenn-render-check.sh
+          if [[ -d "images/${SLUG}" ]]; then
+            mkdir -p "_zenn_release/images"
+            rm -rf "_zenn_release/images/${SLUG}"
+            cp -R "images/${SLUG}" "_zenn_release/images/${SLUG}"
           fi
 
-          grep -q '^published: true$' "articles/${SLUG}.md" || {
-            echo "publication intent changed: ${SLUG}"
-            exit 1
-          }
+          cd _zenn_release
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "articles/${SLUG}.md"
+          if [[ -d "images/${SLUG}" ]]; then
+            git add "images/${SLUG}"
+          fi
+
+          if git diff --cached --quiet; then
+            git commit --allow-empty -m "deploy: retry ${SLUG}"
+          else
+            git commit -m "deploy: publish ${SLUG}"
+          fi
+          git push origin HEAD:zenn-release
 
       - name: Verify Zenn production
         shell: bash
         env:
           ZENN_USERNAME: kafka2306
-          SLUG: ${{ inputs.slug }}
         run: |
-          set -euo pipefail
-          if ! python -m pipeline.zenn_production \
-            --root . \
-            --wait-seconds 900; then
-            echo "DEPLOY_PENDING $SLUG"
-            echo "main remains the single publication source; no rollback push is emitted."
-            exit 1
-          fi
-          echo "PUBLISHED_VERIFIED $SLUG"
+          python -m pipeline.zenn_production \
+            --root _zenn_release \
+            --wait-seconds 900 \
+            --interval-seconds 15

--- a/.github/workflows/zenn-production-verify.yml
+++ b/.github/workflows/zenn-production-verify.yml
@@ -13,21 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - name: Checkout Zenn deployment branch
+      - name: Checkout verifier
         uses: actions/checkout@v6
         with:
           ref: main
-          fetch-depth: 1
+          path: main
+
+      - name: Checkout deployed snapshot
+        uses: actions/checkout@v6
+        with:
+          ref: zenn-release
+          path: release
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Verifier contract tests
-        run: python -m unittest tests.test_zenn_production -v
-      - name: Verify main against Zenn production
+
+      - name: Verify zenn-release against Zenn
+        working-directory: main
         env:
           ZENN_USERNAME: kafka2306
         run: |
+          python -m unittest tests.test_zenn_production -v
           python -m pipeline.zenn_production \
-            --root . \
-            --wait-seconds 0 \
-            --interval-seconds 15
+            --root ../release \
+            --wait-seconds 0

--- a/docs/PUBLICATION.md
+++ b/docs/PUBLICATION.md
@@ -35,12 +35,12 @@ workflowが行うことは次だけ。
 2. `published: true` と `published_at` を確認する
 3. `articles/<slug>.md` を `zenn-release` へコピーする
 4. `images/<slug>/` があれば同時にコピーする
-5. `zenn-release` をpushする
+5. 差分があれば `zenn-release` をpushする
 6. Zenn公開状態を確認する
 
 workflowはmainの記事本文、`published`、`published_at` を書き換えない。
 
-同じ内容を再送する場合は、記事を改変せず `zenn-release` に空のdeploy commitを1件だけ作る。
+`zenn-release` が同一内容なら何もしない。デプロイ失敗時はZennダッシュボードのデプロイ履歴で原因を確認し、原因を修正してから再実行する。
 
 ## 3. zenn-release
 
@@ -79,6 +79,7 @@ images/<slug>/
 
 - retry用の本文コメント追加
 - retry用のtimestamp変更
+- retry用の空コミット
 - `published_at` の書き換え
 - `zenn-release` での通常開発
 - `main` をproduction snapshotとして検証すること

--- a/docs/PUBLICATION.md
+++ b/docs/PUBLICATION.md
@@ -1,172 +1,93 @@
-# Publication contract
+# Zenn publication
 
-## Invariant
-
-このrepositoryで「公開済み」と呼べる状態は次だけとする。
-
-```text
-published: true in canonical Zenn release snapshot
-+
-Zenn公式ユーザーRSSにcanonical slugが存在
-+
-RSS上のtitleがrelease snapshotのtitleと一致
-=
-PUBLISHED_VERIFIED
-```
-
-公開カタログのauthorityはZenn公式ユーザーRSS `https://zenn.dev/kafka2306/feed?all=1` とする。GitHub上の `published: true`、commit成功、Actions green、deploy trigger成功だけでは公開完了と呼ばない。
-
-## Deployment topology
-
-通常作業とZenn production deployをbranchで分離する。
+公開経路は3段階だけにする。
 
 ```text
 main
-  = drafting / review / CI / publication intent
-              │
-              │ explicit one-article release
-              ▼
+  ↓  published: true を人が確定
+Zenn Manual Release
+  ↓  対象1記事だけコピー
 zenn-release
-  = deployed production snapshot
-    + approved target article
-    + that article's referenced images
-              │
-              │ Zenn GitHub integration watches this branch
-              ▼
+  ↓  Zenn Connect
 zenn.dev
-              │
-              ▼
-feed?all=1 verification
 ```
 
-- `main` は正準作業branch。
-- `zenn-release` はZenn deploy専用snapshot branch。
-- `zenn-release` をmainへ丸ごと追従させない。
-- `.github/workflows/zenn-manual-release.yml` だけが承認済みarticleと必要画像をrelease snapshotへ反映する。
-- main上の別article、draft、実験、docsをrelease snapshotへ混入させない。
-- force pushは禁止する。
+## 1. main
 
-## State machine
+`main` は執筆とレビューの正準。
 
-```text
-DRAFT
-  published:false on main
-    │ explicit approval
-    ▼
-PUBLICATION_INTENT
-  published:true on main
-    │ Zenn Manual Release
-    ▼
-RELEASE_SNAPSHOT
-  zenn-release contains approved target version
-    │ Zenn GitHub sync
-    ▼
-PRODUCTION_VERIFICATION
-    ├─ RSS slug + title一致 -> PUBLISHED_VERIFIED
-    └─ missing / mismatch / fetch failure -> DEPLOY_PENDING
+公開する記事だけFront Matterを次の状態にする。
+
+```yaml
+published: true
+published_at: YYYY-MM-DD HH:MM
 ```
 
-verification failureで `published:false` へ自動rollbackしない。公開意思はmain上で保持し、必要なら同じarticleをreconcileする。
+`published_at` は公開retryのために変更しない。
 
-## Zenn slug contract
+## 2. Zenn Manual Release
 
-Zennでは `articles/<slug>.md` のファイル名が記事slugになる。slugは12〜50文字、`a-z`、`0-9`、`-`、`_` のみ。
+`.github/workflows/zenn-manual-release.yml` を手動実行し、slugを1件指定する。
 
-canonical validatorは `pipeline.zenn_slug` とする。
+workflowが行うことは次だけ。
+
+1. slugと記事を検証する
+2. `published: true` と `published_at` を確認する
+3. `articles/<slug>.md` を `zenn-release` へコピーする
+4. `images/<slug>/` があれば同時にコピーする
+5. `zenn-release` をpushする
+6. Zenn公開状態を確認する
+
+workflowはmainの記事本文、`published`、`published_at` を書き換えない。
+
+同じ内容を再送する場合は、記事を改変せず `zenn-release` に空のdeploy commitを1件だけ作る。
+
+## 3. zenn-release
+
+`zenn-release` はZenn Connectが監視するデプロイ専用branch。
+
+通常作業は行わない。
+
+Zenn公式では、登録したbranchに変更があると同期が開始され、変更されたMarkdownファイルがzenn.devへ同期される。
+
+- https://zenn.dev/zenn/articles/connect-to-github
+- https://zenn.dev/zenn/articles/zenn-cli-guide
+
+## 公開完了
+
+GitHubへのpushだけでは完了にしない。
+
+`pipeline.zenn_production` がZenn公式ユーザーRSSでslugとtitleを確認できた時だけ公開済みとする。
 
 ```bash
-python -m pipeline.zenn_slug
-python -m pipeline.zenn_slug --slug my-valid-article-slug
+python -m pipeline.zenn_production --root <zenn-release checkout>
 ```
 
-記事生成時に最終slugをfilesystem mutation前に検証し、repository-wide CIでも全articleを再検証する。公開済みslugはrenameしない。
+定期確認は `.github/workflows/zenn-production-verify.yml` が `zenn-release` を基準に行う。
 
-## Main-side publication intent
+## 画像
 
-Manual Releaseは入力された任意のvalid slugを1本だけ扱う。
-
-- `published:false` なら対象articleだけを `true` にしてmainへcommitする。
-- 既に `published:true` ならmainを変更せずreconcileする。
-- `published_at` は既存値を保持する。
-- mainへの変更がある場合、rebase後のexact commitへ `pipeline.zenn_slug`、`pipeline.publication_diff`、`pipeline.audit` を実行する。
-- mainへのpushはnormal fast-forwardのみとし、force pushしない。
-
-公開retryのためにarticle本文へmarker、timestamp、no-op commentを埋め込まない。
-
-## Release snapshot construction
-
-release snapshotへcopyしてよいものは原則として次だけ。
+記事固有画像は次に置く。
 
 ```text
-articles/<approved-slug>.md
-images/...   # approved articleが実際に参照するものだけ
+images/<slug>/
 ```
 
-workflowはrelease worktreeのchanged/untracked pathsを検査し、上記以外が混入したらfailする。
+これ以外の画像配置を増やさない。
 
-## Pre-deploy gates
+## 禁止
 
-`zenn-release` へpushする前にrelease snapshotそのものへ次を実行する。
+- retry用の本文コメント追加
+- retry用のtimestamp変更
+- `published_at` の書き換え
+- `zenn-release` での通常開発
+- `main` をproduction snapshotとして検証すること
+- 複数記事を1回のmanual releaseで公開すること
 
-1. `pipeline.zenn_slug --root <release>`
-2. `collect_published_articles(<release>)` のcontract errors = 0
-3. release diffがtarget article + referenced imagesだけ
-4. Zenn CLI `preview --no-watch` で全article render
-5. render結果に `data-body-error` がない
-6. `git diff --check`
+## Zenn側設定
 
-対象内容が前回releaseと同一のreconcileでは、articleを改変せず `zenn-release` に明示的なempty deploy commitを1件だけ作る。deploy trigger目的のdocs変更、本文marker、rollback commitは作らない。
+Zenn Connectの同期branchは `zenn-release` にする。
 
-## Production verification
+Zenn公式では同期branchをダッシュボードから指定できる。
 
-`pipeline.zenn_production` は `--root` で指定したrelease snapshotの `published:true` をproduction expectationとして扱う。
-
-```bash
-python -m pipeline.zenn_production \
-  --root _zenn_release \
-  --wait-seconds 900 \
-  --interval-seconds 15
-```
-
-- canonical slug missing -> FAIL
-- title mismatch -> FAIL
-- RSS fetch / parse failure -> FAIL
-- 全件一致 -> PASS
-
-定期 `.github/workflows/zenn-production-verify.yml` も `zenn-release` をexpectation sourceとして使う。
-
-## Immutable `published_at`
-
-既存 `published_at` はrelease/reconcile時に変更しない。誤変更の修復時のみ、Git履歴上でそのarticleに最初にcommitされた非null valueをcanonical originとして復元する。
-
-禁止:
-- retry時刻への更新
-- 現在時刻への置換
-- 推測値への置換
-- 任意の過去値への変更
-
-## Branch hygiene
-
-- `main` と `zenn-release` は恒久branchとして保持する。
-- merged / patch-equivalentでopen PRのない作業branchは `.github/workflows/branch-hygiene.yml` が削除する。
-- unique patchまたはopen PRを持つbranchは自動削除しない。
-
-## Canonical implementation
-
-- work branch: `main`
-- deploy branch: `zenn-release`
-- slug validator: `pipeline/zenn_slug.py`
-- transition guard: `pipeline/publication_diff.py`
-- repository CI: `.github/workflows/article-pipeline-ci.yml`
-- one-article release: `.github/workflows/zenn-manual-release.yml`
-- production verifier: `pipeline/zenn_production.py`
-- production observer: `.github/workflows/zenn-production-verify.yml`
-- branch cleanup: `.github/workflows/branch-hygiene.yml`
-- regression tests: `tests/test_zenn_slug.py`, `tests/test_publication_diff.py`, `tests/test_zenn_production.py`
-
-## External authority
-
-- Zenn GitHub integration / sync branch: https://zenn.dev/zenn/articles/connect-to-github
-- Zenn CLI: https://zenn.dev/zenn/articles/zenn-cli-guide
-- Zenn slug: https://zenn.dev/zenn/articles/what-is-slug
-- Zenn RSS: https://zenn.dev/zenn/articles/zenn-feed-rss
+- https://zenn.dev/zenn/articles/connect-to-github


### PR DESCRIPTION
Zenn公開経路を3段階に固定します。

1. mainで `published: true` を確定
2. Manual Releaseが対象1記事と `images/<slug>/` だけを `zenn-release` へコピー
3. `zenn-release` を基準にZenn本番を検証

削除した複雑性:
- workflowによるmainの自動書き換え
- retry時の `published_at` 生成・変更
- mainをproduction snapshotとして扱う検証
- 公開意思決定とdeploy処理の混在

Zenn公式仕様:
- https://zenn.dev/zenn/articles/connect-to-github
- https://zenn.dev/zenn/articles/zenn-cli-guide