### PR TITLE
test: Zenn release contractを現行PRフローへ揃える

### DIFF
--- a/tests/test_zenn_production.py
+++ b/tests/test_zenn_production.py
@@ -78,20 +78,23 @@ class ZennProductionTests(unittest.TestCase):
         self.assertIn("path: release", workflow)
         self.assertIn("--root ../release", workflow)
         self.assertIn("cron:", workflow)
-        self.assertNotIn("push:\n", workflow)
+        self.assertIn("push:\n", workflow)
+        self.assertIn("branches: [zenn-release]", workflow)
         self.assertNotIn("cancel-in-progress", workflow)
 
-    def test_manual_release_updates_zenn_release_from_main(self) -> None:
+    def test_manual_release_stages_zenn_release_pr_from_main(self) -> None:
         workflow = (
             zenn_production.ROOT / ".github" / "workflows" / "zenn-manual-release.yml"
         ).read_text(encoding="utf-8")
         self.assertIn("ref: main", workflow)
         self.assertIn("git fetch origin zenn-release", workflow)
-        self.assertIn("git push origin HEAD:zenn-release", workflow)
         self.assertIn("published_at:", workflow)
         self.assertIn("bash scripts/zenn-render-check.sh", workflow)
         self.assertIn("git worktree add _zenn_release origin/zenn-release", workflow)
-        self.assertIn("--root _zenn_release", workflow)
+        self.assertIn('branch="zenn-sync/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"', workflow)
+        self.assertIn("gh pr create", workflow)
+        self.assertIn("--base zenn-release", workflow)
+        self.assertNotIn("git push origin HEAD:zenn-release", workflow)
         self.assertNotIn("git push origin HEAD:main", workflow)
         self.assertNotIn("git push --force", workflow)
         self.assertNotIn("git push -f", workflow)

--- a/tests/test_zenn_slug.py
+++ b/tests/test_zenn_slug.py
@@ -83,10 +83,14 @@ class ZennSlugTests(unittest.TestCase):
         )
         self.assertIn("python -m pipeline.zenn_slug", workflow)
         self.assertIn("type: string", workflow)
-        self.assertNotIn("type: choice", workflow)
+        self.assertIn("action:", workflow)
+        self.assertIn("- publish", workflow)
+        self.assertIn("- unpublish", workflow)
         self.assertNotIn("zenn-deploy-sync", workflow)
-        self.assertIn("git push origin HEAD:zenn-release", workflow)
         self.assertIn("git worktree add _zenn_release origin/zenn-release", workflow)
+        self.assertIn("gh pr create", workflow)
+        self.assertIn("--base zenn-release", workflow)
+        self.assertNotIn("git push origin HEAD:zenn-release", workflow)
         self.assertNotIn("git push origin HEAD:main", workflow)
 
 


### PR DESCRIPTION
## 原因

`zenn-release` への直接pushを廃止し、`zenn-sync/* -> zenn-release` PRでproduction transitionを行う実装へ変わっている一方、旧テスト3件が直接push前提を残していました。

## 修正
- production verifierは `zenn-release` pushで起動する現行仕様を検証
- manual releaseはproduction branchへ直接pushせず、release PRを作ることを検証
- slug側のrelease testも同じPR staging contractへ統一

実装workflowは変更しません。テストを現在の実装契約へ揃えるだけです。